### PR TITLE
Basic worker image building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,34 +11,54 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
         with:
-          go-version: "^1.19"
-
-      - run: go build -o temporal-omes ./cmd
-      - run: go test ./...
-      - name: Go all-in-one
-        run: ./temporal-omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --log-level debug --language go --embedded-server
+          go-version: "^1.20"
+      - name: Build exe
+        run: go build -o temporal-omes ./cmd
+      - name: Test
+        run: go test ./...
+      - name: Run local scenario with worker
+        run: ./temporal-omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --log-level debug --language go --embedded-server --iterations 5
+      - name: Build worker image
+        run: ./temporal-omes build-worker-image --language go --version v1.22.1
+      - name: Run worker image
+        run: docker run --rm --detach -i -p 10233:10233 omes:go-1.22.1 --scenario workflow_with_single_noop_activity --log-level debug --language go --run-id {{ github.run_id }} --embedded-server-address 0.0.0.0:10233
+      - name: Run scenario against image
+        run: ./temporal-omes run-scenario --scenario workflow_with_single_noop_activity --log-level debug --server-address 127.0.0.1:10233 --run-id {{ github.run_id }} --wait-for-server 1m --iterations 5
 
   build-lint-test-python:
     runs-on: ubuntu-latest
     steps:
       - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
         with:
           python-version: '3.10'
-      - run: python -m pip install --upgrade wheel poetry poethepoet
-      - run: cd workers/python && poetry install --no-root
-      - run: cd workers/python && poe lint
-
-      - uses: actions/setup-go@v2
+      - name: Install Python prequisites
+        run: python -m pip install --upgrade wheel poetry poethepoet
+      - name: Initialize Python worker
+        run: cd workers/python && poetry install --no-root
+      - name: Lint Python worker
+        run: cd workers/python && poe lint
+      - name: Setup Go
+        uses: actions/setup-go@v2
         with:
-          go-version: "^1.19"
-      - run: go build -o temporal-omes ./cmd
-
-      - name: Python all-in-one
-        run: ./temporal-omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --log-level debug --language python --embedded-server
+          go-version: "^1.20"
+      - name: Build exe
+        run: go build -o temporal-omes ./cmd
+      - name: Run local scenario with worker
+        run: ./temporal-omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --log-level debug --language python --embedded-server --iterations 5
+      - name: Build worker image
+        run: ./temporal-omes build-worker-image --language python --version 1.2.0
+      - name: Run worker image
+        run: docker run --rm --detach -i -p 10233:10233 omes:python-1.2.0 --scenario workflow_with_single_noop_activity --log-level debug --language python --run-id {{ github.run_id }} --embedded-server-address 0.0.0.0:10233
+      - name: Run scenario against image
+        run: ./temporal-omes run-scenario --scenario workflow_with_single_noop_activity --log-level debug --server-address 127.0.0.1:10233 --run-id {{ github.run_id }} --wait-for-server 1m --iterations 5

--- a/cmd/build_worker_image.go
+++ b/cmd/build_worker_image.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/temporalio/omes/cmd/cmdoptions"
+	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
+)
+
+func buildWorkerImageCmd() *cobra.Command {
+	var b workerImageBuilder
+	cmd := &cobra.Command{
+		Use:   "build-worker-image",
+		Short: "Build an image",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := b.build(cmd.Context()); err != nil {
+				b.logger.Fatal(err)
+			}
+		},
+	}
+	b.addCLIFlags(cmd.Flags())
+	cmd.MarkFlagRequired("language")
+	cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+type workerImageBuilder struct {
+	logger         *zap.SugaredLogger
+	language       string
+	version        string
+	semverTags     string
+	platform       string
+	imageName      string
+	dryRun         bool
+	tags           []string
+	labels         []string
+	loggingOptions cmdoptions.LoggingOptions
+}
+
+func (b *workerImageBuilder) addCLIFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&b.language, "language", "", "Language to build a worker image for")
+	fs.StringVar(&b.version, "version", "",
+		"SDK version to build a worker image for - treated as path if slash present, but must be beneath this dir and at least one tag required")
+	fs.StringVar(&b.semverTags, "semver-tags", "",
+		"Can be 'minor', 'major', or 'all' - affects additional tags, only used on non-path version")
+	fs.StringVar(&b.platform, "platform", "", "Platform for use in docker build --platform")
+	fs.StringVar(&b.imageName, "image-name", "omes", "Name of the image to build")
+	fs.BoolVar(&b.dryRun, "dry-run", false, "If set, just print the commands that would run but do not run them")
+	fs.StringSliceVar(&b.tags, "image-tag", nil, "Additional tags to add to the image")
+	fs.StringSliceVar(&b.labels, "image-label", nil, "Additional labels to add to the image")
+	b.loggingOptions.AddCLIFlags(fs)
+}
+
+func (b *workerImageBuilder) build(ctx context.Context) error {
+	b.logger = b.loggingOptions.MustCreateLogger()
+	lang, err := normalizeLangName(b.language)
+	if err != nil {
+		return err
+	}
+
+	// Setup args, tags, and labels based on version
+	isPathVersion := strings.ContainsAny(b.version, `/\`)
+	var buildArgs []string
+	if isPathVersion {
+		if len(b.tags) == 0 {
+			return fmt.Errorf("at least one tag required for path version")
+		} else if s, err := os.Stat(b.version); err != nil {
+			return fmt.Errorf("invalid path version: %w", err)
+		} else if !s.IsDir() {
+			return fmt.Errorf("invalid path version: must be dir")
+		} else if !filepath.IsLocal(b.version) {
+			return fmt.Errorf("invalid path version: must be beneath this dir")
+		}
+		// We have to copy the entire
+		buildArgs = append(buildArgs, "SDK_VERSION=./repo", "SDK_DIR="+b.version)
+	} else {
+		buildArgs = append(buildArgs, "SDK_VERSION="+b.version)
+		// Add label for version
+		b.addLabelIfNotPresent("io.temporal.sdk.version", b.version)
+		// Check for valid version
+		versionToCheck := b.version
+		if !strings.HasPrefix(b.version, "v") {
+			versionToCheck = "v" + versionToCheck
+		}
+		if semver.Canonical(versionToCheck) == "" {
+			return fmt.Errorf("expected valid semver")
+		}
+		// Add tag for lang-fullsemver without leading "v". We are intentionally
+		// including semver build metadata.
+		b.tags = append(b.tags, lang+"-"+strings.TrimPrefix(b.version, "v"))
+		// Add lang-major.minor, lang-major, and/or lang tags if requested
+		switch b.semverTags {
+		case "":
+		case "minor":
+			b.tags = append(b.tags, lang+"-"+semver.MajorMinor(versionToCheck))
+			fallthrough
+		case "major":
+			b.tags = append(b.tags, lang+"-"+semver.Major(versionToCheck))
+			fallthrough
+		case "all":
+			b.tags = append(b.tags, lang)
+		default:
+			return fmt.Errorf("unrecognized semver-tags value")
+		}
+	}
+
+	// Setup additional labels
+	gitRef, err := gitRef(ctx, ".git")
+	if err != nil {
+		return err
+	}
+	b.addLabelIfNotPresent("org.opencontainers.image.created", time.Now().UTC().Format(time.RFC3339))
+	b.addLabelIfNotPresent("org.opencontainers.image.source", "https://github.com/temporalio/omes")
+	b.addLabelIfNotPresent("org.opencontainers.image.vendor", "Temporal Technologies Inc.")
+	b.addLabelIfNotPresent("org.opencontainers.image.authors", "Temporal SDK team <sdk-team@temporal.io>")
+	b.addLabelIfNotPresent("org.opencontainers.image.licenses", "MIT")
+	b.addLabelIfNotPresent("org.opencontainers.image.revision", gitRef)
+	b.addLabelIfNotPresent("org.opencontainers.image.title", "Load testing for "+lang)
+	b.addLabelIfNotPresent("org.opencontainers.image.documentation", "See README at https://github.com/temporalio/omes")
+	b.addLabelIfNotPresent("io.temporal.sdk.name", lang)
+
+	// Prepare docker command args
+	args := []string{
+		"build",
+		"--pull",
+		"--file", "dockerfiles/" + lang + ".Dockerfile",
+	}
+	if b.platform != "" {
+		args = append(args, "--platform", b.platform, "--build-arg", "PLATFORM="+b.platform)
+	}
+	for _, tag := range b.tags {
+		args = append(args, "--tag", b.imageName+":"+tag)
+	}
+	for _, label := range b.labels {
+		args = append(args, "--label", label)
+	}
+	for _, arg := range buildArgs {
+		args = append(args, "--build-arg", arg)
+	}
+	args = append(args, rootDir())
+	b.logger.Infof("Running: docker %v", strings.Join(args, " "))
+	if b.dryRun {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (b *workerImageBuilder) addLabelIfNotPresent(key, value string) {
+	for _, label := range b.labels {
+		if strings.HasPrefix(label, key+"=") {
+			return
+		}
+	}
+	b.labels = append(b.labels, key+"="+value)
+}
+
+func gitRef(ctx context.Context, gitDir string) (string, error) {
+	cmd := exec.Command("git", "--git-dir", gitDir, "rev-parse", "HEAD")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed getting git ref: %w", err)
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	_ "github.com/temporalio/omes/scenarios" // Register scenarios (side-effect)
 )
@@ -11,11 +14,15 @@ func main() {
 		Short: "A load generator for Temporal",
 	}
 
+	rootCmd.AddCommand(buildWorkerImageCmd())
 	rootCmd.AddCommand(cleanupScenarioCmd())
 	rootCmd.AddCommand(prepareWorkerCmd())
 	rootCmd.AddCommand(runScenarioCmd())
 	rootCmd.AddCommand(runScenarioWithWorkerCmd())
 	rootCmd.AddCommand(runWorkerCmd())
 
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/prepare_worker.go
+++ b/cmd/prepare_worker.go
@@ -44,7 +44,7 @@ type workerBuilder struct {
 func (b *workerBuilder) addCLIFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&b.dirName, "dir-name", "", "Directory name for prepared worker")
 	fs.StringVar(&b.language, "language", "", "Language to prepare a worker for")
-	fs.StringVar(&b.version, "version", "", "Version to prepare a worker for")
+	fs.StringVar(&b.version, "version", "", "Version to prepare a worker for - treated as path if slash present")
 	b.loggingOptions.AddCLIFlags(fs)
 }
 

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,0 +1,32 @@
+# Build in a full featured container
+FROM golang:1.20 as build
+
+WORKDIR /app
+
+# Copy CLI build dependencies
+COPY cmd ./cmd
+COPY loadgen ./loadgen
+COPY scenarios ./scenarios
+COPY workers ./workers
+COPY go.mod go.sum ./
+
+# Build the CLI
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd
+
+ARG SDK_VERSION
+
+# Optional SDK dir to copy, defaults to unimportant file
+ARG SDK_DIR=.gitignore
+COPY ${SDK_DIR} ./repo
+
+# Build the worker
+RUN CGO_ENABLED=0 ./temporal-omes prepare-worker --language go --dir-name prepared --version "$SDK_VERSION"
+
+# Copy the CLI and built worker to a distroless "run" container
+FROM gcr.io/distroless/static-debian11:nonroot
+
+COPY --from=build /app/temporal-omes /app/temporal-omes
+COPY --from=build /app/workers/go/prepared /app/workers/go/prepared
+
+# Put the language and dir, but let other options (like required scenario and run-id) be given by user
+ENTRYPOINT ["/app/temporal-omes", "run-worker", "--language", "go", "--dir-name", "prepared"]

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -1,0 +1,55 @@
+# Build in a full featured container
+FROM python:3.11-bullseye as build
+
+# Install protobuf compiler
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends --assume-yes \
+      protobuf-compiler=3.12.4-1 libprotobuf-dev=3.12.4-1
+
+# Get go compiler
+ARG PLATFORM=amd64
+RUN wget -q https://go.dev/dl/go1.20.4.linux-${PLATFORM}.tar.gz \
+    && tar -C /usr/local -xzf go1.20.4.linux-${PLATFORM}.tar.gz
+# Install Rust for compiling the core bridge - only required for installation from a repo but is cheap enough to install
+# in the "build" container (-y is for non-interactive install)
+# hadolint ignore=DL4006
+RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="$PATH:/root/.cargo/bin"
+
+# Install poetry
+RUN pip install --no-cache-dir "poetry==1.2.2"
+
+WORKDIR /app
+
+# Copy CLI build dependencies
+COPY cmd ./cmd
+COPY loadgen ./loadgen
+COPY scenarios ./scenarios
+COPY workers ./workers
+COPY go.mod go.sum ./
+
+# Build the CLI
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+
+# Optional SDK dir to copy, defaults to unimportant file
+ARG SDK_DIR=.gitignore
+COPY ${SDK_DIR} ./repo
+
+# Build the worker
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+RUN CGO_ENABLED=0 ./temporal-omes prepare-worker --language python --dir-name prepared --version "$SDK_VERSION"
+
+# Copy the CLI and built worker to a distroless "run" container
+FROM python:3.11-slim-bullseye
+
+# Poetry needed for running python tests
+RUN pip install --no-cache-dir "poetry==1.2.2"
+
+COPY --from=build /app/temporal-omes /app/temporal-omes
+COPY --from=build /app/workers/python /app/workers/python
+
+# Put the language and dir, but let other options (like required scenario and run-id) be given by user
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+ENTRYPOINT ["/app/temporal-omes", "run-worker", "--language", "python", "--dir-name", "prepared"]

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.temporal.io/features v1.0.0
 	go.temporal.io/sdk v1.22.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/mod v0.8.0
 	golang.org/x/sys v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -960,6 +960,7 @@ golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/workers/go/go.sum
+++ b/workers/go/go.sum
@@ -528,7 +528,7 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
## What was changed

Added `build-worker-image` command. Intentionally don't have a bunch of `git` commands or support `push`ing at this time, though we can add later if we must (though we may find cloning a repo and pushing a docker image to be better suited for the environment and not the CLI).