### PR TITLE
Multi-task-queue Scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ $ go run ./cmd run-worker --scenario workflow_with_single_noop_activity --run-id
 Notes:
 
 - `--embedded-server` can be passed here to start an embedded localhost server
+- `--task-queue-suffix-index-start` and `--task-queue-suffix-index-end` represent an inclusive range for running the
+  worker on multiple task queues. The process will create a worker for every task queue from `<task-queue>-<start>`
+  through `<task-queue>-end`. This only applies to multi-task-queue scenarios.
 
 ### Run a test scenario
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.2
 	go.temporal.io/api v1.19.1-0.20230322213042-07fb271d475b
 	go.temporal.io/features v1.0.0
 	go.temporal.io/sdk v1.22.1
@@ -39,7 +40,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -105,6 +105,7 @@ func (g *genericRun) Run(ctx context.Context) error {
 			IterationInTest: i + 1,
 			Logger:          g.logger.With("iteration", i),
 			ID:              g.options.RunID,
+			RunOptions:      &g.options,
 		}
 		go func() {
 			startTime := time.Now()

--- a/scenarios/workflow_on_many_task_queues.go
+++ b/scenarios/workflow_on_many_task_queues.go
@@ -1,0 +1,33 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Each iteration executes a single workflow on one of the task queues. " +
+			"Workers must be started with --task-queue-suffix-index-end as one less than task queue count here. " +
+			"Additional options: task-queue-count (required).",
+		Executor: loadgen.KitchenSinkExecutor{
+			WorkflowParams: kitchensink.NewWorkflowParams(kitchensink.NopActionExecuteActivity),
+			PrepareWorkflowParams: func(ctx context.Context, opts loadgen.RunOptions, params *kitchensink.WorkflowParams) error {
+				// Require task queue count
+				if opts.ScenarioOptionInt("task-queue-count", 0) == 0 {
+					return fmt.Errorf("task-queue-count option required")
+				}
+				return nil
+			},
+			UpdateWorkflowOptions: func(ctx context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
+				// Add suffix to the task queue based on modulus of iteration
+				options.StartOptions.TaskQueue +=
+					fmt.Sprintf("-%v", run.IterationInTest%run.RunOptions.ScenarioOptionInt("task-queue-count", 0))
+				return nil
+			},
+		},
+	})
+}


### PR DESCRIPTION
## What was changed

Added a new `workflow_on_many_task_queues` scenario and support for running many workers in a single worker process.

For example to run scenario with 500 workflows across 20 task queues in Go using embedded server and running worker at the same time, you'd run

```
go run ./cmd run-scenario-with-worker --scenario workflow_on_many_task_queues --language go --embedded-server --iterations 500 --option task-queue-count=20 --task-queue-suffix-index-end 19
```

Of course this could be broken out to just, say, 2 workers running 10 each against existing server:

```
go run ./cmd run-worker --server-address 1.2.3.4:7233 --scenario workflow_on_many_task_queues --language go --run-id my-run --task-queue-suffix-index-end 9
```
```
go run ./cmd run-worker --server-address 1.2.3.4:7233 --scenario workflow_on_many_task_queues --language go --run-id my-run --task-queue-suffix-index-start 10 --task-queue-suffix-index-end 19
```
```
go run ./cmd run-scenario --scenario workflow_on_many_task_queues --iterations 500 --option task-queue-count=20
```

Also works for Python.

## Checklist

1. Closes #13