### PR TITLE
Naive steady state transition scenario

### DIFF
--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -99,21 +99,14 @@ func (g *genericRun) Run(ctx context.Context) error {
 		// Run concurrently
 		g.logger.Debugf("Running iteration %v", i)
 		currentlyRunning++
-		run := &Run{
-			Client:          g.options.Client,
-			ScenarioName:    g.options.ScenarioName,
-			IterationInTest: i + 1,
-			Logger:          g.logger.With("iteration", i),
-			ID:              g.options.RunID,
-			RunOptions:      &g.options,
-		}
+		run := g.options.NewRun(i + 1)
 		go func() {
 			startTime := time.Now()
 			err := g.executor.Execute(ctx, run)
 			// Only log/wrap/send to channel if context is not done
 			if ctx.Err() == nil {
 				if err != nil {
-					err = fmt.Errorf("iteration %v failed: %w", run.IterationInTest, err)
+					err = fmt.Errorf("iteration %v failed: %w", run.Iteration, err)
 					g.logger.Error(err)
 				}
 				select {

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -71,7 +71,7 @@ func TestRunHappyPathIterations(t *testing.T) {
 	tracker := newIterationTracker()
 	err := execute(&GenericExecutor{
 		Execute: func(ctx context.Context, run *Run) error {
-			tracker.track(run.IterationInTest)
+			tracker.track(run.Iteration)
 			return nil
 		},
 		DefaultConfiguration: RunConfiguration{Iterations: 5},
@@ -85,10 +85,10 @@ func TestRunFailIterations(t *testing.T) {
 	concurrency := 3
 	err := execute(&GenericExecutor{
 		Execute: func(ctx context.Context, run *Run) error {
-			tracker.track(run.IterationInTest)
+			tracker.track(run.Iteration)
 			// Start this short timer to allow all concurrent routines to be spawned
 			<-time.After(time.Millisecond)
-			if run.IterationInTest == 2 {
+			if run.Iteration == 2 {
 				return errors.New("deliberate fail from test")
 			}
 			return nil
@@ -103,7 +103,7 @@ func TestRunHappyPathDuration(t *testing.T) {
 	tracker := newIterationTracker()
 	err := execute(&GenericExecutor{
 		Execute: func(ctx context.Context, run *Run) error {
-			tracker.track(run.IterationInTest)
+			tracker.track(run.Iteration)
 			time.Sleep(time.Millisecond * 20)
 			return nil
 		},
@@ -117,8 +117,8 @@ func TestRunFailDuration(t *testing.T) {
 	tracker := newIterationTracker()
 	err := execute(&GenericExecutor{
 		Execute: func(ctx context.Context, run *Run) error {
-			tracker.track(run.IterationInTest)
-			if run.IterationInTest == 2 {
+			tracker.track(run.Iteration)
+			if run.Iteration == 2 {
 				return errors.New("deliberate fail from test")
 			}
 			return nil

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -25,6 +25,12 @@ type Executor interface {
 	Run(context.Context, RunOptions) error
 }
 
+// ExecutorFunc is an [Executor] implementation for a function
+type ExecutorFunc func(context.Context, RunOptions) error
+
+// Run implements [Executor.Run].
+func (e ExecutorFunc) Run(ctx context.Context, opts RunOptions) error { return e(ctx, opts) }
+
 // HasDefaultConfiguration is an interface executors can implement to show their
 // default configuration.
 type HasDefaultConfiguration interface {
@@ -66,7 +72,8 @@ func GetScenario(name string) *Scenario {
 type RunOptions struct {
 	// Name of the scenario (inferred from the file name)
 	ScenarioName string
-	// Run ID of the current scenario run, used to generate a unique task queue and workflow ID prefix.
+	// Run ID of the current scenario run, used to generate a unique task queue
+	// and workflow ID prefix. This is a single value for the whole scenario.
 	RunID string
 	// Metrics component for registering new metrics.
 	MetricsHandler client.MetricsHandler
@@ -115,20 +122,21 @@ func (r *RunConfiguration) ApplyDefaults() {
 	}
 }
 
-// Run represents a scenario run.
+// Run represents a scenario individual run (many may be in a scenario).
 type Run struct {
-	// Used for Workflow ID and task queue name generation.
-	ID string
-	// The name of the scenario used for the run.
-	ScenarioName string
-	// Temporal client to use for executing workflows, etc.
-	Client client.Client
-	// Each call to the Execute method gets a distinct `IterationInTest`. This
-	// will never be 0.
-	IterationInTest int
-	Logger          *zap.SugaredLogger
-	// Do not mutate this
-	RunOptions *RunOptions
+	// Do not mutate this, this is shared across the entire scenario
+	*RunOptions
+	// Each run should have a unique iteration.
+	Iteration int
+	Logger    *zap.SugaredLogger
+}
+
+func (r *RunOptions) NewRun(iteration int) *Run {
+	return &Run{
+		RunOptions: r,
+		Iteration:  iteration,
+		Logger:     r.Logger.With("iteration", iteration),
+	}
 }
 
 // TaskQueueForRun returns a default task queue name for the given scenario name and run ID.
@@ -136,14 +144,16 @@ func TaskQueueForRun(scenarioName, runID string) string {
 	return fmt.Sprintf("%s:%s", scenarioName, runID)
 }
 
-func (r *Run) DefaultKitchenSinkWorkflowOptions() KitchenSinkWorkflowOptions {
-	return KitchenSinkWorkflowOptions{
-		StartOptions: client.StartWorkflowOptions{
-			TaskQueue:                                TaskQueueForRun(r.ScenarioName, r.ID),
-			ID:                                       fmt.Sprintf("w-%s-%d", r.ID, r.IterationInTest),
-			WorkflowExecutionErrorWhenAlreadyStarted: true,
-		},
+func (r *Run) DefaultStartWorkflowOptions() client.StartWorkflowOptions {
+	return client.StartWorkflowOptions{
+		TaskQueue:                                TaskQueueForRun(r.ScenarioName, r.RunID),
+		ID:                                       fmt.Sprintf("w-%s-%d", r.RunID, r.Iteration),
+		WorkflowExecutionErrorWhenAlreadyStarted: true,
 	}
+}
+
+func (r *Run) DefaultKitchenSinkWorkflowOptions() KitchenSinkWorkflowOptions {
+	return KitchenSinkWorkflowOptions{StartOptions: r.DefaultStartWorkflowOptions()}
 }
 
 type KitchenSinkWorkflowOptions struct {

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -122,7 +122,7 @@ func (r *RunConfiguration) ApplyDefaults() {
 	}
 }
 
-// Run represents a scenario individual run (many may be in a scenario).
+// Run represents an individual scenario run (many may be in a scenario).
 type Run struct {
 	// Do not mutate this, this is shared across the entire scenario
 	*RunOptions
@@ -131,6 +131,7 @@ type Run struct {
 	Logger    *zap.SugaredLogger
 }
 
+// NewRun creates a new run.
 func (r *RunOptions) NewRun(iteration int) *Run {
 	return &Run{
 		RunOptions: r,
@@ -144,6 +145,7 @@ func TaskQueueForRun(scenarioName, runID string) string {
 	return fmt.Sprintf("%s:%s", scenarioName, runID)
 }
 
+// DefaultStartWorkflowOptions gets default start workflow options.
 func (r *Run) DefaultStartWorkflowOptions() client.StartWorkflowOptions {
 	return client.StartWorkflowOptions{
 		TaskQueue:                                TaskQueueForRun(r.ScenarioName, r.RunID),
@@ -152,6 +154,7 @@ func (r *Run) DefaultStartWorkflowOptions() client.StartWorkflowOptions {
 	}
 }
 
+// DefaultKitchenSinkWorkflowOptions gets the default kitchen sink workflow options.
 func (r *Run) DefaultKitchenSinkWorkflowOptions() KitchenSinkWorkflowOptions {
 	return KitchenSinkWorkflowOptions{StartOptions: r.DefaultStartWorkflowOptions()}
 }

--- a/scenarios/state_transitions_steady.go
+++ b/scenarios/state_transitions_steady.go
@@ -1,0 +1,123 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Run a certain number of state transitions per second. This requires duration option to be set " +
+			"and the state-transitions-per-second scenario option to be set. Any iteration configuration is ignored. For " +
+			"example, can be run with: run-scenario-with-worker --scenario state_transitions_steady --language go " +
+			"--embedded-server --duration 5m --option state-transitions-per-second=3",
+		Executor: loadgen.ExecutorFunc(func(ctx context.Context, runOptions loadgen.RunOptions) error {
+			return (&stateTransitionsSteady{runOptions}).run(ctx)
+		}),
+	})
+}
+
+type stateTransitionsSteady struct{ loadgen.RunOptions }
+
+func (s *stateTransitionsSteady) run(ctx context.Context) error {
+	// The goal here is to meet a certain number of state transitions per second.
+	// For us this means a certain number of workflows per second. So we must
+	// first execute a basic workflow (i.e. with a simple activity) and get the
+	// number of state transitions it took
+
+	// TODO(cretz): Note, this is a known naive approach because if workflows are
+	// backed up and/or slow down this won't match.
+
+	if s.Configuration.Duration == 0 {
+		return fmt.Errorf("duration required for this scenario")
+	}
+	stateTransitionsPerSecond := s.ScenarioOptionInt("state-transitions-per-second", 0)
+	if stateTransitionsPerSecond == 0 {
+		return fmt.Errorf("state-transitions-per-second scenario option required")
+	}
+	durationPerStateTransition := time.Second / time.Duration(stateTransitionsPerSecond)
+	s.Logger.Infof(
+		"State transitions per second is %v, which means %v between every state transition",
+		stateTransitionsPerSecond,
+		durationPerStateTransition,
+	)
+
+	// Execute initial workflow and get the transition count
+	workflowParams := kitchensink.WorkflowParams{
+		ActionSet: kitchensink.ActionSet{Actions: []*kitchensink.Action{kitchensink.NopActionExecuteActivity}},
+	}
+	workflowRun, err := s.Client.ExecuteWorkflow(
+		ctx,
+		s.NewRun(0).DefaultStartWorkflowOptions(),
+		"kitchenSink",
+		workflowParams,
+	)
+	if err != nil {
+		return fmt.Errorf("failed starting initial workflow: %w", err)
+	} else if err := workflowRun.Get(ctx, nil); err != nil {
+		return fmt.Errorf("failed executing initial workflow: %w", err)
+	}
+	resp, err := s.Client.DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+	if err != nil {
+		return fmt.Errorf("failed describing workflow: %w", err)
+	}
+	stateTransitionsPerWorkflow := resp.WorkflowExecutionInfo.StateTransitionCount
+	workflowStartInterval := durationPerStateTransition * time.Duration(stateTransitionsPerWorkflow)
+	s.Logger.Infof(
+		"Simple workflow takes %v state transitions, which means we need to start a workflow every %v. "+
+			"Running for %v now...",
+		stateTransitionsPerWorkflow,
+		workflowStartInterval,
+		s.Configuration.Duration,
+	)
+
+	// Start a workflow every X interval until duration reached or there are N
+	// start failures in a row
+
+	const maxConsecutiveErrors = 5
+	errCh := make(chan error, 10000)
+	ticker := time.NewTicker(workflowStartInterval)
+	defer ticker.Stop()
+	var consecutiveErrCount int
+	iter := 1
+	for begin := time.Now(); time.Since(begin) < s.Configuration.Duration; iter++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errCh:
+			if err == nil {
+				consecutiveErrCount = 0
+			} else {
+				consecutiveErrCount++
+				if consecutiveErrCount >= maxConsecutiveErrors {
+					return fmt.Errorf("got %v consecutive errors, most recent: %w", maxConsecutiveErrors, err)
+				}
+			}
+		case <-ticker.C:
+			s.Logger.Debugf("Running iteration %v", iter)
+			go func(iter int) {
+				_, err := s.Client.ExecuteWorkflow(
+					ctx,
+					s.NewRun(iter).DefaultStartWorkflowOptions(),
+					"kitchenSink",
+					workflowParams,
+				)
+				// Only send to err ch if there is room just in case
+				select {
+				case errCh <- err:
+				default:
+				}
+			}(iter)
+		}
+	}
+	// We don't want to wait to let workflows complete here. In dev cases the
+	// local server will just shutdown, in non-dev cases, the server admin can
+	// wait. But we don't want to introduce delays for those that may want to run
+	// this quickly/frequently.
+	s.Logger.Infof("Run complete, ran %v iterations", iter)
+	return nil
+}

--- a/scenarios/workflow_on_many_task_queues.go
+++ b/scenarios/workflow_on_many_task_queues.go
@@ -25,7 +25,7 @@ func init() {
 			UpdateWorkflowOptions: func(ctx context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
 				// Add suffix to the task queue based on modulus of iteration
 				options.StartOptions.TaskQueue +=
-					fmt.Sprintf("-%v", run.IterationInTest%run.RunOptions.ScenarioOptionInt("task-queue-count", 0))
+					fmt.Sprintf("-%v", run.Iteration%run.RunOptions.ScenarioOptionInt("task-queue-count", 0))
 				return nil
 			},
 		},

--- a/workers/go/workflows/kitchen_sink.go
+++ b/workers/go/workflows/kitchen_sink.go
@@ -12,7 +12,7 @@ import (
 
 func KitchenSinkWorkflow(ctx workflow.Context, params *kitchensink.WorkflowParams) (interface{}, error) {
 	b, _ := json.Marshal(params)
-	workflow.GetLogger(ctx).Info("Started kitchen sink workflow", "params", string(b))
+	workflow.GetLogger(ctx).Debug("Started kitchen sink workflow", "params", string(b))
 	if params == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
## What was changed

Created new steady state transition scenario. This requires duration and requires a `state-transitions-per-second` scenario option. This is a naive implementation that just runs a basic workflow once to get the count, and then runs that as many times as necessary to run that count. There is no backpressure nor is there any logic in checking whether server state transitions is actually matching this.

To try out with embedded server/worker, clone branch and run:

    go run ./cmd run-scenario-with-worker --scenario state_transitions_steady --language go --embedded-server --duration 30s --option state-transitions-per-second=200

This will output logs like:

```
2023/08/28 10:47:58 INFO  Starting DevServer ExePath C:\Users\user\AppData\Local\Temp\temporal-cli-go-sdk-1.22.1.exe Args [server start-dev --ip 127.0.0.1 --port 62795 --namespace default --dynamic-config-value frontend.enableServerVersionCheck=false --log-level error --headless]
2023/08/28 10:47:59 INFO  DevServer ready
2023-08-28T10:47:59.242-0500    INFO    cmd/run_worker.go:112   Started embedded local server at: 127.0.0.1:62795
2023-08-28T10:47:59.243-0500    INFO    cmd/prepare_worker.go:65        Building go program at c:\work\tem\omes-state-transition\omes\workers\go\omes-temp-2640346882
2023-08-28T10:48:05.810-0500    INFO    cmd/run_worker.go:173   Starting worker with command: [./program.exe --task-queue state_transitions_steady:yjpvisxa --server-address 127.0.0.1:62795 --namespace default --prom-handler-path /metrics --log-level info --log-encoding console]
2023-08-28T10:48:07.021-0500    INFO    cmdoptions/client.go:68 Client connected to 127.0.0.1:62795, namespace: default
2023-08-28T10:48:07.021-0500    INFO    scenarios/state_transitions_steady.go:56        State transitions per second is 200, which means 5ms between every state transition
2023-08-28T10:48:07.072-0500    INFO    cmdoptions/client.go:68 Client connected to 127.0.0.1:62795, namespace: default
2023-08-28T10:48:07.127-0500    INFO    internal/internal_worker.go:965 Started Worker  {"Namespace": "default", "TaskQueue": "state_transitions_steady:yjpvisxa", "WorkerID": "58352@cretz-laptop@"}
2023-08-28T10:48:07.148-0500    INFO    scenarios/state_transitions_steady.go:83        Simple workflow takes 7 state transitions, which means we need to start a workflow every 35ms. Running for 30s now...
2023-08-28T10:48:37.150-0500    INFO    scenarios/state_transitions_steady.go:134       Run complete, ran 1715 iterations
2023-08-28T10:48:37.151-0500    INFO    cmd/run_worker.go:192   Sending interrupt to worker, PID: 58352
```

I do not know whether this even works or solves the needs.