### PR TITLE
Re-do throughputstress executor as a workflow

### DIFF
--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -75,7 +75,7 @@ type ScenarioInfo struct {
 	ScenarioName string
 	// Run ID of the current scenario run, used to generate a unique task queue
 	// and workflow ID prefix. This is a single value for the whole scenario, and
-	// not a Workflow RunId.
+	// not a Workflow RunID.
 	RunID string
 	// Metrics component for registering new metrics.
 	MetricsHandler client.MetricsHandler
@@ -101,6 +101,22 @@ func (s *ScenarioInfo) ScenarioOptionInt(name string, defaultValue int) int {
 		panic(err)
 	}
 	return i
+}
+
+func (s *ScenarioInfo) ScenarioOptionDuration(name string, defaultValue time.Duration) time.Duration {
+	v := s.ScenarioOptions[name]
+	if v == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func (s *ScenarioInfo) TaskQueue() string {
+	return TaskQueueForRun(s.ScenarioName, s.RunID)
 }
 
 const DefaultIterations = 10
@@ -147,10 +163,6 @@ func (s *ScenarioInfo) NewRun(iteration int) *Run {
 // TaskQueueForRun returns a default task queue name for the given scenario name and run ID.
 func TaskQueueForRun(scenarioName, runID string) string {
 	return fmt.Sprintf("%s:%s", scenarioName, runID)
-}
-
-func (r *Run) TaskQueue() string {
-	return TaskQueueForRun(r.ScenarioName, r.RunID)
 }
 
 // DefaultStartWorkflowOptions gets default start workflow info.

--- a/loadgen/throughputstress/throughput_stress.go
+++ b/loadgen/throughputstress/throughput_stress.go
@@ -1,15 +1,17 @@
 package throughputstress
 
+const ThroughputStressScenarioIdSearchAttribute = "ThroughputStressScenarioId"
+
 // WorkflowParams is the single input for the throughput stress workflow.
 type WorkflowParams struct {
 	// Number of times we should loop through the steps in the workflow.
 	Iterations int `json:"iterations"`
-	// What iteration to start on. If we have continued-as-new, we might be starting at a nonzero
-	// number.
-	InitialIteration int `json:"initialIteration"`
 	// If nonzero, we will continue as new after history has grown to be at least this many events.
 	ContinueAsNewAfterEventCount int `json:"continueAsNewAfterEventCount"`
 
+	// Set internally. What iteration to start on. If we have continued-as-new, we might be starting
+	// at a nonzero number.
+	InitialIteration int `json:"initialIteration"`
 	// Set internally and incremented every time the workflow continues as new.
 	TimesContinued int `json:"timesContinued"`
 	// Set internally and incremented every time the workflow spawns a child.
@@ -21,4 +23,15 @@ type WorkflowOutput struct {
 	ChildrenSpawned int `json:"childrenSpawned"`
 	// The total number of times the workflow continued as new.
 	TimesContinued int `json:"timesContinued"`
+}
+
+type ExecutorWorkflowInput struct {
+	// Number of iterations to run of the load workflow
+	Iterations int `json:"iterations"`
+	// Maximum number of instances of the load workflow to run concurrently
+	MaxConcurrent int `json:"maxConcurrent"`
+	// The RunID as from ScenarioInfo
+	RunID string `json:"runId"`
+	// Parameters for the actual load workflow
+	LoadParams WorkflowParams `json:"loadParams"`
 }

--- a/loadgen/workflow_executor.go
+++ b/loadgen/workflow_executor.go
@@ -1,0 +1,41 @@
+package loadgen
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/client"
+)
+
+// WorkflowExecutor is a very dumb executor that does nothing but run the specified workflow.
+// Scenarios using it are expected to implement all their driver logic as a workflow.
+type WorkflowExecutor struct {
+	WorkflowType       string
+	WorkflowArgCreator func(info ScenarioInfo) []interface{}
+}
+
+func (w WorkflowExecutor) Run(ctx context.Context, info ScenarioInfo) error {
+	// TODO: ??
+	//executorTimeout := info.ScenarioOptionDuration(scenarios.ExecutorTimeoutFlag, 1*time.Hour)
+	executorTimeout := 1 * time.Hour
+	workflowOpts := client.StartWorkflowOptions{
+		ID:                       fmt.Sprintf("%s-driver", info.TaskQueue()),
+		TaskQueue:                info.TaskQueue(), // TODO: Should be special tq for driver?
+		WorkflowExecutionTimeout: executorTimeout,
+	}
+	run, err := info.Client.ExecuteWorkflow(
+		ctx,
+		workflowOpts,
+		w.WorkflowType,
+		w.WorkflowArgCreator(info)...,
+	)
+	if err != nil {
+		return err
+	}
+	err = run.Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -1,20 +1,10 @@
 package scenarios
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"go.temporal.io/api/workflowservice/v1"
-	"sync/atomic"
-	"time"
-
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/operatorservice/v1"
-	"go.temporal.io/api/serviceerror"
 
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/loadgen/throughputstress"
-	"go.temporal.io/sdk/client"
 )
 
 // --option arguments
@@ -23,102 +13,26 @@ const (
 	CANEventFlag = "continue-as-new-after-event-count"
 )
 
-const ThroughputStressScenarioIdSearchAttribute = "ThroughputStressScenarioId"
-
-type tpsExecutor struct {
-	workflowCount atomic.Uint64
-}
-
-func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error {
-	// Make sure the search attribute is registered
-	attribMap := map[string]enums.IndexedValueType{
-		ThroughputStressScenarioIdSearchAttribute: enums.INDEXED_VALUE_TYPE_KEYWORD,
-	}
-	_, err := info.Client.OperatorService().AddSearchAttributes(ctx,
-		&operatorservice.AddSearchAttributesRequest{
-			Namespace:        info.Namespace,
-			SearchAttributes: attribMap,
-		})
-	var svcErr *serviceerror.AlreadyExists
-	if !errors.As(err, &svcErr) {
-		return err
-	}
-
-	// Complain if there are already existing workflows with the provided run id
-	visibilityCount, err := info.Client.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
-		Namespace: info.Namespace,
-		Query:     fmt.Sprintf("%s='%s'", ThroughputStressScenarioIdSearchAttribute, info.RunID),
-	})
-	if err != nil {
-		return err
-	}
-	if visibilityCount.Count > 0 {
-		return fmt.Errorf("there are already %d workflows with scenario Run ID '%s'",
-			visibilityCount.Count, info.RunID)
-	}
-
-	genericExec := &loadgen.GenericExecutor{
-		DefaultConfiguration: loadgen.RunConfiguration{
-			Iterations:    20,
-			MaxConcurrent: 5,
-		},
-		Execute: func(ctx context.Context, run *loadgen.Run) error {
-			internalIterations := run.ScenarioInfo.ScenarioOptionInt(IterFlag, 5)
-			continueAsNewCount := run.ScenarioInfo.ScenarioOptionInt(CANEventFlag, 100)
-			timeout := time.Duration(1*internalIterations) * time.Minute
-
-			wfID := fmt.Sprintf("throughputStress-%s-%d", run.RunID, run.Iteration)
-			var result throughputstress.WorkflowOutput
-			err := run.ExecuteAnyWorkflow(ctx,
-				client.StartWorkflowOptions{
-					ID:                                       wfID,
-					TaskQueue:                                run.TaskQueue(),
-					WorkflowExecutionTimeout:                 timeout,
-					WorkflowExecutionErrorWhenAlreadyStarted: true,
-					SearchAttributes: map[string]interface{}{
-						ThroughputStressScenarioIdSearchAttribute: run.ScenarioInfo.RunID,
-					},
-				},
-				"throughputStress",
-				&result,
-				throughputstress.WorkflowParams{
-					Iterations:                   internalIterations,
-					ContinueAsNewAfterEventCount: continueAsNewCount,
-				})
-			// The 1 is for the final workflow run
-			t.workflowCount.Add(uint64(result.TimesContinued + result.ChildrenSpawned + 1))
-			return err
-		},
-	}
-	err = genericExec.Run(ctx, info)
-	if err != nil {
-		return err
-	}
-
-	// Post-scenario, verify visibility counts
-	totalWorkflowCount := t.workflowCount.Load()
-	info.Logger.Info("Total workflows executed: ", totalWorkflowCount)
-	return loadgen.VisibilityCountIsEventually(
-		ctx,
-		info.Client,
-		&workflowservice.CountWorkflowExecutionsRequest{
-			Namespace: info.Namespace,
-			Query: fmt.Sprintf("%s='%s'",
-				ThroughputStressScenarioIdSearchAttribute, info.RunID),
-		},
-		int(totalWorkflowCount),
-		3*time.Minute,
-	)
-
-}
-
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: fmt.Sprintf(
 			"Throughput stress scenario. Use --%s and --%s to control internal parameters",
 			IterFlag, CANEventFlag),
-		Executor: &tpsExecutor{
-			workflowCount: atomic.Uint64{},
+		Executor: &loadgen.WorkflowExecutor{
+			WorkflowType: "ThroughputStressExecutorWorkflow",
+			WorkflowArgCreator: func(info loadgen.ScenarioInfo) []interface{} {
+				internalIterations := info.ScenarioOptionInt(IterFlag, 5)
+				continueAsNewCount := info.ScenarioOptionInt(CANEventFlag, 100)
+				return []interface{}{throughputstress.ExecutorWorkflowInput{
+					Iterations:    20,
+					MaxConcurrent: 5,
+					RunID:         info.RunID,
+					LoadParams: throughputstress.WorkflowParams{
+						Iterations:                   internalIterations,
+						ContinueAsNewAfterEventCount: continueAsNewCount,
+					},
+				}}
+			},
 		},
 	})
 }

--- a/workers/go/throughputstress/activities.go
+++ b/workers/go/throughputstress/activities.go
@@ -2,9 +2,17 @@ package throughputstress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 
+	"go.temporal.io/api/workflowservice/v1"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/serviceerror"
+
+	"github.com/temporalio/omes/loadgen/throughputstress"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 )
@@ -83,4 +91,47 @@ func (a *Activities) SelfUpdate(ctx context.Context, updateName string) error {
 func (a *Activities) SelfSignal(ctx context.Context, signalName string) error {
 	we := activity.GetInfo(ctx).WorkflowExecution
 	return a.Client.SignalWorkflow(ctx, we.ID, we.RunID, signalName, nil)
+}
+
+func (a *Activities) EnsureSearchAttributeRegistered(ctx context.Context, namespace string) error {
+	attribMap := map[string]enums.IndexedValueType{
+		throughputstress.ThroughputStressScenarioIdSearchAttribute: enums.INDEXED_VALUE_TYPE_KEYWORD,
+	}
+	_, err := a.Client.OperatorService().AddSearchAttributes(ctx,
+		&operatorservice.AddSearchAttributesRequest{
+			Namespace:        namespace,
+			SearchAttributes: attribMap,
+		})
+	var svcErr *serviceerror.AlreadyExists
+	if !errors.As(err, &svcErr) {
+		return err
+	}
+
+	return nil
+}
+
+func (a *Activities) VisibilityCount(ctx context.Context, query string) (int64, error) {
+	visibilityCount, err := a.Client.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+		Query: query,
+	})
+	if err != nil {
+		return -1, err
+	}
+	return visibilityCount.Count, nil
+}
+
+type VisibilityCountMatchesInput struct {
+	Query    string
+	Expected int
+}
+
+func (a *Activities) VisibilityCountMatches(ctx context.Context, input *VisibilityCountMatchesInput) error {
+	count, err := a.VisibilityCount(ctx, input.Query)
+	if err != nil {
+		return err
+	}
+	if count != int64(input.Expected) {
+		return fmt.Errorf("expected %d workflows in visibility, got %d", input.Expected, count)
+	}
+	return nil
 }

--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -65,6 +65,7 @@ func runWorkers(client client.Client, taskQueues []string) error {
 			w.RegisterActivityWithOptions(kitchensink.Noop, activity.RegisterOptions{Name: "noop"})
 			w.RegisterWorkflowWithOptions(throughputstress.ThroughputStressWorkflow, workflow.RegisterOptions{Name: "throughputStress"})
 			w.RegisterWorkflow(throughputstress.ThroughputStressChild)
+			w.RegisterWorkflow(throughputstress.ThroughputStressExecutorWorkflow)
 			w.RegisterActivity(&tpsActivities)
 			errCh <- w.Run(worker.InterruptCh())
 		}()


### PR DESCRIPTION
Still a couple of TODOs left but no big changes

## What was changed
Re-did the throughputstress scenario to be driven from a workflow

## Why?
Makes it much easier to invoke by simply starting a workflow in CI/CD pipelines

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Ran directly

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
