### PR TITLE
Introduce --tls flag

### DIFF
--- a/cmd/cmdoptions/client.go
+++ b/cmd/cmdoptions/client.go
@@ -34,10 +34,11 @@ func (c *ClientOptions) loadTLSConfig() (*tls.Config, error) {
 			return nil, fmt.Errorf("failed to load certs: %s", err)
 		}
 		return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
-	} else if c.EnableTLS {
-		return &tls.Config{}, nil
 	} else if c.ClientKeyPath != "" {
 		return nil, errors.New("got TLS key with no cert")
+	}
+	if c.EnableTLS {
+		return &tls.Config{}, nil
 	}
 	return nil, nil
 }

--- a/cmd/run_worker.go
+++ b/cmd/run_worker.go
@@ -93,8 +93,8 @@ func (r *workerRunner) run(ctx context.Context) error {
 	// Run an embedded server if requested
 	if r.embeddedServer || r.embeddedServerAddress != "" {
 		// Intentionally don't use context, will stop on defer
-		if r.clientOptions.ClientCertPath != "" || r.clientOptions.ClientKeyPath != "" {
-			return fmt.Errorf("cannot give TLS certs with embedded server")
+		if r.clientOptions.EnableTLS || r.clientOptions.ClientCertPath != "" || r.clientOptions.ClientKeyPath != "" {
+			return fmt.Errorf("cannot use TLS with embedded server")
 		} else if r.clientOptions.Address != client.DefaultHostPort {
 			return fmt.Errorf("cannot supply non-default client address when using embedded server")
 		}

--- a/workers/python/main.py
+++ b/workers/python/main.py
@@ -61,6 +61,7 @@ async def run():
         default="localhost:7233",
         help="Address of Temporal server",
     )
+    parser.add_argument("--tls", action="store_true", help="Enable TLS")
     parser.add_argument(
         "--tls-cert-path", default="", help="Path to client TLS certificate"
     )
@@ -87,6 +88,8 @@ async def run():
         tls_config = TLSConfig(client_cert=client_cert, client_private_key=client_key)
     elif args.tls_key_path and not args.tls_cert_path:
         raise ValueError("Client key specified, but not client cert!")
+    elif args.tls:
+        tls_config = TLSConfig()
 
     # Configure logging
     logger = logging.getLogger()


### PR DESCRIPTION
## What was changed

`--tls` flag was added.

## Why?

To allow connecting to Temporal clusters that use TLS but not require client certificates.