### PR TITLE
Introduce flags for setting worker options such as task poller counts and concurrent execution limits

### DIFF
--- a/cmd/cmdoptions/worker.go
+++ b/cmd/cmdoptions/worker.go
@@ -1,0 +1,39 @@
+package cmdoptions
+
+import (
+	"github.com/spf13/pflag"
+	"strconv"
+)
+
+// WorkerOptions for setting up worker parameters
+type WorkerOptions struct {
+	MaxConcurrentActivityTaskPollers       int
+	MaxConcurrentWorkflowTaskPollers       int
+	MaxConcurrentActivityExecutionSize     int
+	MaxConcurrentWorkflowTaskExecutionSize int
+}
+
+// AddCLIFlags adds the relevant flags to populate the options struct.
+func (m *WorkerOptions) AddCLIFlags(fs *pflag.FlagSet, prefix string) {
+	fs.IntVar(&m.MaxConcurrentActivityTaskPollers, prefix+"max-concurrent-activity-task-pollers", 0, "Max concurrent activity task pollers")
+	fs.IntVar(&m.MaxConcurrentWorkflowTaskPollers, prefix+"max-concurrent-workflow-task-pollers", 0, "Max concurrent workflow task pollers")
+	fs.IntVar(&m.MaxConcurrentActivityExecutionSize, prefix+"max-concurrent-activity-execution-size", 0, "Max concurrent activity execution size")
+	fs.IntVar(&m.MaxConcurrentWorkflowTaskExecutionSize, prefix+"max-concurrent-workflow-task-execution-size", 0, "Max concurrent workflow task execution size")
+}
+
+// ToFlags converts these options to string flags.
+func (m *WorkerOptions) ToFlags() (flags []string) {
+	if m.MaxConcurrentActivityTaskPollers != 0 {
+		flags = append(flags, "--max-concurrent-activity-task-pollers", strconv.Itoa(m.MaxConcurrentActivityTaskPollers))
+	}
+	if m.MaxConcurrentWorkflowTaskPollers != 0 {
+		flags = append(flags, "--max-concurrent-workflow-task-pollers", strconv.Itoa(m.MaxConcurrentWorkflowTaskPollers))
+	}
+	if m.MaxConcurrentActivityExecutionSize != 0 {
+		flags = append(flags, "--max-concurrent-activity-execution-size", strconv.Itoa(m.MaxConcurrentActivityExecutionSize))
+	}
+	if m.MaxConcurrentWorkflowTaskExecutionSize != 0 {
+		flags = append(flags, "--max-concurrent-workflow-task-execution-size", strconv.Itoa(m.MaxConcurrentWorkflowTaskExecutionSize))
+	}
+	return
+}

--- a/cmd/cmdoptions/worker.go
+++ b/cmd/cmdoptions/worker.go
@@ -1,39 +1,40 @@
 package cmdoptions
 
 import (
-	"github.com/spf13/pflag"
 	"strconv"
+
+	"github.com/spf13/pflag"
 )
 
 // WorkerOptions for setting up worker parameters
 type WorkerOptions struct {
-	MaxConcurrentActivityTaskPollers       int
-	MaxConcurrentWorkflowTaskPollers       int
-	MaxConcurrentActivityExecutionSize     int
-	MaxConcurrentWorkflowTaskExecutionSize int
+	MaxConcurrentActivityPollers int
+	MaxConcurrentWorkflowPollers int
+	MaxConcurrentActivities      int
+	MaxConcurrentWorkflowTasks   int
 }
 
 // AddCLIFlags adds the relevant flags to populate the options struct.
 func (m *WorkerOptions) AddCLIFlags(fs *pflag.FlagSet, prefix string) {
-	fs.IntVar(&m.MaxConcurrentActivityTaskPollers, prefix+"max-concurrent-activity-task-pollers", 0, "Max concurrent activity task pollers")
-	fs.IntVar(&m.MaxConcurrentWorkflowTaskPollers, prefix+"max-concurrent-workflow-task-pollers", 0, "Max concurrent workflow task pollers")
-	fs.IntVar(&m.MaxConcurrentActivityExecutionSize, prefix+"max-concurrent-activity-execution-size", 0, "Max concurrent activity execution size")
-	fs.IntVar(&m.MaxConcurrentWorkflowTaskExecutionSize, prefix+"max-concurrent-workflow-task-execution-size", 0, "Max concurrent workflow task execution size")
+	fs.IntVar(&m.MaxConcurrentActivityPollers, prefix+"max-concurrent-activity-pollers", 0, "Max concurrent activity pollers")
+	fs.IntVar(&m.MaxConcurrentWorkflowPollers, prefix+"max-concurrent-workflow-pollers", 0, "Max concurrent workflow pollers")
+	fs.IntVar(&m.MaxConcurrentActivities, prefix+"max-concurrent-activities", 0, "Max concurrent activities")
+	fs.IntVar(&m.MaxConcurrentWorkflowTasks, prefix+"max-concurrent-workflow-tasks", 0, "Max concurrent workflow tasks")
 }
 
 // ToFlags converts these options to string flags.
 func (m *WorkerOptions) ToFlags() (flags []string) {
-	if m.MaxConcurrentActivityTaskPollers != 0 {
-		flags = append(flags, "--max-concurrent-activity-task-pollers", strconv.Itoa(m.MaxConcurrentActivityTaskPollers))
+	if m.MaxConcurrentActivityPollers != 0 {
+		flags = append(flags, "--max-concurrent-activity-pollers", strconv.Itoa(m.MaxConcurrentActivityPollers))
 	}
-	if m.MaxConcurrentWorkflowTaskPollers != 0 {
-		flags = append(flags, "--max-concurrent-workflow-task-pollers", strconv.Itoa(m.MaxConcurrentWorkflowTaskPollers))
+	if m.MaxConcurrentWorkflowPollers != 0 {
+		flags = append(flags, "--max-concurrent-workflow-pollers", strconv.Itoa(m.MaxConcurrentWorkflowPollers))
 	}
-	if m.MaxConcurrentActivityExecutionSize != 0 {
-		flags = append(flags, "--max-concurrent-activity-execution-size", strconv.Itoa(m.MaxConcurrentActivityExecutionSize))
+	if m.MaxConcurrentActivities != 0 {
+		flags = append(flags, "--max-concurrent-activities", strconv.Itoa(m.MaxConcurrentActivities))
 	}
-	if m.MaxConcurrentWorkflowTaskExecutionSize != 0 {
-		flags = append(flags, "--max-concurrent-workflow-task-execution-size", strconv.Itoa(m.MaxConcurrentWorkflowTaskExecutionSize))
+	if m.MaxConcurrentWorkflowTasks != 0 {
+		flags = append(flags, "--max-concurrent-workflow-tasks", strconv.Itoa(m.MaxConcurrentWorkflowTasks))
 	}
 	return
 }

--- a/cmd/run_worker.go
+++ b/cmd/run_worker.go
@@ -166,6 +166,7 @@ func (r *workerRunner) run(ctx context.Context) error {
 	args = append(args, r.clientOptions.ToFlags()...)
 	args = append(args, r.metricsOptions.ToFlags()...)
 	args = append(args, r.loggingOptions.ToFlags()...)
+	args = append(args, r.workerOptions.ToFlags()...)
 
 	// Start the command. Do not use the context so we can send interrupt.
 	cmd, err := prog.NewCommand(context.Background(), args...)

--- a/cmd/run_worker.go
+++ b/cmd/run_worker.go
@@ -53,6 +53,7 @@ type workerRunner struct {
 	taskQueueIndexSuffixEnd   int
 	clientOptions             cmdoptions.ClientOptions
 	metricsOptions            cmdoptions.MetricsOptions
+	workerOptions             cmdoptions.WorkerOptions
 	onWorkerStarted           func()
 }
 
@@ -70,6 +71,7 @@ func (r *workerRunner) addCLIFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&r.taskQueueIndexSuffixEnd, "task-queue-suffix-index-end", 0, "Inclusive end for task queue suffix range")
 	r.clientOptions.AddCLIFlags(fs)
 	r.metricsOptions.AddCLIFlags(fs, "worker-")
+	r.workerOptions.AddCLIFlags(fs, "worker-")
 }
 
 func (r *workerRunner) run(ctx context.Context) error {

--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -3,12 +3,11 @@ package worker
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"github.com/temporalio/omes/cmd/cmdoptions"
 	"github.com/temporalio/omes/workers/go/kitchensink"
 	"github.com/temporalio/omes/workers/go/throughputstress"
 	"go.temporal.io/sdk/activity"
-
-	"github.com/spf13/cobra"
-	"github.com/temporalio/omes/cmd/cmdoptions"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -62,10 +61,10 @@ func runWorkers(client client.Client, taskQueues []string, options cmdoptions.Wo
 		taskQueue := taskQueue
 		go func() {
 			w := worker.New(client, taskQueue, worker.Options{
-				MaxConcurrentActivityExecutionSize:     options.MaxConcurrentActivityExecutionSize,
-				MaxConcurrentWorkflowTaskExecutionSize: options.MaxConcurrentWorkflowTaskExecutionSize,
-				MaxConcurrentActivityTaskPollers:       options.MaxConcurrentActivityTaskPollers,
-				MaxConcurrentWorkflowTaskPollers:       options.MaxConcurrentWorkflowTaskPollers,
+				MaxConcurrentActivityExecutionSize:     options.MaxConcurrentActivities,
+				MaxConcurrentWorkflowTaskExecutionSize: options.MaxConcurrentWorkflowTasks,
+				MaxConcurrentActivityTaskPollers:       options.MaxConcurrentActivityPollers,
+				MaxConcurrentWorkflowTaskPollers:       options.MaxConcurrentWorkflowPollers,
 			})
 			w.RegisterWorkflowWithOptions(kitchensink.KitchenSinkWorkflow, workflow.RegisterOptions{Name: "kitchenSink"})
 			w.RegisterActivityWithOptions(kitchensink.Noop, activity.RegisterOptions{Name: "noop"})

--- a/workers/python/main.py
+++ b/workers/python/main.py
@@ -95,7 +95,7 @@ async def run():
         raise ValueError("Task queue suffix start after end")
 
     # Configure TLS
-    tls_config = TLSConfig()
+    tls_config = None
     if args.tls_cert_path:
         if not args.tls_key_path:
             raise ValueError("Client cert specified, but not client key!")

--- a/workers/python/main.py
+++ b/workers/python/main.py
@@ -49,22 +49,20 @@ async def run():
     parser.add_argument(
         "--max-concurrent-activity-pollers",
         type=int,
-        help="Max concurrent activity pollers"
+        help="Max concurrent activity pollers",
     )
     parser.add_argument(
         "--max-concurrent-workflow-pollers",
         type=int,
-        help="Max concurrent workflow pollers"
+        help="Max concurrent workflow pollers",
     )
     parser.add_argument(
-        "--max-concurrent-activities",
-        type=int,
-        help="Max concurrent activities"
+        "--max-concurrent-activities", type=int, help="Max concurrent activities"
     )
     parser.add_argument(
         "--max-concurrent-workflow-tasks",
         type=int,
-        help="Max concurrent workflow tasks "
+        help="Max concurrent workflow tasks",
     )
     # Log arguments
     parser.add_argument(
@@ -163,13 +161,19 @@ async def run():
 
     worker_kwargs = {}
     if args.max_concurrent_activity_pollers is not None:
-        worker_kwargs['max_concurrent_activity_task_polls'] = args.max_concurrent_activity_pollers
+        worker_kwargs[
+            "max_concurrent_activity_task_polls"
+        ] = args.max_concurrent_activity_pollers
     if args.max_concurrent_workflow_pollers is not None:
-        worker_kwargs['max_concurrent_workflow_task_polls'] = args.max_concurrent_workflow_pollers
+        worker_kwargs[
+            "max_concurrent_workflow_task_polls"
+        ] = args.max_concurrent_workflow_pollers
     if args.max_concurrent_activities is not None:
-        worker_kwargs['max_concurrent_activities'] = args.max_concurrent_activities
+        worker_kwargs["max_concurrent_activities"] = args.max_concurrent_activities
     if args.max_concurrent_workflow_tasks is not None:
-        worker_kwargs['max_concurrent_workflow_tasks'] = args.max_concurrent_workflow_tasks
+        worker_kwargs[
+            "max_concurrent_workflow_tasks"
+        ] = args.max_concurrent_workflow_tasks
 
     # Start all workers, throwing on first exception
     workers = [


### PR DESCRIPTION
## What was changed
The following flags were added:
```
      --worker-max-concurrent-activity-execution-size int        Max concurrent activity execution size
      --worker-max-concurrent-activity-task-pollers int          Max concurrent activity task pollers
      --worker-max-concurrent-workflow-task-execution-size int   Max concurrent workflow task execution size
      --worker-max-concurrent-workflow-task-pollers int          Max concurrent workflow task pollers
```

## Why?
To be able to set up workers according to [the recommendations](https://docs.temporal.io/dev-guide/worker-performance#configuration).