### PR TITLE
Fix typescript docker build pipeline

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/setup-go@v4
         with:

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -23,6 +23,7 @@ COPY go.mod go.sum ./
 # Build the CLI
 RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
 # Build typescript proto files
+# hadolint ignore=DL3003
 RUN cd workers/typescript && npm install && npm run proto-gen
 
 ARG SDK_VERSION


### PR DESCRIPTION
- checkout submodules
- Ignore linter complaint about `cd` in dockerfile