### PR TITLE
Fix non-determinism due to HashMap

### DIFF
--- a/loadgen/kitchen-sink-gen/src/main.rs
+++ b/loadgen/kitchen-sink-gen/src/main.rs
@@ -504,7 +504,8 @@ impl<'a> Arbitrary<'a> for Action {
                 if c.cur_workflow_state.kvs.is_empty() {
                     None
                 } else {
-                    let keys = c.cur_workflow_state.kvs.keys().collect::<Vec<_>>();
+                    let mut keys = c.cur_workflow_state.kvs.keys().collect::<Vec<_>>();
+                    keys.sort();
                     Some(u.choose(&keys).map(|s| s.to_string()))
                 }
             });

--- a/loadgen/kitchen-sink-gen/src/main.rs
+++ b/loadgen/kitchen-sink-gen/src/main.rs
@@ -271,7 +271,6 @@ fn generate(args: GenerateCmd) -> Result<(), Error> {
     let context = ArbContext {
         config,
         cur_workflow_state: Default::default(),
-        did_a_nested_action: false,
         action_set_nest_level: 0,
     };
     ARB_CONTEXT.set(context);
@@ -298,7 +297,6 @@ static WF_TYPE_NAME: &str = "kitchenSink";
 struct ArbContext {
     config: GeneratorConfig,
     cur_workflow_state: WorkflowState,
-    did_a_nested_action: bool,
     action_set_nest_level: usize,
 }
 


### PR DESCRIPTION
## Problem
When using the same RNG seed output should be identical. We're using `unstructured.choose()`, which will make the same choice on the same input, but we're passing it input from `HashMap.keys()` which varies in a way that doesn't respect our RNG seed.

## Solution
Sort the keys before sampling from them.

I've also removed an used struct field.

## TODO
The protobuf output is still not identical between runs using the same seed

```
$ md5sum <(cargo run -- generate --explicit-seed=12345 2>/dev/null) <(cargo run -- generate --explicit-seed=12345 2>/dev/null)
0e6a07381e53be30917f70469f67b8e0  /dev/fd/11
0cbf879a9a16bd8cb86c8abd1c0a5dc4  /dev/fd/12
```

I believe that is due to non-deterministic serialization of the `WorkflowState` HashMap. Even if that has no consequences for the workflow generation, it would be nice to fix since it would be reassuring for people to see identical output for the same seed.