### PR TITLE
Use https URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "workers/proto/api_upstream"]
 	path = workers/proto/api_upstream
-	url = git@github.com:temporalio/api.git
+	url = https://github.com/temporalio/api


### PR DESCRIPTION
This is convenient when building a docker image. Specifically, this PR helps Omes CICD work https://github.com/temporalio/saas-cicd/pull/558.