### PR TITLE
Fix state_transitions_steady workflow input

### DIFF
--- a/scenarios/state_transitions_steady.go
+++ b/scenarios/state_transitions_steady.go
@@ -49,11 +49,9 @@ func (s *stateTransitionsSteady) run(ctx context.Context) error {
 	)
 
 	// Execute initial workflow and get the transition count
-	workflowParams := &kitchensink.TestInput{
-		WorkflowInput: &kitchensink.WorkflowInput{
-			InitialActions: []*kitchensink.ActionSet{
-				kitchensink.NoOpSingleActivityActionSet(),
-			},
+	workflowParams := &kitchensink.WorkflowInput{
+		InitialActions: []*kitchensink.ActionSet{
+			kitchensink.NoOpSingleActivityActionSet(),
 		},
 	}
 	workflowRun, err := s.Client.ExecuteWorkflow(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Use the raw WorkflowInput instead of TestInput wrapper for the params to the sdk client when executing the state transistion steady state scenario.

## Why?
<!-- Tell your future self why have you made these changes -->
This wrapper is unecessary and was causing the scenario to fail.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
```
go run ./cmd run-scenario-with-worker --language go --scenario state_transitions_steady --run-id local-test-run-4 --duration 10s --option state-transitions-per-second=10
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
