### PR TITLE
Allow pre-built kitchen-sink-gen executable

### DIFF
--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -45,10 +45,18 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 		}
 		testInputs = append(testInputs, asTInput)
 	} else if fileOrArgs.Args != nil {
-		args := []string{"run", "--"}
-		args = append(args, fileOrArgs.Args...)
-		cmd := exec.CommandContext(ctx, "cargo", args...)
-		cmd.Dir = filepath.Join(info.RootPath, "loadgen", "kitchen-sink-gen")
+		var cmd *exec.Cmd
+		// The value of the 'kitchen-sink-gen' option is the name of or absolute
+		// path to the executable.
+		executable, ok := info.ScenarioOptions["kitchen-sink-gen"]
+		if ok && executable != "" {
+			cmd = exec.CommandContext(ctx, executable, fileOrArgs.Args...)
+		} else {
+			args := []string{"run", "--"}
+			args = append(args, fileOrArgs.Args...)
+			cmd = exec.CommandContext(ctx, "cargo", args...)
+			cmd.Dir = filepath.Join(info.RootPath, "loadgen", "kitchen-sink-gen")
+		}
 		cmd.Stderr = os.Stderr
 		protoBytes, err := cmd.Output()
 		if err != nil {


### PR DESCRIPTION
## Problem
In some contexts (e.g. CICD control plane workers) a client of the omes Go library will want to build the `kitchen-sink-gen` executable at (docker image) build time. However, currently omes invokes `kitchen-sink-gen` via `cargo run` at run-time.

## Solution
Support passing this as  scenario-specific option named `kitchen-sink-gen`. Its value is either the name of the executable (to be resolved via `$PATH`) or an absolute path. This is usable via the CLI as `--option=kitchen-sink-gen=my-executable`, or by a library client as 

```go
ScenarioOptions: map[string]string{
	"kitchen-sink-gen": "my-executable",
},
```

## How this was tested

```
go run ./cmd run-scenario --scenario fuzzer_example --run-id 1234 --duration 10s --option kitchen-sink-gen=$PWD/ksg
```

where

```
$ cat ksg
#!/bin/bash
echo using pre-built kitchen-sink-gen executable 1>&2
docker run my-image kitchen-sink-gen "$@"
```