### PR TITLE
Fix Python worker prometheus exporter

### DIFF
--- a/workers/python/main.py
+++ b/workers/python/main.py
@@ -3,14 +3,10 @@ import asyncio
 import logging
 import os
 import sys
-import threading
 from typing import List
-from urllib.parse import urlparse
-from wsgiref.simple_server import make_server
 
-from prometheus_client import make_wsgi_app
 from pythonjsonlogger import jsonlogger
-from temporalio.client import Client, TLSConfig
+from temporalio.client import Client
 from temporalio.runtime import (
     LoggingConfig,
     PrometheusConfig,
@@ -18,6 +14,7 @@ from temporalio.runtime import (
     TelemetryConfig,
     TelemetryFilter,
 )
+from temporalio.service import TLSConfig
 from temporalio.worker import Worker
 
 from activities import delay_activity, noop_activity
@@ -125,22 +122,11 @@ async def run():
     logger.addHandler(logHandler)
     logger.setLevel(nameToLevel[args.log_level.upper()])
 
-    # Configure metrics
-    prometheus = None
-    if args.prom_listen_address:
-        prom_addr = urlparse(args.prom_listen_address)
-        metrics_app = make_wsgi_app()
-        handle_path = args.prom_handler_path
-
-        def prom_app(environ, start_fn):
-            if environ["PATH_INFO"] == handle_path:
-                return metrics_app(environ, start_fn)
-
-        httpd = make_server(prom_addr.hostname, prom_addr.port, prom_app)
-        t = threading.Thread(target=httpd.serve_forever)
-        t.daemon = True
-        t.start()
-        prometheus = PrometheusConfig(bind_address=parser.prom_listen_address)
+    prometheus = (
+        PrometheusConfig(bind_address=args.prom_listen_address)
+        if args.prom_listen_address
+        else None
+    )
 
     new_runtime = Runtime(
         telemetry=TelemetryConfig(


### PR DESCRIPTION
The prometheus server is started by the core bridge nowadays. This PR gets rid of some draft code we had that was starting a server directly in Python. Without this PR there are errors in the python code and a port conflict that can be reproduced with

```
docker build -f dockerfiles/python.Dockerfile -t omes-python .
docker run -e RUST_BACKTRACE=full omes-python \
        --scenario workflow_with_single_noop_activity \
        --run-id local-test-run \
        --language python \
        --namespace default \
        --server-address=host.docker.internal:7233 \
        --worker-prom-listen-address=127.0.0.1:9090
```