### PR TITLE
Omes empty payload

### DIFF
--- a/loadgen/kitchen-sink-gen/src/main.rs
+++ b/loadgen/kitchen-sink-gen/src/main.rs
@@ -810,7 +810,7 @@ fn empty_payload() -> Payload {
     Payload {
         metadata: {
             let mut m = HashMap::new();
-            m.insert("encoding".to_string(), "binary/protobuf".into());
+            m.insert("encoding".to_string(), "binary/null".into());
             m
         },
         data: vec![], // Empty

--- a/loadgen/kitchen-sink-gen/src/main.rs
+++ b/loadgen/kitchen-sink-gen/src/main.rs
@@ -810,9 +810,9 @@ fn empty_payload() -> Payload {
     Payload {
         metadata: {
             let mut m = HashMap::new();
-            m.insert("encoding".to_string(), "json/plain".into());
+            m.insert("encoding".to_string(), "binary/protobuf".into());
             m
         },
-        data: serde_json::to_vec("").expect("serializes"),
+        data: vec![], // Empty
     }
 }

--- a/scenarios/fuzzer.go
+++ b/scenarios/fuzzer.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"context"
+
 	"github.com/temporalio/omes/loadgen"
 )
 
@@ -15,6 +16,10 @@ func init() {
 				seed, ok := info.ScenarioOptions["seed"]
 				if ok && seed != "" {
 					args = append(args, "--explicit-seed", seed)
+				}
+				config, ok := info.ScenarioOptions["config"]
+				if ok && config != "" {
+					args = append(args, "--generator-config-override", config)
 				}
 				return loadgen.FileOrArgs{
 					Args: args,


### PR DESCRIPTION
This PR has two major changes:
* Change the empty payload type used as a protobuf message to `binary/protobuf` instead of `json/plain` because some languages json dataconverter cannot handle protobuf messages
* Support passing config options the fizzer