### PR TITLE
Add the ability to skip sleeps.

### DIFF
--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -3,8 +3,6 @@ package loadgen
 import (
 	"context"
 	"fmt"
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/operatorservice/v1"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -12,6 +10,8 @@ import (
 	"time"
 
 	"github.com/temporalio/omes/loadgen/kitchensink"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
 )
@@ -105,6 +105,11 @@ func (s *ScenarioInfo) ScenarioOptionInt(name string, defaultValue int) int {
 		panic(err)
 	}
 	return i
+}
+
+func (s *ScenarioInfo) ScenarioOptionBool(name string, defaultValue bool) bool {
+	v := s.ScenarioOptions[name]
+	return v == "true"
 }
 
 const DefaultIterations = 10

--- a/loadgen/throughputstress/throughput_stress.go
+++ b/loadgen/throughputstress/throughput_stress.go
@@ -4,6 +4,8 @@ package throughputstress
 type WorkflowParams struct {
 	// Number of times we should loop through the steps in the workflow.
 	Iterations int `json:"iterations"`
+	// If true, skip sleeps. This makes workflow end to end latency more informative.
+	SkipSleep bool `json:"skipSleep"`
 	// What iteration to start on. If we have continued-as-new, we might be starting at a nonzero
 	// number.
 	InitialIteration int `json:"initialIteration"`

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -19,8 +19,9 @@ import (
 
 // --option arguments
 const (
-	IterFlag     = "internal-iterations"
-	CANEventFlag = "continue-as-new-after-event-count"
+	IterFlag      = "internal-iterations"
+	SkipSleepFlag = "skip-sleep"
+	CANEventFlag  = "continue-as-new-after-event-count"
 )
 
 const ThroughputStressScenarioIdSearchAttribute = "ThroughputStressScenarioId"
@@ -76,6 +77,7 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 		Execute: func(ctx context.Context, run *loadgen.Run) error {
 			internalIterations := run.ScenarioInfo.ScenarioOptionInt(IterFlag, 5)
 			continueAsNewCount := run.ScenarioInfo.ScenarioOptionInt(CANEventFlag, 100)
+			skipSleep := run.ScenarioInfo.ScenarioOptionBool(SkipSleepFlag, false)
 			timeout := time.Duration(1*internalIterations) * time.Minute
 
 			wfID := fmt.Sprintf("throughputStress-%s-%d", run.RunID, run.Iteration)
@@ -93,6 +95,7 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 				"throughputStress",
 				&result,
 				throughputstress.WorkflowParams{
+					SkipSleep:                    skipSleep,
 					Iterations:                   internalIterations,
 					ContinueAsNewAfterEventCount: continueAsNewCount,
 				})
@@ -126,8 +129,8 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: fmt.Sprintf(
-			"Throughput stress scenario. Use --%s and --%s to control internal parameters",
-			IterFlag, CANEventFlag),
+			"Throughput stress scenario. Use --option with '%s', '%s' '%s' to control internal parameters",
+			IterFlag, CANEventFlag, SkipSleepFlag),
 		Executor: &tpsExecutor{
 			workflowCount: atomic.Uint64{},
 		},

--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -2,11 +2,11 @@ package throughputstress
 
 import (
 	"fmt"
-	"github.com/temporalio/omes/workers/go/workflowutils"
 	"time"
 
 	"github.com/temporalio/omes/loadgen/throughputstress"
 	"github.com/temporalio/omes/scenarios"
+	"github.com/temporalio/omes/workers/go/workflowutils"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -36,6 +36,9 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 		return output, err
 	}
 	err = workflow.SetUpdateHandler(ctx, UpdateSleep, func(ctx workflow.Context) error {
+		if params.SkipSleep {
+			return nil
+		}
 		return workflow.Sleep(ctx, 1*time.Second)
 	})
 	if err != nil {

--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -36,9 +36,6 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 		return output, err
 	}
 	err = workflow.SetUpdateHandler(ctx, UpdateSleep, func(ctx workflow.Context) error {
-		if params.SkipSleep {
-			return nil
-		}
 		return workflow.Sleep(ctx, 1*time.Second)
 	})
 	if err != nil {
@@ -142,6 +139,9 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 			},
 			func(ctx workflow.Context) error {
 				actCtx := workflow.WithActivityOptions(ctx, defaultActivityOpts())
+				if params.SkipSleep {
+					return nil
+				}
 				return workflow.ExecuteActivity(actCtx, activityStub.SelfUpdate, UpdateSleep).Get(ctx, nil)
 			},
 			func(ctx workflow.Context) error {


### PR DESCRIPTION
This makes workflow end to end latency more informative by avoiding dilution with un-optimisable time.
