### PR TITLE
Add required wait stage to Go client calls

### DIFF
--- a/loadgen/kitchensink/helpers.go
+++ b/loadgen/kitchensink/helpers.go
@@ -134,15 +134,17 @@ func (e *ClientActionsExecutor) executeClientAction(ctx context.Context, action 
 		var handle client.WorkflowUpdateHandle
 		if actionsUpdate := update.GetDoActions(); actionsUpdate != nil {
 			handle, err = e.Client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
-				WorkflowID: e.WorkflowID,
-				UpdateName: "do_actions_update",
-				Args:       []any{actionsUpdate},
+				WorkflowID:   e.WorkflowID,
+				UpdateName:   "do_actions_update",
+				WaitForStage: client.WorkflowUpdateStageCompleted,
+				Args:         []any{actionsUpdate},
 			})
 		} else if handler := update.GetCustom(); handler != nil {
 			handle, err = e.Client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
-				WorkflowID: e.WorkflowID,
-				UpdateName: handler.Name,
-				Args:       []any{handler.Args},
+				WorkflowID:   e.WorkflowID,
+				UpdateName:   handler.Name,
+				WaitForStage: client.WorkflowUpdateStageCompleted,
+				Args:         []any{handler.Args},
 			})
 		} else {
 			return fmt.Errorf("do_update must recognizable variant")

--- a/workers/go/throughputstress/activities.go
+++ b/workers/go/throughputstress/activities.go
@@ -74,9 +74,10 @@ func (a *Activities) SelfDescribe(ctx context.Context) error {
 func (a *Activities) SelfUpdate(ctx context.Context, updateName string) error {
 	we := activity.GetInfo(ctx).WorkflowExecution
 	handle, err := a.Client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
-		WorkflowID: we.ID,
-		RunID:      we.RunID,
-		UpdateName: updateName,
+		WorkflowID:   we.ID,
+		RunID:        we.RunID,
+		UpdateName:   updateName,
+		WaitForStage: client.WorkflowUpdateStageCompleted,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Evidence this is correct

Without this change, there are errors like this:

```
$ go run ./cmd run-scenario --scenario fuzzer --run-id $runid --duration 10s

2024-07-15T10:56:56.371-0400    ERROR   loadgen/scenario.go:242 Client actions failed: failed \
 to execute client action do_update: \
{do_actions:{do_actions:{actions:{exec_activity:{delay:{nanos:177000000} \
start_to_close_timeout:{seconds:5} remote:{cancellation_type:WAIT_CANCELLATION_COMPLETED} \
 awaitable_choice:{abandon:{}}}}}}}: \
WaitForStage must be specified        {"iteration": 4}
...
```