### PR TITLE
Include failed command in error message

### DIFF
--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -60,7 +60,7 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 		cmd.Stderr = os.Stderr
 		protoBytes, err := cmd.Output()
 		if err != nil {
-			return fmt.Errorf("failed to run rust generator: %w", err)
+			return fmt.Errorf("failed to run rust generator (%v): %w", cmd, err)
 		}
 		asTInput := &kitchensink.TestInput{}
 		err = proto.Unmarshal(protoBytes, asTInput)


### PR DESCRIPTION
Evidence this change is correct:

Output with invalid executable path:

> 2024-07-25T22:57:44.753-0400    FATAL   cmd/run_scenario_with_worker.go:20      scenario failed: failed scenario: failed to run rust generator (xxx generate --output-path last_fuzz_run.proto): exec: "xxx": executab
le file not found in $PATH
