### PR TITLE
Allow building worker images from local SDK paths

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -61,14 +61,6 @@ jobs:
           ref: ${{ inputs.sdk-repo-ref }}
           fetch-depth: 0
 
-      - name: Set SDK Version Variable
-        run: |
-          if [ -z "${{ inputs.sdk-version }}" ]; then
-              echo "SDK_VERSION=checked-out-sdk/" >> $GITHUB_ENV
-          else
-              echo "SDK_VERSION=${{ inputs.sdk-version }}" >> $GITHUB_ENV
-          fi
-
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
@@ -79,7 +71,7 @@ jobs:
       - name: Build docker image
         run: |
           go run ./cmd build-worker-image --language ${{ inputs.lang }} \
-          --version ${{ env.SDK_VERSION }} \
+          --version ${{ inputs.sdk-version || 'checked-out-sdk/' }} \
           --save-image /tmp/image.tar \
           ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, github.sha) || ''}} \
           ${{ inputs.as-latest && '--tag-as-latest' || ''}}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -41,7 +41,7 @@ jobs:
       REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", triggering sha: ${{ github.sha }}'
 
       - name: Checkout omes repo
         uses: actions/checkout@v4
@@ -81,16 +81,16 @@ jobs:
           go run ./cmd build-worker-image --language ${{ inputs.lang }} \
           --version ${{ env.SDK_VERSION }} \
           --save-image /tmp/image.tar \
-          ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, inputs.sdk-repo-ref) || ''}} \
+          ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, github.sha) || ''}} \
           ${{ inputs.as-latest && '--tag-as-latest' || ''}}
 
       - name: Prepare docker artifact
         run: |
-          # Upload-artifact has no good way to flatten paths, so we need to move the compose file
-          # to avoid some disgustingly long inner path inside the artifact zip.
-          echo -n "${{env.IMAGE_TAG}}" > /tmp/image_tag
+          echo -n "${{env.SAVED_IMAGE_TAG}}" > /tmp/image_tag
 
       - name: Upload docker artifacts
+        # Access download url at ${{ steps.artifact-upload.outputs.artifact-url }}
+        id: artifact-upload
         uses: actions/upload-artifact@v4
         with:
           name: omes-${{ inputs.lang }}-docker-image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -6,15 +6,14 @@ on:
         description: SDK language to build the container for
         required: true
         type: string
-# TODO: Add ability to get SDK by repo ref. This should be shared with implementation in features.
-#      sdk-repo-ref:
-#        description: Git ref of SDK repo to use to build (overrides "sdk-version")
-#        required: false
-#        type: string
-#      sdk-repo-url:
-#        description: URL of SDK repo to use to build (only used if "sdk-repo-ref" is provided)
-#        required: false
-#        type: string
+      sdk-repo-ref:
+        description: Git ref of SDK repo to use to build (overrides "sdk-version")
+        required: false
+        type: string
+      sdk-repo-url:
+        description: URL of SDK repo to use to build (only used if "sdk-repo-ref" is provided)
+        required: false
+        type: string
       sdk-version:
         description: Version of SDK to use (ignored if "sdk-repo-ref" is provided)
         required: false
@@ -27,6 +26,12 @@ on:
         description: If set, tag the images as latest for the lang ('<lang>-latest').
         type: boolean
         default: false
+      omes-repo-path:
+        type: string
+        default: 'temporalio/omes'
+      omes-repo-ref:
+        type: string
+        default: 'main'
 
 jobs:
   build-image:
@@ -38,9 +43,31 @@ jobs:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
 
-      - uses: actions/checkout@v4
+      - name: Checkout omes repo
+        uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.omes-repo-path }}
+          ref: ${{ inputs.omes-repo-ref }}
           submodules: true
+          fetch-depth: 0
+
+      - name: Checkout lang repo
+        if: ${{ inputs.sdk-repo-ref }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.sdk-repo-url }}
+          submodules: recursive
+          path: checked-out-sdk/
+          ref: ${{ inputs.sdk-repo-ref }}
+          fetch-depth: 0
+
+      - name: Set SDK Version Variable
+        run: |
+          if [ -z "${{ inputs.sdk-version }}" ]; then
+              echo "SDK_VERSION=checked-out-sdk/" >> $GITHUB_ENV
+          else
+              echo "SDK_VERSION=${{ inputs.sdk-version }}" >> $GITHUB_ENV
+          fi
 
       - uses: actions/setup-go@v4
         with:
@@ -52,7 +79,8 @@ jobs:
       - name: Build docker image
         run: |
           go run ./cmd build-worker-image --language ${{ inputs.lang }} \
-          --version ${{ inputs.sdk-version }} \
+          --version ${{ env.SDK_VERSION }} \
+          ${{ inputs.sdk-repo-ref && format('--image-tag {0}', inputs.sdk-repo-ref) || ''}} \
           ${{ inputs.as-latest && '--tag-as-latest' || ''}}
 
       - name: Login to DockerHub

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -80,8 +80,23 @@ jobs:
         run: |
           go run ./cmd build-worker-image --language ${{ inputs.lang }} \
           --version ${{ env.SDK_VERSION }} \
+          --save-image /tmp/image.tar \
           ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, inputs.sdk-repo-ref) || ''}} \
           ${{ inputs.as-latest && '--tag-as-latest' || ''}}
+
+      - name: Prepare docker artifact
+        run: |
+          # Upload-artifact has no good way to flatten paths, so we need to move the compose file
+          # to avoid some disgustingly long inner path inside the artifact zip.
+          echo -n "${{env.IMAGE_TAG}}" > /tmp/image_tag
+
+      - name: Upload docker artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: omes-${{ inputs.lang }}-docker-image
+          path: |
+            /tmp/image.tar
+            /tmp/image_tag
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           go run ./cmd build-worker-image --language ${{ inputs.lang }} \
           --version ${{ env.SDK_VERSION }} \
-          ${{ inputs.sdk-repo-ref && format('--image-tag {0}', inputs.sdk-repo-ref) || ''}} \
+          ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, inputs.sdk-repo-ref) || ''}} \
           ${{ inputs.as-latest && '--tag-as-latest' || ''}}
 
       - name: Login to DockerHub

--- a/cmd/build_worker_image.go
+++ b/cmd/build_worker_image.go
@@ -41,6 +41,7 @@ type workerImageBuilder struct {
 	platform       string
 	imageName      string
 	dryRun         bool
+	saveImage      string
 	tags           []string
 	labels         []string
 	loggingOptions cmdoptions.LoggingOptions
@@ -57,6 +58,7 @@ func (b *workerImageBuilder) addCLIFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&b.dryRun, "dry-run", false, "If set, just print the commands that would run but do not run them")
 	fs.StringSliceVar(&b.tags, "image-tag", nil, "Additional tags to add to the image")
 	fs.StringSliceVar(&b.labels, "image-label", nil, "Additional labels to add to the image")
+	fs.StringVar(&b.saveImage, "save-image", "", "If set, will run `docker save` on the produced image, saving it to the provided path")
 	b.loggingOptions.AddCLIFlags(fs)
 }
 
@@ -163,7 +165,22 @@ func (b *workerImageBuilder) build(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed building image: %w", err)
+	}
+
+	if b.saveImage != "" {
+		saveCmd := exec.CommandContext(ctx, "docker", "save", "-o", b.saveImage, imageTagsForPublish[0])
+		saveCmd.Stdout = os.Stdout
+		saveCmd.Stderr = os.Stderr
+		err = saveCmd.Run()
+		if err != nil {
+			return fmt.Errorf("failed saving image: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (b *workerImageBuilder) addLabelIfNotPresent(key, value string) {

--- a/cmd/build_worker_image.go
+++ b/cmd/build_worker_image.go
@@ -171,6 +171,10 @@ func (b *workerImageBuilder) build(ctx context.Context) error {
 	}
 
 	if b.saveImage != "" {
+		err = writeGitHubEnv("SAVED_IMAGE_TAG", imageTagsForPublish[0])
+		if err != nil {
+			return fmt.Errorf("writing image tags to github env failed: %s", err)
+		}
 		saveCmd := exec.CommandContext(ctx, "docker", "save", "-o", b.saveImage, imageTagsForPublish[0])
 		saveCmd.Stdout = os.Stdout
 		saveCmd.Stderr = os.Stderr


### PR DESCRIPTION
Allows the image building workflow to use a reference to an SDK repo to build an image with it as of that commit