### PR TITLE
Warn when registering search attributes fails

### DIFF
--- a/cmd/run_scenario.go
+++ b/cmd/run_scenario.go
@@ -132,6 +132,9 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 		},
 		Namespace: r.clientOptions.Namespace,
 	})
+	if err != nil {
+		r.logger.Warnf("Error ignored when registering search attributes: %v", err)
+	}
 
 	scenarioInfo := loadgen.ScenarioInfo{
 		ScenarioName:   r.scenario,


### PR DESCRIPTION
### How tested
I tested that it compiled and the log message was formatted appropriately when I created a fake error:

```go
	err = errors.New("an error")
```

```
WARN    cmd/run_scenario.go:139 Error ignored when registering search attributes: an error
```