### PR TITLE
Add Nexus to throughput_stress scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for more.
 
 ## Throughput stress and Nexus
 
-The throughput_stress scenario, which is currently on avalilable for Golang) can generate Nexus load if the scenario is
+The throughput_stress scenario (which is currently only available for Golang) can generate Nexus load if the scenario is
 started with `--option nexus-endpoint=my-nexus-endpoint`. This doesn't work with the `--embedded-server` option, and
 requires the following steps:
 
@@ -140,12 +140,12 @@ requires the following steps:
    unless specified otherwise.
 1. Create a nexus endpoint:
 
-  ```
-  temporal operator nexus endpoint create \
-  --name my-nexus-endpoint \
-  --target-namespace default \ # Change if needed
-  --target-task-queue throughput_stress:default-run-id
-  ```
+   ```
+   temporal operator nexus endpoint create \
+   --name my-nexus-endpoint \
+   --target-namespace default \ # Change if needed
+   --target-task-queue throughput_stress:default-run-id
+   ```
 
 1. Start the scenario with the given run-id:
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,32 @@ This will produce an image tagged like `<current git commit hash>-go-v1.24.0`.
 Publishing images is typically done via CI, using the `push-images` command. See the GHA workflows
 for more.
 
+## Throughput stress and Nexus
+
+The throughput_stress scenario, which is currently on avalilable for Golang) can generate Nexus load if the scenario is
+started with `--option nexus-endpoint=my-nexus-endpoint`. This doesn't work with the `--embedded-server` option, and
+requires the following steps:
+
+1. Allocate a scenario run-id. This determines the scenario's task queue. (we'll use `default-run-id` in this tutorial).
+1. Start a server with nexus enabled (e.g. `--http-port 7243 --dynamic-config-value system.enableNexus=true` for the
+   dev server).
+1. Create your namespace ahead of time. Note that the dev server will automatically create the `default` namespace
+   unless specified otherwise.
+1. Create a nexus endpoint:
+
+  ```
+  temporal operator nexus endpoint create \
+  --name my-nexus-endpoint \
+  --target-namespace default \ # Change if needed
+  --target-task-queue throughput_stress:default-run-id
+  ```
+
+1. Start the scenario with the given run-id:
+
+  ```
+  go run ./cmd run-scenario-with-worker --scenario throughput_stress --language go --option nexus-endpoint=my-nexus-endpoint --run-id default-run-id
+  ```
+
 ## The fuzzer
 
 The fuzzer scenario makes use of the kitchen sink workflow (see below) to exercise a wide

--- a/loadgen/throughputstress/throughput_stress.go
+++ b/loadgen/throughputstress/throughput_stress.go
@@ -16,6 +16,10 @@ type WorkflowParams struct {
 	TimesContinued int `json:"timesContinued"`
 	// Set internally and incremented every time the workflow spawns a child.
 	ChildrenSpawned int `json:"childrenSpawned"`
+
+	// If set, the workflow will run nexus tests.
+	// The endpoint should be created ahead of time.
+	NexusEndpoint string `json:"nexusEndpoint"`
 }
 
 type WorkflowOutput struct {

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -19,9 +19,10 @@ import (
 
 // --option arguments
 const (
-	IterFlag      = "internal-iterations"
-	SkipSleepFlag = "skip-sleep"
-	CANEventFlag  = "continue-as-new-after-event-count"
+	IterFlag          = "internal-iterations"
+	SkipSleepFlag     = "skip-sleep"
+	CANEventFlag      = "continue-as-new-after-event-count"
+	NexusEndpointFlag = "nexus-endpoint"
 )
 
 const ThroughputStressScenarioIdSearchAttribute = "ThroughputStressScenarioId"
@@ -76,7 +77,9 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 		},
 		Execute: func(ctx context.Context, run *loadgen.Run) error {
 			internalIterations := run.ScenarioInfo.ScenarioOptionInt(IterFlag, 5)
-			continueAsNewCount := run.ScenarioInfo.ScenarioOptionInt(CANEventFlag, 100)
+			continueAsNewCount := run.ScenarioInfo.ScenarioOptionInt(CANEventFlag, 120)
+			// Disabled by default.
+			nexusEndpoint := run.ScenarioInfo.ScenarioOptions[NexusEndpointFlag]
 			skipSleep := run.ScenarioInfo.ScenarioOptionBool(SkipSleepFlag, false)
 			timeout := time.Duration(1*internalIterations) * time.Minute
 
@@ -98,6 +101,7 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 					SkipSleep:                    skipSleep,
 					Iterations:                   internalIterations,
 					ContinueAsNewAfterEventCount: continueAsNewCount,
+					NexusEndpoint:                nexusEndpoint,
 				})
 			// The 1 is for the final workflow run
 			t.workflowCount.Add(uint64(result.TimesContinued + result.ChildrenSpawned + 1))

--- a/workers/go/throughputstress/operations.go
+++ b/workers/go/throughputstress/operations.go
@@ -1,0 +1,48 @@
+package throughputstress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/workflow"
+)
+
+var ThroughputStressServiceName = "throughput-stress"
+
+var EchoSyncOperation = temporalnexus.NewSyncOperation("echo-sync", func(ctx context.Context, c client.Client, s string, opts nexus.StartOperationOptions) (string, error) {
+	return s, nil
+})
+
+func EchoWorkflow(ctx workflow.Context, s string) (string, error) {
+	return s, nil
+}
+
+func WaitForCancelWorkflow(ctx workflow.Context, input nexus.NoValue) (nexus.NoValue, error) {
+	return nil, workflow.Await(ctx, func() bool {
+		return false
+	})
+}
+
+var EchoAsyncOperation = temporalnexus.NewWorkflowRunOperation("echo-async", EchoWorkflow, func(ctx context.Context, s string, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+	return client.StartWorkflowOptions{
+		ID: opts.RequestID,
+	}, nil
+})
+
+var WaitForCancelOperation = temporalnexus.NewWorkflowRunOperation("wait-for-cancel", WaitForCancelWorkflow, func(ctx context.Context, _ nexus.NoValue, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+	return client.StartWorkflowOptions{
+		ID: opts.RequestID,
+	}, nil
+})
+
+func MustCreateNexusService() *nexus.Service {
+	service := nexus.NewService(ThroughputStressServiceName)
+	err := service.Register(EchoSyncOperation, EchoAsyncOperation, WaitForCancelOperation)
+	if err != nil {
+		panic(fmt.Sprintf("failed to register operations: %v", err))
+	}
+	return service
+}

--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -57,6 +57,8 @@ func runWorkers(client client.Client, taskQueues []string, options cmdoptions.Wo
 	tpsActivities := throughputstress.Activities{
 		Client: client,
 	}
+	service := throughputstress.MustCreateNexusService()
+
 	for _, taskQueue := range taskQueues {
 		taskQueue := taskQueue
 		go func() {
@@ -73,7 +75,10 @@ func runWorkers(client client.Client, taskQueues []string, options cmdoptions.Wo
 			w.RegisterActivityWithOptions(kitchensink.Delay, activity.RegisterOptions{Name: "delay"})
 			w.RegisterWorkflowWithOptions(throughputstress.ThroughputStressWorkflow, workflow.RegisterOptions{Name: "throughputStress"})
 			w.RegisterWorkflow(throughputstress.ThroughputStressChild)
+			w.RegisterWorkflow(throughputstress.EchoWorkflow)
+			w.RegisterWorkflow(throughputstress.WaitForCancelWorkflow)
 			w.RegisterActivity(&tpsActivities)
+			w.RegisterNexusService(service)
 			errCh <- w.Run(worker.InterruptCh())
 		}()
 	}


### PR DESCRIPTION
Added three new steps to the throughput_stress scenario:

1. Sync Nexus operation
2. Async Nexus operation
3. Async Nexus operation with cancelation

See added instructions in the README for running with Nexus.