### PR TITLE
Add iteration timeout to throughput_stress

### DIFF
--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -114,6 +114,18 @@ func (s *ScenarioInfo) ScenarioOptionBool(name string, defaultValue bool) bool {
 	return v == "true"
 }
 
+func (s *ScenarioInfo) ScenarioOptionDuration(name string, defaultValue time.Duration) time.Duration {
+	v := s.ScenarioOptions[name]
+	if v == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
 const DefaultIterations = 10
 const DefaultMaxConcurrent = 10
 

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -20,6 +20,7 @@ import (
 // --option arguments
 const (
 	IterFlag          = "internal-iterations"
+	IterTimeout       = "internal-iterations-timeout"
 	SkipSleepFlag     = "skip-sleep"
 	CANEventFlag      = "continue-as-new-after-event-count"
 	NexusEndpointFlag = "nexus-endpoint"
@@ -77,11 +78,12 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 		},
 		Execute: func(ctx context.Context, run *loadgen.Run) error {
 			internalIterations := run.ScenarioInfo.ScenarioOptionInt(IterFlag, 5)
+			internalIterTimeout := run.ScenarioInfo.ScenarioOptionDuration(IterTimeout, time.Minute)
 			continueAsNewCount := run.ScenarioInfo.ScenarioOptionInt(CANEventFlag, 120)
 			// Disabled by default.
 			nexusEndpoint := run.ScenarioInfo.ScenarioOptions[NexusEndpointFlag]
 			skipSleep := run.ScenarioInfo.ScenarioOptionBool(SkipSleepFlag, false)
-			timeout := time.Duration(1*internalIterations) * time.Minute
+			timeout := time.Duration(internalIterations) * internalIterTimeout
 
 			wfID := fmt.Sprintf("throughputStress-%s-%d", run.RunID, run.Iteration)
 			var result throughputstress.WorkflowOutput


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added timeout for throughput stress run.

## Why?
<!-- Tell your future self why have you made these changes -->

Workflow execution timeout was hard-coded. I need it to either be zero or a higher value for when testing delayed workflow processing.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
