### PR TITLE
Customizable throughputStress Workflow IDs

### DIFF
--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,5 +1,5 @@
 # Build in a full featured container
-FROM golang:1.21 as build
+FROM golang:1.24 as build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/temporalio/omes
 
-go 1.21
-
-toolchain go1.22.5
+go 1.24.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/workers/go/go.mod
+++ b/workers/go/go.mod
@@ -1,8 +1,6 @@
 module github.com/temporalio/omes/workers/go
 
-go 1.21
-
-toolchain go1.22.5
+go 1.24.2
 
 require github.com/temporalio/omes v1.0.0
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allow to customize Workflow ID in throughputStress scenario.

## Why?
<!-- Tell your future self why have you made these changes -->

For our test pipeline, I need to start multiple Omes runs (since I don't want to abort the entire pipeline run if one fails).

But changing the Omes RunID or Scenario is not possible, as that is used to compute the task queue (Workers are deployed separately and rely on the task queue identifier).

Thus, to avoid Workflow ID conflicts, generating unique Workflow IDs is needed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
