### PR TITLE
throughput_stress: Assert expected signal is received at least once, slight refactoring

### DIFF
--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -25,23 +25,19 @@ var activityStub = Activities{}
 // ThroughputStressWorkflow is meant to mimic the throughputstress scenario from bench-go of days
 // past, but in a less-opaque way. We do not ask why it is the way it is, it is not our place to
 // question the inscrutable ways of the old code.
-func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.WorkflowParams) (throughputstress.WorkflowOutput, error) {
-	output := throughputstress.WorkflowOutput{
-		ChildrenSpawned: params.ChildrenSpawned,
-		TimesContinued:  params.TimesContinued,
-	}
+func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.WorkflowParams) (*throughputstress.WorkflowOutput, error) {
 	// Establish handlers
 	err := workflow.SetQueryHandler(ctx, "myquery", func() (string, error) {
 		return "hi", nil
 	})
 	if err != nil {
-		return output, err
+		return nil, err
 	}
 	err = workflow.SetUpdateHandler(ctx, UpdateSleep, func(ctx workflow.Context) error {
 		return workflow.Sleep(ctx, 1*time.Second)
 	})
 	if err != nil {
-		return output, err
+		return nil, err
 	}
 	err = workflow.SetUpdateHandler(ctx, UpdateActivity, func(ctx workflow.Context) error {
 		actCtx := workflow.WithActivityOptions(ctx, defaultActivityOpts())
@@ -49,7 +45,7 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 			actCtx, activityStub.Payload, MakePayloadInput(0, 256)).Get(ctx, nil)
 	})
 	if err != nil {
-		return output, err
+		return nil, err
 	}
 	err = workflow.SetUpdateHandler(ctx, UpdateLocalActivity, func(ctx workflow.Context) error {
 		localActCtx := workflow.WithLocalActivityOptions(ctx, defaultLocalActivityOpts())
@@ -57,44 +53,37 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 			localActCtx, activityStub.Payload, MakePayloadInput(0, 256)).Get(ctx, nil)
 	})
 	if err != nil {
-		return output, err
+		return nil, err
 	}
-	signchan := workflow.GetSignalChannel(ctx, ASignal)
-	workflow.Go(ctx, func(ctx workflow.Context) {
-		for {
-			signchan.Receive(ctx, nil)
-		}
-	})
-
 	for i := params.InitialIteration; i < params.Iterations; i++ {
 		// Repeat the steps as defined by the ancient ritual
 		actCtx := workflow.WithActivityOptions(ctx, defaultActivityOpts())
 		err = workflow.ExecuteActivity(
 			actCtx, activityStub.Payload, MakePayloadInput(256, 256)).Get(ctx, nil)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 
 		err = workflow.ExecuteActivity(actCtx, activityStub.SelfQuery, "myquery").Get(ctx, nil)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 
 		err = workflow.ExecuteActivity(actCtx, activityStub.SelfDescribe).Get(ctx, nil)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 
 		localActCtx := workflow.WithLocalActivityOptions(ctx, defaultLocalActivityOpts())
 		err = workflow.ExecuteLocalActivity(
 			localActCtx, activityStub.Payload, MakePayloadInput(0, 256)).Get(ctx, nil)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 		err = workflow.ExecuteLocalActivity(
 			localActCtx, activityStub.Payload, MakePayloadInput(0, 256)).Get(ctx, nil)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 
 		// Do some stuff in parallel
@@ -104,13 +93,13 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 				// run to the child.
 				attrs := workflow.GetInfo(ctx).SearchAttributes.IndexedFields
 				childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
-					WorkflowID: fmt.Sprintf("%s/child-%d", workflow.GetInfo(ctx).WorkflowExecution.ID, output.ChildrenSpawned),
+					WorkflowID: fmt.Sprintf("%s/child-%d", workflow.GetInfo(ctx).WorkflowExecution.ID, params.ChildrenSpawned),
 					SearchAttributes: map[string]interface{}{
 						scenarios.ThroughputStressScenarioIdSearchAttribute: attrs[scenarios.ThroughputStressScenarioIdSearchAttribute],
 					},
 				})
 				child := workflow.ExecuteChildWorkflow(childCtx, ThroughputStressChild)
-				output.ChildrenSpawned++
+				params.ChildrenSpawned++
 				return child.Get(ctx, nil)
 			},
 			func(ctx workflow.Context) error {
@@ -206,22 +195,27 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 			},
 		)
 		if err != nil {
-			return output, err
+			return nil, err
 		}
 
 		// Possibly continue as new
 		if params.ContinueAsNewAfterEventCount > 0 && workflow.GetInfo(ctx).GetCurrentHistoryLength() >= params.ContinueAsNewAfterEventCount {
 			if i == 0 {
-				return output, fmt.Errorf("trying to continue as new on first iteration, workflow will never end")
+				return nil, fmt.Errorf("trying to continue as new on first iteration, workflow will never end")
 			}
 			params.InitialIteration = i
 			params.TimesContinued++
-			params.ChildrenSpawned = output.ChildrenSpawned
-			return output, workflow.NewContinueAsNewError(ctx, "throughputStress", params)
+			return nil, workflow.NewContinueAsNewError(ctx, "throughputStress", params)
 		}
 	}
+	// Expect the self signal local activity to be run.
+	signchan := workflow.GetSignalChannel(ctx, ASignal)
+	signchan.Receive(ctx, nil)
 
-	return output, nil
+	return &throughputstress.WorkflowOutput{
+		ChildrenSpawned: params.ChildrenSpawned,
+		TimesContinued:  params.TimesContinued,
+	}, nil
 }
 
 func nexusClient(ctx workflow.Context, params *throughputstress.WorkflowParams) workflow.NexusClient {


### PR DESCRIPTION
Mostly this change ensures that we only update the `params` variable and have that serve as the source of truth for the workflow state.

I also changed the workflow to wait for the self signal to be received before completing (which was the original reason I took this on). 