### PR TITLE
Remove throughputstress activity timeouts

### DIFF
--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -267,7 +267,6 @@ func ThroughputStressChild(ctx workflow.Context) error {
 
 func defaultActivityOpts() workflow.ActivityOptions {
 	return workflow.ActivityOptions{
-		StartToCloseTimeout: 10 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 5,
 		},
@@ -276,7 +275,6 @@ func defaultActivityOpts() workflow.ActivityOptions {
 
 func defaultLocalActivityOpts() workflow.LocalActivityOptions {
 	return workflow.LocalActivityOptions{
-		StartToCloseTimeout: 3 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 10 * time.Millisecond,
 			MaximumAttempts: 10,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

WISOTT

Use workflow timeout instead. 

## Why?
<!-- Tell your future self why have you made these changes -->

Activity timeouts were too aggressive and caused pipeline failures when encountering minimal server disruption.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
