### PR TITLE
Replace temporalnexus.NewSyncOperation with nexus.NewSyncOperation

### DIFF
--- a/workers/go/throughputstress/operations.go
+++ b/workers/go/throughputstress/operations.go
@@ -12,7 +12,7 @@ import (
 
 var ThroughputStressServiceName = "throughput-stress"
 
-var EchoSyncOperation = temporalnexus.NewSyncOperation("echo-sync", func(ctx context.Context, c client.Client, s string, opts nexus.StartOperationOptions) (string, error) {
+var EchoSyncOperation = nexus.NewSyncOperation("echo-sync", func(ctx context.Context, s string, opts nexus.StartOperationOptions) (string, error) {
 	return s, nil
 })
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Replace `temporalnexus.NewSyncOperation` with `nexus.NewSyncOperation`

## Why?
<!-- Tell your future self why have you made these changes -->
`temporalnexus.NewSyncOperation` is deprecated and no longer available.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
