### PR TITLE
Remove yaml version dupe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,8 @@ jobs:
           path: generator.diff
           if-no-files-found: ignore
 
+  # env cannot be referenced in jobs.<job_id>.with.<with_id>, so we need a job to run before
+  # to append a "v" to the version string
   prepare-for-docker-push:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
remove some code duplication, removes chance of forgetting to update one of these spots

`env` cannot be referenced in jobs.<job_id>.with.<with_id>, so we need a job to run before to append a "v" to the version string

## Why?
<!-- Tell your future self why have you made these changes -->
YAML is the best

and to remove the chance we forget to update 1 or these 2 places

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
