### PR TITLE
Fix SleepActivityConfig

### DIFF
--- a/loadgen/helpers.go
+++ b/loadgen/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strconv"
 	"time"
 
@@ -17,8 +18,8 @@ type distValueType interface {
 }
 
 type distribution[T distValueType] interface {
-	// Sample returns a random value from the distribution.
-	Sample() (T, bool)
+	// Sample returns a random value from the distribution using the provided seed.
+	Sample(seed int64) (T, bool)
 	// GetType returns the distribution type identifier.
 	GetType() string
 	// Validate checks if the distribution is valid.
@@ -126,7 +127,7 @@ func (d fixedDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d fixedDistribution[T]) Sample() (T, bool) {
+func (d fixedDistribution[T]) Sample(_ int64) (T, bool) {
 	return d.value, true
 }
 
@@ -179,7 +180,7 @@ func (d discreteDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d discreteDistribution[T]) Sample() (T, bool) {
+func (d discreteDistribution[T]) Sample(seed int64) (T, bool) {
 	var zero T
 	if len(d.weights) == 0 {
 		return zero, false
@@ -190,19 +191,38 @@ func (d discreteDistribution[T]) Sample() (T, bool) {
 		}
 	}
 
-	totalWeight := 0
+	rng := rand.New(rand.NewSource(seed))
+
 	keys := make([]T, 0, len(d.weights))
-	weights := make([]int, 0, len(d.weights))
-	for k, w := range d.weights {
+	for k := range d.weights {
 		keys = append(keys, k)
-		weights = append(weights, w)
-		totalWeight += int(w)
+	}
+	switch any(keys[0]).(type) {
+	case int64:
+		sort.Slice(keys, func(i, j int) bool {
+			return any(keys[i]).(int64) < any(keys[j]).(int64)
+		})
+	case float32:
+		sort.Slice(keys, func(i, j int) bool {
+			return any(keys[i]).(float32) < any(keys[j]).(float32)
+		})
+	case time.Duration:
+		sort.Slice(keys, func(i, j int) bool {
+			return any(keys[i]).(time.Duration) < any(keys[j]).(time.Duration)
+		})
 	}
 
-	r := rand.Intn(totalWeight)
+	totalWeight := 0
+	weights := make([]int, len(keys))
+	for i, k := range keys {
+		weights[i] = d.weights[k]
+		totalWeight += weights[i]
+	}
+
+	r := rng.Intn(totalWeight)
 	cumulativeWeight := 0
 	for i, w := range weights {
-		cumulativeWeight += int(w)
+		cumulativeWeight += w
 		if r < cumulativeWeight {
 			return keys[i], true
 		}
@@ -272,28 +292,30 @@ func (d uniformDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d uniformDistribution[T]) Sample() (T, bool) {
+func (d uniformDistribution[T]) Sample(seed int64) (T, bool) {
+	rng := rand.New(rand.NewSource(seed))
+
 	switch any(d.min).(type) {
 	case int64:
 		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
 		if maxVal <= minVal {
 			return d.min, true
 		}
-		result := minVal + rand.Int63n(maxVal-minVal+1)
+		result := minVal + rng.Int63n(maxVal-minVal+1)
 		return T(result), true
 	case float32:
 		minVal, maxVal := any(d.min).(float32), any(d.max).(float32)
 		if maxVal <= minVal {
 			return d.min, true
 		}
-		result := minVal + rand.Float32()*(maxVal-minVal)
+		result := minVal + rng.Float32()*(maxVal-minVal)
 		return any(result).(T), true
 	case time.Duration:
 		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
 		if maxVal <= minVal {
 			return d.min, true
 		}
-		result := time.Duration(int64(minVal) + rand.Int63n(int64(maxVal)-int64(minVal)+1))
+		result := time.Duration(int64(minVal) + rng.Int63n(int64(maxVal)-int64(minVal)+1))
 		return T(result), true
 	default:
 		return d.min, true
@@ -353,8 +375,9 @@ func (d zipfDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d zipfDistribution[T]) Sample() (T, bool) {
-	zipf := rand.NewZipf(rand.New(rand.NewSource(time.Now().UnixNano())), d.s, d.v, d.n)
+func (d zipfDistribution[T]) Sample(seed int64) (T, bool) {
+	rng := rand.New(rand.NewSource(seed))
+	zipf := rand.NewZipf(rng, d.s, d.v, d.n)
 	return T(zipf.Uint64()), true
 }
 
@@ -433,13 +456,15 @@ func (d normalDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d normalDistribution[T]) Sample() (T, bool) {
+func (d normalDistribution[T]) Sample(seed int64) (T, bool) {
+	rng := rand.New(rand.NewSource(seed))
+
 	switch any(d.mean).(type) {
 	case int64:
 		mean, stdDev := any(d.mean).(int64), any(d.stdDev).(int64)
 		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
 
-		result := mean + int64(float64(stdDev)*rand.NormFloat64())
+		result := mean + int64(float64(stdDev)*rng.NormFloat64())
 		if result < minVal {
 			result = minVal
 		}
@@ -451,7 +476,7 @@ func (d normalDistribution[T]) Sample() (T, bool) {
 		mean, stdDev := any(d.mean).(float32), any(d.stdDev).(float32)
 		minVal, maxVal := any(d.min).(float32), any(d.max).(float32)
 
-		result := mean + float32(float64(stdDev)*rand.NormFloat64())
+		result := mean + float32(float64(stdDev)*rng.NormFloat64())
 		if result < minVal {
 			result = minVal
 		}
@@ -463,7 +488,7 @@ func (d normalDistribution[T]) Sample() (T, bool) {
 		mean, stdDev := any(d.mean).(time.Duration), any(d.stdDev).(time.Duration)
 		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
 
-		result := time.Duration(int64(mean) + int64(float64(stdDev)*rand.NormFloat64()))
+		result := time.Duration(int64(mean) + int64(float64(stdDev)*rng.NormFloat64()))
 		if result < minVal {
 			result = minVal
 		}

--- a/loadgen/helpers.go
+++ b/loadgen/helpers.go
@@ -18,8 +18,8 @@ type distValueType interface {
 }
 
 type distribution[T distValueType] interface {
-	// Sample returns a random value from the distribution using the provided seed.
-	Sample(seed int64) (T, bool)
+	// Sample returns a random value from the distribution using the provided random number generator.
+	Sample(rng *rand.Rand) (T, bool)
 	// GetType returns the distribution type identifier.
 	GetType() string
 	// Validate checks if the distribution is valid.
@@ -127,7 +127,7 @@ func (d fixedDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d fixedDistribution[T]) Sample(_ int64) (T, bool) {
+func (d fixedDistribution[T]) Sample(_ *rand.Rand) (T, bool) {
 	return d.value, true
 }
 
@@ -180,7 +180,7 @@ func (d discreteDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d discreteDistribution[T]) Sample(seed int64) (T, bool) {
+func (d discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	var zero T
 	if len(d.weights) == 0 {
 		return zero, false
@@ -190,8 +190,6 @@ func (d discreteDistribution[T]) Sample(seed int64) (T, bool) {
 			return v, true
 		}
 	}
-
-	rng := rand.New(rand.NewSource(seed))
 
 	keys := make([]T, 0, len(d.weights))
 	for k := range d.weights {
@@ -292,9 +290,7 @@ func (d uniformDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d uniformDistribution[T]) Sample(seed int64) (T, bool) {
-	rng := rand.New(rand.NewSource(seed))
-
+func (d uniformDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	switch any(d.min).(type) {
 	case int64:
 		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
@@ -375,8 +371,7 @@ func (d zipfDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d zipfDistribution[T]) Sample(seed int64) (T, bool) {
-	rng := rand.New(rand.NewSource(seed))
+func (d zipfDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	zipf := rand.NewZipf(rng, d.s, d.v, d.n)
 	return T(zipf.Uint64()), true
 }
@@ -456,9 +451,7 @@ func (d normalDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d normalDistribution[T]) Sample(seed int64) (T, bool) {
-	rng := rand.New(rand.NewSource(seed))
-
+func (d normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	switch any(d.mean).(type) {
 	case int64:
 		mean, stdDev := any(d.mean).(int64), any(d.stdDev).(int64)

--- a/loadgen/helpers_test.go
+++ b/loadgen/helpers_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestDistributionField(t *testing.T) {
+	const testSeed = int64(12345) // Fixed seed for deterministic testing
+
 	t.Run("Discrete Distribution", func(t *testing.T) {
 		t.Run("Int64", func(t *testing.T) {
 			jsonData := `{"type":"discrete","weights":{"1":10,"5":20,"10":70}}`
@@ -30,11 +32,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			// Test with fixed seed for exact deterministic results
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.Contains(t, []int64{1, 5, 10}, value)
+			assert.Equal(t, int64(10), value)
 
-			checkJsonRoundtrip(t, err, df)
+			// Test that same seed produces same result
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with different specific seeds for exact results
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, int64(1), value3)
 		})
 
 		t.Run("Float32", func(t *testing.T) {
@@ -56,9 +67,19 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.Contains(t, []float32{1.5, 5.25, 10.75}, value)
+			assert.Equal(t, float32(10.75), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, float32(1.5), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -82,9 +103,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.Contains(t, []time.Duration{1 * time.Second, 5 * time.Second, 10 * time.Second}, value)
+			assert.Equal(t, 10*time.Second, value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -92,7 +118,7 @@ func TestDistributionField(t *testing.T) {
 
 	t.Run("Uniform Distribution", func(t *testing.T) {
 		t.Run("Int64", func(t *testing.T) {
-			jsonData := `{"type":"uniform","min":1,"max":100,"steps":10}`
+			jsonData := `{"type":"uniform","min":1,"max":100}`
 			var df DistributionField[int64]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -107,12 +133,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			// Test exact values with specific seeds
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, int64(1))
-			assert.LessOrEqual(t, value, int64(100))
+			assert.Equal(t, int64(99), value)
 
-			checkJsonRoundtrip(t, err, df)
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, int64(76), value3)
 		})
 
 		t.Run("Float32", func(t *testing.T) {
@@ -131,10 +165,19 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, float32(1.5))
-			assert.LessOrEqual(t, value, float32(99.9))
+			assert.Equal(t, float32(85.01509), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, float32(38.205994), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -155,10 +198,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, 1*time.Second)
-			assert.LessOrEqual(t, value, 1*time.Minute)
+			assert.Equal(t, time.Duration(21344346453), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -166,7 +213,7 @@ func TestDistributionField(t *testing.T) {
 
 	t.Run("Zipf Distribution", func(t *testing.T) {
 		t.Run("Int64", func(t *testing.T) {
-			jsonData := `{"type":"zipf","s":1.5,"v":2.0,"n":100}`
+			jsonData := `{"type":"zipf","s":2.0,"v":1.0,"n":100}`
 			var df DistributionField[int64]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -183,16 +230,25 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, int64(0))
-			assert.LessOrEqual(t, value, int64(100))
+			assert.Equal(t, int64(0), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, int64(1), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
 
 		t.Run("Float32", func(t *testing.T) {
-			jsonData := `{"type":"zipf","s":1.5,"v":2.0,"n":100}`
+			jsonData := `{"type":"zipf","s":2.0,"v":1.0,"n":100}`
 			var df DistributionField[float32]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -209,16 +265,25 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, float32(0))
-			assert.LessOrEqual(t, value, float32(100))
+			assert.Equal(t, float32(0), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, float32(1), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
-			jsonData := `{"type":"zipf","s":1.5,"v":2.0,"n":50}`
+			jsonData := `{"type":"zipf","s":2.0,"v":1.0,"n":100}`
 			var df DistributionField[time.Duration]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -234,9 +299,19 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, time.Duration(0))
+			assert.Equal(t, time.Duration(0), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, time.Duration(1), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -244,7 +319,7 @@ func TestDistributionField(t *testing.T) {
 
 	t.Run("Normal Distribution", func(t *testing.T) {
 		t.Run("Int64", func(t *testing.T) {
-			jsonData := `{"type":"normal","mean":50,"stdDev":1,"min":30,"max":70}`
+			jsonData := `{"type":"normal","mean":50,"stdDev":10,"min":30,"max":70}`
 			var df DistributionField[int64]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -261,12 +336,19 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, int64(30))
-			assert.LessOrEqual(t, value, int64(70))
+			assert.Equal(t, int64(48), value)
 
-			checkJsonRoundtrip(t, err, df)
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, int64(65), value3)
 		})
 
 		t.Run("Float32", func(t *testing.T) {
@@ -287,16 +369,25 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, float32(30.1))
-			assert.LessOrEqual(t, value, float32(70.9))
+			assert.Equal(t, float32(47.62513), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values
+			value3, ok3 := df.Sample(42)
+			assert.True(t, ok3)
+			assert.Equal(t, float32(66.34703), value3)
 
 			checkJsonRoundtrip(t, err, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
-			jsonData := `{"type":"normal","mean":"20s","stdDev":"1s","min":"1s","max":"60s"}`
+			jsonData := `{"type":"normal","mean":"20s","stdDev":"5s","min":"1s","max":"60s"}`
 			var df DistributionField[time.Duration]
 
 			err := json.Unmarshal([]byte(jsonData), &df)
@@ -305,7 +396,7 @@ func TestDistributionField(t *testing.T) {
 			expected := DistributionField[time.Duration]{
 				distribution: normalDistribution[time.Duration]{
 					mean:   20 * time.Second,
-					stdDev: 5000.0,
+					stdDev: 5 * time.Second,
 					min:    1 * time.Second,
 					max:    60 * time.Second,
 				},
@@ -313,10 +404,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample()
+			value, ok := df.Sample(testSeed)
 			assert.True(t, ok)
-			assert.GreaterOrEqual(t, value, 1*time.Second)
-			assert.LessOrEqual(t, value, 60*time.Second)
+			assert.Equal(t, time.Duration(18590749775), value)
+
+			// Verify deterministic behavior
+			value2, ok2 := df.Sample(testSeed)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
 
 			checkJsonRoundtrip(t, err, df)
 		})
@@ -338,9 +433,9 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.Equal(t, expected.distType, df.distType)
 
-			// Test all samples return the same value.
+			// Test all samples return the same value regardless of seed.
 			for i := 0; i < 10; i++ {
-				v, ok := df.Sample()
+				v, ok := df.Sample(testSeed + int64(i))
 				assert.True(t, ok)
 				assert.Equal(t, int64(42), v)
 			}

--- a/loadgen/helpers_test.go
+++ b/loadgen/helpers_test.go
@@ -2,6 +2,7 @@ package loadgen
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -33,17 +34,20 @@ func TestDistributionField(t *testing.T) {
 			assert.EqualExportedValues(t, expected, df)
 
 			// Test with fixed seed for exact deterministic results
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, int64(10), value)
 
 			// Test that same seed produces same result
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with different specific seeds for exact results
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, int64(1), value3)
 		})
@@ -67,17 +71,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, float32(10.75), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, float32(1.5), value3)
 
@@ -103,12 +110,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, 10*time.Second, value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
@@ -134,17 +143,20 @@ func TestDistributionField(t *testing.T) {
 			assert.EqualExportedValues(t, expected, df)
 
 			// Test exact values with specific seeds
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, int64(99), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, int64(76), value3)
 		})
@@ -165,17 +177,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, float32(85.01509), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, float32(38.205994), value3)
 
@@ -198,12 +213,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, time.Duration(21344346453), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
@@ -230,17 +247,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, int64(0), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, int64(1), value3)
 
@@ -265,17 +285,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, float32(0), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, float32(1), value3)
 
@@ -299,17 +322,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, time.Duration(0), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, time.Duration(1), value3)
 
@@ -336,17 +362,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, int64(48), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, int64(65), value3)
 		})
@@ -369,17 +398,20 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, float32(47.62513), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
 			// Test with other specific seeds for different values
-			value3, ok3 := df.Sample(42)
+			rng3 := rand.New(rand.NewSource(42))
+			value3, ok3 := df.Sample(rng3)
 			assert.True(t, ok3)
 			assert.Equal(t, float32(66.34703), value3)
 
@@ -404,12 +436,14 @@ func TestDistributionField(t *testing.T) {
 			}
 			assert.EqualExportedValues(t, expected, df)
 
-			value, ok := df.Sample(testSeed)
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
 			assert.True(t, ok)
 			assert.Equal(t, time.Duration(18590749775), value)
 
 			// Verify deterministic behavior
-			value2, ok2 := df.Sample(testSeed)
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
@@ -435,7 +469,8 @@ func TestDistributionField(t *testing.T) {
 
 			// Test all samples return the same value regardless of seed.
 			for i := 0; i < 10; i++ {
-				v, ok := df.Sample(testSeed + int64(i))
+				rng := rand.New(rand.NewSource(testSeed + int64(i)))
+				v, ok := df.Sample(rng)
 				assert.True(t, ok)
 				assert.Equal(t, int64(42), v)
 			}

--- a/loadgen/throughputstress/throughput_stress.go
+++ b/loadgen/throughputstress/throughput_stress.go
@@ -3,6 +3,7 @@ package throughputstress
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/temporalio/omes/loadgen"
@@ -92,12 +93,12 @@ func ParseAndValidateSleepActivityConfig(jsonStr string) (*SleepActivityConfig, 
 }
 
 // Sample generates a list of SleepActivityInput instances based on the SleepActivityConfig.
-func (config *SleepActivityConfig) Sample() []*kitchensink.ExecuteActivityAction {
+func (config *SleepActivityConfig) Sample(seed int64) []*kitchensink.ExecuteActivityAction {
 	if config == nil {
 		return nil
 	}
 
-	count, ok := config.Count.Sample()
+	count, ok := config.Count.Sample(seed)
 	if !ok || count <= 0 {
 		return nil
 	}
@@ -105,27 +106,30 @@ func (config *SleepActivityConfig) Sample() []*kitchensink.ExecuteActivityAction
 		return nil
 	}
 
-	// Create discrete distribution using indices instead of group IDs.
-	i := int64(0)
-	groupIDs := make([]string, len(config.Groups))
-	indexWeights := make(map[int64]int, len(config.Groups))
+	// Index the groups.
+	groupIDs := make([]string, 0, len(config.Groups))
 	for groupID := range config.Groups {
-		groupIDs[i] = groupID
-		indexWeights[i] = max(1, config.Groups[groupID].Weight)
-		i++
+		groupIDs = append(groupIDs, groupID)
+	}
+	sort.Strings(groupIDs)
+
+	// Create discrete distribution of the groups according to their weights.
+	indexWeights := make(map[int64]int, len(config.Groups))
+	for groupIdx, groupID := range groupIDs {
+		indexWeights[int64(groupIdx)] = max(1, config.Groups[groupID].Weight)
 	}
 	indexDist := loadgen.NewDiscreteDistribution(indexWeights)
 
 	actions := make([]*kitchensink.ExecuteActivityAction, 0, count)
 	for range count {
-		groupIndex, _ := indexDist.Sample()
-		groupConfig := config.Groups[groupIDs[groupIndex]]
+		groupIdx, _ := indexDist.Sample(seed)
+		groupConfig := config.Groups[groupIDs[groupIdx]]
 		action := &kitchensink.ExecuteActivityAction{
 			Priority: &commonpb.Priority{},
 		}
 
 		// Pick SleepDuration.
-		if duration, ok := groupConfig.SleepDuration.Sample(); ok {
+		if duration, ok := groupConfig.SleepDuration.Sample(seed); ok {
 			action.ActivityType = &kitchensink.ExecuteActivityAction_Delay{
 				Delay: durationpb.New(duration),
 			}
@@ -134,14 +138,14 @@ func (config *SleepActivityConfig) Sample() []*kitchensink.ExecuteActivityAction
 
 		// Optional: PriorityKeys
 		if groupConfig.PriorityKeys != nil {
-			if priorityKey, ok := groupConfig.PriorityKeys.Sample(); ok {
+			if priorityKey, ok := groupConfig.PriorityKeys.Sample(seed); ok {
 				action.Priority.PriorityKey = int32(priorityKey)
 			}
 		}
 
 		// Optional: FairnessKeys
 		if groupConfig.FairnessKeys != nil {
-			if fairnessKey, ok := groupConfig.FairnessKeys.Sample(); ok {
+			if fairnessKey, ok := groupConfig.FairnessKeys.Sample(seed); ok {
 				action.FairnessKey = fmt.Sprintf("%d", fairnessKey)
 				action.FairnessWeight = 1.0 // always set default
 			}
@@ -149,7 +153,7 @@ func (config *SleepActivityConfig) Sample() []*kitchensink.ExecuteActivityAction
 
 		// Optional: FairnessWeight
 		if groupConfig.FairnessWeight != nil {
-			if weight, ok := groupConfig.FairnessWeight.Sample(); ok {
+			if weight, ok := groupConfig.FairnessWeight.Sample(seed); ok {
 				action.FairnessWeight = weight
 			}
 		}

--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -3,6 +3,7 @@ package throughputstress
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/google/uuid"
@@ -145,14 +146,10 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 					return nil
 				}
 
-				generateSeed := workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-					return time.Now().UnixNano()
-				})
-				var random int64
-				generateSeed.Get(&random)
+				rng := rand.New(rand.NewSource(workflow.Now(ctx).UnixNano()))
 
 				var sleepFuncs []func(workflow.Context) error
-				for _, actInput := range params.SleepActivities.Sample(random) {
+				for _, actInput := range params.SleepActivities.Sample(rng) {
 					sleepFuncs = append(sleepFuncs, func(ctx workflow.Context) error {
 						opts := defaultActivityOpts(ctx)
 						if actInput.Priority != nil {

--- a/workers/go/throughputstress/workflow.go
+++ b/workers/go/throughputstress/workflow.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/temporalio/omes/loadgen/kitchensink"
 	"github.com/temporalio/omes/loadgen/throughputstress"
 	"github.com/temporalio/omes/scenarios"
 	"github.com/temporalio/omes/workers/go/workflowutils"
@@ -146,14 +145,14 @@ func ThroughputStressWorkflow(ctx workflow.Context, params *throughputstress.Wor
 					return nil
 				}
 
-				var sleepInputs []*kitchensink.ExecuteActivityAction
-				genSleepInputs := workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-					return params.SleepActivities.Sample()
+				generateSeed := workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+					return time.Now().UnixNano()
 				})
-				genSleepInputs.Get(&sleepInputs)
+				var random int64
+				generateSeed.Get(&random)
 
 				var sleepFuncs []func(workflow.Context) error
-				for _, actInput := range sleepInputs {
+				for _, actInput := range params.SleepActivities.Sample(random) {
 					sleepFuncs = append(sleepFuncs, func(ctx workflow.Context) error {
 						opts := defaultActivityOpts(ctx)
 						if actInput.Priority != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Using a random seed instead of wrapping randomly generated output in `workflow.SideEffect`.

## Why?
<!-- Tell your future self why have you made these changes -->

`workflow.SideEffect` doesn't work with arrays of proto messages. The serialization breaks the result in this case, as one of the fields is not JSON exportable.

## Checklist
<!--- add/delete as needed --->

**Reviewer: Looks bigger than it really is. I marked the two actual changes.** 