### PR TITLE
Re-usable Worker build and start

### DIFF
--- a/cmd/cmdoptions/scenario.go
+++ b/cmd/cmdoptions/scenario.go
@@ -1,0 +1,36 @@
+package cmdoptions
+
+import (
+	"encoding/base32"
+	"math/rand"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type ScenarioID struct {
+	scenario string
+	runID    string
+}
+
+func (r *ScenarioID) AddCLIFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&r.scenario, "scenario", "", "Scenario name to run")
+	fs.StringVar(&r.runID, "run-id", shortRand(), "Run ID for this run")
+}
+
+func (r *ScenarioID) Scenario() string {
+	return r.scenario
+}
+
+func (r *ScenarioID) RunID() string {
+	return r.runID
+}
+
+func shortRand() string {
+	b := make([]byte, 5)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return strings.ToLower(base32.StdEncoding.EncodeToString(b))
+}

--- a/cmd/cmdoptions/sdk.go
+++ b/cmd/cmdoptions/sdk.go
@@ -1,0 +1,53 @@
+package cmdoptions
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type Language string
+
+const (
+	LangGo         Language = "go"
+	LangPython     Language = "python"
+	LangJava       Language = "java"
+	LangTypeScript Language = "typescript"
+	LangDotNet     Language = "dotnet"
+)
+
+func (lf *Language) String() string {
+	return string(*lf)
+}
+
+func (lf *Language) Set(value string) error {
+	switch value {
+	case string(LangGo):
+		*lf = LangGo
+	case string(LangPython), "py":
+		*lf = LangPython
+	case string(LangJava):
+		*lf = LangJava
+	case string(LangTypeScript), "ts":
+		*lf = LangTypeScript
+	case string(LangDotNet), "cs":
+		*lf = LangDotNet
+	default:
+		return fmt.Errorf("invalid language %q, must be one of: [go, python, java, typescript, dotnet] or aliases [py, ts, cs]", value)
+	}
+	return nil
+}
+
+func (lf *Language) Type() string {
+	return "language"
+}
+
+type SdkOptions struct {
+	Language Language
+	Version  string
+}
+
+func (s *SdkOptions) AddCLIFlags(fs *pflag.FlagSet) {
+	fs.Var(&s.Language, "language", "Language to use (go, python, ts, cs, java)")
+	fs.StringVar(&s.Version, "version", "", "SDK version to use - treated as path if slash present")
+}

--- a/cmd/prepare_worker.go
+++ b/cmd/prepare_worker.go
@@ -1,30 +1,27 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"html"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/features/sdkbuild"
 	"github.com/temporalio/omes/cmd/cmdoptions"
-	"go.uber.org/zap"
+	"github.com/temporalio/omes/workers"
 )
 
 func prepareWorkerCmd() *cobra.Command {
-	b := workerBuilder{createDir: true}
+	b := workerBuilder{}
 	cmd := &cobra.Command{
 		Use:   "prepare-worker",
 		Short: "Build worker ready to run",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			b.preRun()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if _, err := b.build(cmd.Context()); err != nil {
-				b.logger.Fatal(err)
+			baseDir := filepath.Join(rootDir(), "workers", b.SdkOptions.Language.String())
+			if _, err := b.Build(cmd.Context(), baseDir); err != nil {
+				b.Logger.Fatal(err)
 			}
 		},
 	}
@@ -35,279 +32,21 @@ func prepareWorkerCmd() *cobra.Command {
 }
 
 type workerBuilder struct {
-	logger         *zap.SugaredLogger
-	dirName        string
-	language       string
-	version        string
+	workers.Builder
 	loggingOptions cmdoptions.LoggingOptions
-	createDir      bool
 }
 
 func (b *workerBuilder) addCLIFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&b.dirName, "dir-name", "", "Directory name for prepared worker")
-	fs.StringVar(&b.language, "language", "", "Language to prepare a worker for")
-	fs.StringVar(&b.version, "version", "", "Version to prepare a worker for - treated as path if slash present")
+	fs.StringVar(&b.DirName, "dir-name", "", "Directory name for prepared worker")
+	b.SdkOptions.AddCLIFlags(fs)
 	b.loggingOptions.AddCLIFlags(fs)
 }
 
-func (b *workerBuilder) build(ctx context.Context) (sdkbuild.Program, error) {
-	if b.dirName == "" {
-		return nil, fmt.Errorf("directory name required")
-	} else if strings.ContainsAny(b.dirName, `/\`) {
-		return nil, fmt.Errorf("dir name is not a full path, it is a single name")
-	}
-	if b.logger == nil {
-		b.logger = b.loggingOptions.MustCreateLogger()
-	}
-	lang, err := normalizeLangName(b.language)
-	if err != nil {
-		return nil, err
-	}
-	baseDir := filepath.Join(rootDir(), "workers", lang)
-	b.logger.Infof("Building %v program at %v", lang, filepath.Join(baseDir, b.dirName))
-	// Check or create dir
-	if b.createDir {
-		if err := os.Mkdir(filepath.Join(baseDir, b.dirName), 0755); err != nil {
-			return nil, fmt.Errorf("failed creating directory: %w", err)
-		}
-	} else {
-		if _, err := os.Stat(filepath.Join(baseDir, b.dirName)); err != nil {
-			return nil, fmt.Errorf("failed finding directory: %w", err)
-		}
-	}
-	switch lang {
-	case "go":
-		return b.buildGo(ctx, baseDir)
-	case "python":
-		return b.buildPython(ctx, baseDir)
-	case "java":
-		return b.buildJava(ctx, baseDir)
-	case "typescript":
-		return b.buildTypeScript(ctx, baseDir)
-	case "dotnet":
-		return b.buildDotNet(ctx, baseDir)
-	default:
-		return nil, fmt.Errorf("unrecognized language %v", lang)
-	}
-}
-
-func (b *workerBuilder) buildGo(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
-	prog, err := sdkbuild.BuildGoProgram(ctx, sdkbuild.BuildGoProgramOptions{
-		BaseDir: baseDir,
-		DirName: b.dirName,
-		Version: b.version,
-		GoModContents: `module github.com/temporalio/omes-worker
-
-go 1.20
-
-require github.com/temporalio/omes v1.0.0
-require github.com/temporalio/omes/workers/go v1.0.0
-
-replace github.com/temporalio/omes => ../../../
-replace github.com/temporalio/omes/workers/go => ../`,
-		GoMainContents: `package main
-
-import "github.com/temporalio/omes/workers/go/worker"
-
-func main() {
-	worker.Main()
-}`,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing: %w", err)
-	}
-	return prog, nil
-}
-
-func (b *workerBuilder) buildPython(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
-	// If version not provided, try to read it from pyproject.toml
-	version := b.version
-	if version == "" {
-		cmd := exec.CommandContext(ctx, "uv", "tree", "--quiet", "--depth", "0", "--package", "temporalio")
-		cmd.Dir = baseDir
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("failed running uv tree: %w", err)
-		}
-		outStr := strings.TrimSpace(string(out))
-		if strings.HasPrefix(outStr, "temporalio v") {
-			version = outStr[len("temporalio v"):]
-		}
-		if version == "" {
-			return nil, fmt.Errorf("version not found in uv tree output")
-		}
-	}
-
-	// Build
-	prog, err := sdkbuild.BuildPythonProgram(ctx, sdkbuild.BuildPythonProgramOptions{
-		BaseDir: baseDir,
-		DirName: b.dirName,
-		Version: version,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing: %w", err)
-	}
-	return prog, nil
-}
-
-func (b *workerBuilder) buildJava(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
-	prog, err := sdkbuild.BuildJavaProgram(ctx, sdkbuild.BuildJavaProgramOptions{
-		BaseDir:           baseDir,
-		DirName:           b.dirName,
-		Version:           b.version,
-		MainClass:         "io.temporal.omes.Main",
-		HarnessDependency: "io.temporal:omes:0.1.0",
-		Build:             true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing: %w", err)
-	}
-	return prog, nil
-}
-
-func (b *workerBuilder) buildTypeScript(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
-	// If version not provided, try to read it from package.json
-	version := b.version
-	if version == "" {
-		b, err := os.ReadFile(filepath.Join(baseDir, "package.json"))
-		if err != nil {
-			return nil, fmt.Errorf("failed reading package.json: %w", err)
-		}
-		for _, line := range strings.Split(string(b), "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "\"temporalio:\"") || strings.HasPrefix(line, "\"@temporalio/") {
-				split := strings.Split(line, "\"")
-				version = split[len(split)-2]
-				break
-			}
-		}
-		if version == "" {
-			return nil, fmt.Errorf("version not found in package.json")
-		}
-	}
-
-	// Prep the TypeScript runner to be built
-	cmd := exec.Command("npm", "install")
-	cmd.Dir = baseDir
-	err := cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("npm install in ./workers/typescript failed: %w", err)
-	}
-
-	cmd = exec.Command("npm", "run", "build")
-	cmd.Dir = baseDir
-	err = cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("npm run build in ./workers/typescript failed: %w", err)
-	}
-
-	prog, err := sdkbuild.BuildTypeScriptProgram(ctx, sdkbuild.BuildTypeScriptProgramOptions{
-		BaseDir:        baseDir,
-		Version:        version,
-		TSConfigPaths:  map[string][]string{"@temporalio/omes": {"src/omes.ts"}},
-		DirName:        b.dirName,
-		ApplyToCommand: nil,
-		Includes:       []string{"../src/**/*.ts", "../src/protos/json-module.js", "../src/protos/root.js"},
-		MoreDependencies: map[string]string{
-			"winston": "^3.11.0",
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing: %w", err)
-	}
-	return prog, nil
-}
-
-func (b *workerBuilder) buildDotNet(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
-	// Get version from dotnet.csproj if not present
-	version := b.version
-	csprojBytes, err := os.ReadFile(filepath.Join(baseDir, "Temporalio.Omes.csproj"))
-	if err != nil {
-		return nil, fmt.Errorf("failed reading dotnet.csproj: %w", err)
-	}
-	if version == "" {
-		const prefix = `<PackageReference Include="Temporalio" Version="`
-		csproj := string(csprojBytes)
-		beginIndex := strings.Index(csproj, prefix)
-		if beginIndex == -1 {
-			return nil, fmt.Errorf("cannot find Temporal dependency in csproj")
-		}
-		beginIndex += len(prefix)
-		length := strings.Index(csproj[beginIndex:], `"`)
-		version = csproj[beginIndex : beginIndex+length]
-	}
-	omesProjPath := "../Temporalio.Omes.csproj"
-
-	// Delete any existing temp csproj
-	tempCsProjPath := filepath.Join(baseDir, "Temporalio.Omes.temp.csproj")
-	if err := os.Remove(tempCsProjPath); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed removing temp csproj: %w", err)
-	}
-
-	// Prepare replaced csproj if using path-dependency
-	if strings.ContainsAny(version, `/\`) {
-		// Get absolute path of csproj file
-		absCsproj, err := filepath.Abs(filepath.Join(version, "src/Temporalio/Temporalio.csproj"))
-		if err != nil {
-			return nil, fmt.Errorf("cannot make absolute path from version: %w", err)
-		} else if _, err := os.Stat(absCsproj); err != nil {
-			return nil, fmt.Errorf("cannot find version path of %v: %w", absCsproj, err)
-		}
-		depLine := `<ProjectReference Include="` + html.EscapeString(absCsproj) + `" />`
-
-		// Remove whole original package reference tag
-		csproj := string(csprojBytes)
-		beginIndex := strings.Index(csproj, `<PackageReference Include="Temporalio"`)
-		packageRefStr := "</PackageReference>"
-		endIndex := strings.Index(csproj[beginIndex:], packageRefStr) + beginIndex
-		csproj = csproj[:beginIndex] + depLine + csproj[endIndex+len(packageRefStr):]
-
-		// Write new csproj
-		if err := os.WriteFile(tempCsProjPath, []byte(csproj), 0644); err != nil {
-			if err != nil {
-				return nil, fmt.Errorf("failed writing temp csproj: %w", err)
-			}
-		}
-		omesProjPath = "../Temporalio.Omes.temp.csproj"
-	}
-
-	prog, err := sdkbuild.BuildDotNetProgram(ctx, sdkbuild.BuildDotNetProgramOptions{
-		BaseDir:         baseDir,
-		Version:         version,
-		DirName:         b.dirName,
-		ProgramContents: "await Temporalio.Omes.App.RunAsync(args);",
-		CsprojContents: `<Project Sdk="Microsoft.NET.Sdk">
-			<PropertyGroup>
-				<OutputType>Exe</OutputType>
-				<TargetFramework>net8.0</TargetFramework>
-			</PropertyGroup>
-			<ItemGroup>
-				<ProjectReference Include="` + omesProjPath + `" />
-			</ItemGroup>
-		</Project>`,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing: %w", err)
-	}
-	return prog, nil
+func (b *workerBuilder) preRun() {
+	b.Logger = b.loggingOptions.MustCreateLogger()
 }
 
 func rootDir() string {
 	_, currFile, _, _ := runtime.Caller(0)
 	return filepath.Dir(filepath.Dir(currFile))
-}
-
-func normalizeLangName(lang string) (string, error) {
-	switch lang {
-	case "go", "python", "java", "typescript", "dotnet":
-	case "py":
-		lang = "python"
-	case "ts":
-		lang = "typescript"
-	case "cs":
-		lang = "dotnet"
-	default:
-		return "", fmt.Errorf("invalid language %q, must be one of: [go, python, java, typescript, dotnet]", lang)
-	}
-	return lang, nil
 }

--- a/cmd/run_scenario_with_worker.go
+++ b/cmd/run_scenario_with_worker.go
@@ -14,11 +14,14 @@ func runScenarioWithWorkerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run-scenario-with-worker",
 		Short: "Run a worker and a scenario",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			r.preRun()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
 			if err := r.run(ctx); err != nil {
-				r.logger.Fatal(err)
+				r.Logger.Fatal(err)
 			}
 		},
 	}
@@ -40,14 +43,18 @@ func (r *workerWithScenarioRunner) addCLIFlags(fs *pflag.FlagSet) {
 	r.metricsOptions.AddCLIFlags(fs, "")
 }
 
+func (r *workerWithScenarioRunner) preRun() {
+	r.workerRunner.preRun()
+}
+
 func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Start worker and wait on error or started
 	workerErrCh := make(chan error, 1)
 	workerStartCh := make(chan struct{})
-	r.onWorkerStarted = func() { close(workerStartCh) }
-	go func() { workerErrCh <- r.workerRunner.run(ctx) }()
+	r.OnWorkerStarted = func() { close(workerStartCh) }
+	go func() { workerErrCh <- r.Run(ctx, rootDir()) }()
 	select {
 	case err := <-workerErrCh:
 		return fmt.Errorf("worker did not start: %w", err)
@@ -56,11 +63,8 @@ func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 
 	// Run scenario
 	scenarioRunner := scenarioRunner{
-		logger: r.logger,
-		scenarioID: scenarioID{
-			scenario: r.scenario,
-			runID:    r.runID,
-		},
+		logger:   r.Logger,
+		scenario: r.ScenarioID,
 		scenarioRunConfig: scenarioRunConfig{
 			iterations:                    r.iterations,
 			duration:                      r.duration,
@@ -70,9 +74,8 @@ func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 			timeout:                       r.timeout,
 			doNotRegisterSearchAttributes: r.doNotRegisterSearchAttributes,
 		},
-		clientOptions:  r.clientOptions,
+		clientOptions:  r.ClientOptions,
 		metricsOptions: r.metricsOptions,
-		loggingOptions: r.loggingOptions,
 	}
 	scenarioErr := scenarioRunner.run(ctx)
 	cancel()

--- a/cmd/run_worker.go
+++ b/cmd/run_worker.go
@@ -2,23 +2,13 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base32"
-	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/features/sdkbuild"
-	"github.com/temporalio/omes/cmd/cmdoptions"
-	"github.com/temporalio/omes/loadgen"
-	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/testsuite"
+	"github.com/temporalio/omes/workers"
 )
 
 func runWorkerCmd() *cobra.Command {
@@ -26,11 +16,14 @@ func runWorkerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run-worker",
 		Short: "Run a worker",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			r.preRun()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
 			if err := r.run(ctx); err != nil {
-				r.logger.Fatal(err)
+				r.Logger.Fatal(err)
 			}
 		},
 	}
@@ -42,191 +35,33 @@ func runWorkerCmd() *cobra.Command {
 }
 
 type workerRunner struct {
-	workerBuilder
-	scenarioID
-	retainTempDir             bool
-	gracefulShutdownDuration  time.Duration
-	embeddedServer            bool
-	embeddedServerAddress     string
-	taskQueueIndexSuffixStart int
-	taskQueueIndexSuffixEnd   int
-	clientOptions             cmdoptions.ClientOptions
-	metricsOptions            cmdoptions.MetricsOptions
-	workerOptions             cmdoptions.WorkerOptions
-	onWorkerStarted           func()
+	workers.Runner
+	builder workerBuilder
 }
 
 func (r *workerRunner) addCLIFlags(fs *pflag.FlagSet) {
-	r.workerBuilder.addCLIFlags(fs)
-	r.scenarioID.addCLIFlags(fs)
-	fs.BoolVar(&r.retainTempDir, "retain-temp-dir", false,
+	r.builder.addCLIFlags(fs)
+	r.ScenarioID.AddCLIFlags(fs)
+	fs.BoolVar(&r.RetainTempDir, "retain-temp-dir", false,
 		"If set, retain the temp directory created if one wasn't given")
-	fs.DurationVar(&r.gracefulShutdownDuration, "graceful-shutdown-duration", 30*time.Second,
+	fs.DurationVar(&r.GracefulShutdownDuration, "graceful-shutdown-duration", 30*time.Second,
 		"Time to wait for worker to respond to interrupt before killing it")
-	fs.BoolVar(&r.embeddedServer, "embedded-server", false, "Set to run in a local embedded server")
-	fs.StringVar(&r.embeddedServerAddress, "embedded-server-address", "", "Address to bind local embedded server to")
-	fs.IntVar(&r.taskQueueIndexSuffixStart, "task-queue-suffix-index-start", 0, "Inclusive start for task queue suffix range")
-	fs.IntVar(&r.taskQueueIndexSuffixEnd, "task-queue-suffix-index-end", 0, "Inclusive end for task queue suffix range")
-	r.clientOptions.AddCLIFlags(fs)
-	r.metricsOptions.AddCLIFlags(fs, "worker-")
-	r.workerOptions.AddCLIFlags(fs, "worker-")
+	fs.BoolVar(&r.EmbeddedServer, "embedded-server", false, "Set to run in a local embedded server")
+	fs.StringVar(&r.EmbeddedServerAddress, "embedded-server-address", "", "Address to bind local embedded server to")
+	fs.IntVar(&r.TaskQueueIndexSuffixStart, "task-queue-suffix-index-start", 0, "Inclusive start for task queue suffix range")
+	fs.IntVar(&r.TaskQueueIndexSuffixEnd, "task-queue-suffix-index-end", 0, "Inclusive end for task queue suffix range")
+	r.ClientOptions.AddCLIFlags(fs)
+	r.MetricsOptions.AddCLIFlags(fs, "worker-")
+	r.WorkerOptions.AddCLIFlags(fs, "worker-")
+}
+
+func (r *workerRunner) preRun() {
+	r.builder.preRun()
+	r.Runner.Builder = r.builder.Builder
 }
 
 func (r *workerRunner) run(ctx context.Context) error {
-	r.logger = r.loggingOptions.MustCreateLogger()
-	lang, err := normalizeLangName(r.language)
-	if err != nil {
-		return err
-	}
-	scenario := loadgen.GetScenario(r.scenario)
-	if scenario == nil {
-		return fmt.Errorf("scenario %v not found", r.scenario)
-	}
-	if r.taskQueueIndexSuffixStart > r.taskQueueIndexSuffixEnd {
-		return fmt.Errorf("cannot have task queue suffix start past end")
-	}
-	if r.runID == "" {
-		r.runID = shortRand()
-	}
-	baseDir := filepath.Join(rootDir(), "workers", lang)
-
-	// Run an embedded server if requested
-	if r.embeddedServer || r.embeddedServerAddress != "" {
-		// Intentionally don't use context, will stop on defer
-		if r.clientOptions.EnableTLS || r.clientOptions.ClientCertPath != "" || r.clientOptions.ClientKeyPath != "" {
-			return fmt.Errorf("cannot use TLS with embedded server")
-		} else if r.clientOptions.Address != client.DefaultHostPort {
-			return fmt.Errorf("cannot supply non-default client address when using embedded server")
-		}
-		server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
-			ClientOptions: &client.Options{
-				HostPort:  r.embeddedServerAddress,
-				Namespace: r.clientOptions.Namespace,
-			},
-			LogLevel: "error",
-		})
-		if err != nil {
-			return fmt.Errorf("failed starting embedded server: %w", err)
-		}
-		r.clientOptions.Address = server.FrontendHostPort()
-		r.logger.Infof("Started embedded local server at: %v", r.clientOptions.Address)
-		defer func() {
-			r.logger.Info("Stopping embedded local server")
-			if err := server.Stop(); err != nil {
-				r.logger.Warnf("Failed stopping embedded local server: %v", err)
-			}
-		}()
-	}
-
-	// If there is not a prepared dir, we must build a temporary one and perform
-	// the prep. Otherwise we reload the command from the directory.
-	var prog sdkbuild.Program
-	if r.dirName == "" {
-		// Create temp dir
-		tempDir, err := os.MkdirTemp(baseDir, "omes-temp-")
-		if err != nil {
-			return fmt.Errorf("failed creating temp dir: %w", err)
-		}
-		if !r.retainTempDir {
-			defer os.RemoveAll(tempDir)
-		}
-		r.dirName = filepath.Base(tempDir)
-
-		// Build
-		if prog, err = r.build(ctx); err != nil {
-			return err
-		}
-	} else {
-		loadDir := filepath.Join(baseDir, r.dirName)
-		switch lang {
-		case "go":
-			prog, err = sdkbuild.GoProgramFromDir(loadDir)
-		case "python":
-			prog, err = sdkbuild.PythonProgramFromDir(loadDir)
-		case "java":
-			prog, err = sdkbuild.JavaProgramFromDir(loadDir)
-		case "typescript":
-			prog, err = sdkbuild.TypeScriptProgramFromDir(loadDir)
-		case "dotnet":
-			prog, err = sdkbuild.DotNetProgramFromDir(loadDir)
-		default:
-			return fmt.Errorf("unrecognized language %v", lang)
-		}
-		if err != nil {
-			return fmt.Errorf("failed preparing: %w", err)
-		}
-	}
-
-	// Build command args
-	var args []string
-	if lang == "python" {
-		// Python needs module name first
-		args = append(args, "main")
-	} else if lang == "typescript" {
-		// Node also needs module
-		args = append(args, "./tslib/omes.js")
-	}
-	args = append(args, "--task-queue", loadgen.TaskQueueForRun(r.scenario, r.runID))
-	if r.taskQueueIndexSuffixEnd > 0 {
-		args = append(args, "--task-queue-suffix-index-start", strconv.Itoa(r.taskQueueIndexSuffixStart))
-		args = append(args, "--task-queue-suffix-index-end", strconv.Itoa(r.taskQueueIndexSuffixEnd))
-	}
-	args = append(args, r.clientOptions.ToFlags()...)
-	args = append(args, r.metricsOptions.ToFlags()...)
-	args = append(args, r.loggingOptions.ToFlags()...)
-	args = append(args, r.workerOptions.ToFlags()...)
-
-	// Start the command. Do not use the context so we can send interrupt.
-	cmd, err := prog.NewCommand(context.Background(), args...)
-	if err != nil {
-		return fmt.Errorf("failed creating command: %w", err)
-	}
-	r.logger.Infof("Starting worker with command: %v", cmd.Args)
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start: %w", err)
-	}
-	if r.onWorkerStarted != nil {
-		r.onWorkerStarted()
-	}
-
-	// Wait until context done or worker done
-	errCh := make(chan error, 1)
-	go func() { errCh <- cmd.Wait() }()
-	select {
-	case err := <-errCh:
-		if err == nil {
-			err = fmt.Errorf("worker completed unexpectedly without error")
-		}
-		return fmt.Errorf("worker failed: %w", err)
-	case <-ctx.Done():
-		// Context cancelled, interrupt worker
-		r.logger.Infof("Sending interrupt to worker, PID: %v", cmd.Process.Pid)
-		if err := sendInterrupt(cmd.Process); err != nil {
-			return fmt.Errorf("failed to send interrupt to worker: %w", err)
-		}
-		select {
-		case err = <-errCh:
-		case <-time.After(r.gracefulShutdownDuration):
-			if err = cmd.Process.Kill(); err == nil {
-				if err = <-errCh; err == nil {
-					err = fmt.Errorf("worker did not shutdown within graceful timeout")
-				}
-			}
-		}
-		if err != nil {
-			r.logger.Warnf("Worker failed after interrupt: %v", err)
-		}
-		return nil
-	}
-}
-
-func shortRand() string {
-	b := make([]byte, 5)
-	_, err := rand.Read(b)
-	if err != nil {
-		panic(err)
-	}
-	return strings.ToLower(base32.StdEncoding.EncodeToString(b))
+	return r.Run(ctx, rootDir())
 }
 
 func withCancelOnInterrupt(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/workers/build.go
+++ b/workers/build.go
@@ -1,0 +1,248 @@
+package workers
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/temporalio/features/sdkbuild"
+	"github.com/temporalio/omes/cmd/cmdoptions"
+	"go.uber.org/zap"
+)
+
+type Builder struct {
+	DirName    string
+	SdkOptions cmdoptions.SdkOptions
+	Logger     *zap.SugaredLogger
+}
+
+func (b *Builder) Build(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	if b.DirName == "" {
+		return nil, fmt.Errorf("directory name required")
+	} else if strings.ContainsAny(b.DirName, `/\`) {
+		return nil, fmt.Errorf("dir name is not a full path, it is a single name")
+	}
+	b.Logger.Infof("Building %v program at %v", b.SdkOptions.Language.String(), filepath.Join(baseDir, b.DirName))
+
+	dirPath := filepath.Join(baseDir, b.DirName)
+	if err := os.Mkdir(dirPath, 0755); err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("failed creating directory: %w", err)
+	}
+
+	switch b.SdkOptions.Language {
+	case cmdoptions.LangGo:
+		return b.buildGo(ctx, baseDir)
+	case cmdoptions.LangPython:
+		return b.buildPython(ctx, baseDir)
+	case cmdoptions.LangJava:
+		return b.buildJava(ctx, baseDir)
+	case cmdoptions.LangTypeScript:
+		return b.buildTypeScript(ctx, baseDir)
+	case cmdoptions.LangDotNet:
+		return b.buildDotNet(ctx, baseDir)
+	default:
+		return nil, fmt.Errorf("unrecognized language %v", b.SdkOptions.Language)
+	}
+}
+
+func (b *Builder) buildGo(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	prog, err := sdkbuild.BuildGoProgram(ctx, sdkbuild.BuildGoProgramOptions{
+		BaseDir: baseDir,
+		DirName: b.DirName,
+		Version: b.SdkOptions.Version,
+		GoModContents: `module github.com/temporalio/omes-worker
+
+go 1.20
+
+require github.com/temporalio/omes v1.0.0
+require github.com/temporalio/omes/workers/go v1.0.0
+
+replace github.com/temporalio/omes => ../../../
+replace github.com/temporalio/omes/workers/go => ../`,
+		GoMainContents: `package main
+
+import "github.com/temporalio/omes/workers/go/worker"
+
+func main() {
+	worker.Main()
+}`,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed preparing: %w", err)
+	}
+	return prog, nil
+}
+
+func (b *Builder) buildPython(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	// If version not provided, try to read it from pyproject.toml
+	version := b.SdkOptions.Version
+	if version == "" {
+		cmd := exec.CommandContext(ctx, "uv", "tree", "--quiet", "--depth", "0", "--package", "temporalio")
+		cmd.Dir = baseDir
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("failed running uv tree: %w", err)
+		}
+		outStr := strings.TrimSpace(string(out))
+		if strings.HasPrefix(outStr, "temporalio v") {
+			version = outStr[len("temporalio v"):]
+		}
+		if version == "" {
+			return nil, fmt.Errorf("version not found in uv tree output")
+		}
+	}
+
+	prog, err := sdkbuild.BuildPythonProgram(ctx, sdkbuild.BuildPythonProgramOptions{
+		BaseDir: baseDir,
+		DirName: b.DirName,
+		Version: version,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed preparing: %w", err)
+	}
+	return prog, nil
+}
+
+func (b *Builder) buildJava(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	prog, err := sdkbuild.BuildJavaProgram(ctx, sdkbuild.BuildJavaProgramOptions{
+		BaseDir:           baseDir,
+		DirName:           b.DirName,
+		Version:           b.SdkOptions.Version,
+		MainClass:         "io.temporal.omes.Main",
+		HarnessDependency: "io.temporal:omes:0.1.0",
+		Build:             true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed preparing: %w", err)
+	}
+	return prog, nil
+}
+
+func (b *Builder) buildTypeScript(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	// If version not provided, try to read it from package.json
+	version := b.SdkOptions.Version
+	if version == "" {
+		b, err := os.ReadFile(filepath.Join(baseDir, "package.json"))
+		if err != nil {
+			return nil, fmt.Errorf("failed reading package.json: %w", err)
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "\"temporalio:\"") || strings.HasPrefix(line, "\"@temporalio/") {
+				split := strings.Split(line, "\"")
+				version = split[len(split)-2]
+				break
+			}
+		}
+		if version == "" {
+			return nil, fmt.Errorf("version not found in package.json")
+		}
+	}
+
+	// Prep the TypeScript runner to be built
+	cmd := exec.Command("npm", "install")
+	cmd.Dir = baseDir
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("npm install in ./workers/typescript failed: %w", err)
+	}
+
+	cmd = exec.Command("npm", "run", "build")
+	cmd.Dir = baseDir
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("npm run build in ./workers/typescript failed: %w", err)
+	}
+
+	prog, err := sdkbuild.BuildTypeScriptProgram(ctx, sdkbuild.BuildTypeScriptProgramOptions{
+		BaseDir:        baseDir,
+		Version:        version,
+		TSConfigPaths:  map[string][]string{"@temporalio/omes": {"src/omes.ts"}},
+		DirName:        b.DirName,
+		ApplyToCommand: nil,
+		Includes:       []string{"../src/**/*.ts", "../src/protos/json-module.js", "../src/protos/root.js"},
+		MoreDependencies: map[string]string{
+			"winston": "^3.11.0",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed preparing: %w", err)
+	}
+	return prog, nil
+}
+
+func (b *Builder) buildDotNet(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	// Get version from dotnet.csproj if not present
+	version := b.SdkOptions.Version
+	csprojBytes, err := os.ReadFile(filepath.Join(baseDir, "Temporalio.Omes.csproj"))
+	if err != nil {
+		return nil, fmt.Errorf("failed reading dotnet.csproj: %w", err)
+	}
+	if version == "" {
+		const prefix = `<PackageReference Include="Temporalio" Version="`
+		csproj := string(csprojBytes)
+		beginIndex := strings.Index(csproj, prefix)
+		if beginIndex == -1 {
+			return nil, fmt.Errorf("cannot find Temporal dependency in csproj")
+		}
+		beginIndex += len(prefix)
+		length := strings.Index(csproj[beginIndex:], `"`)
+		version = csproj[beginIndex : beginIndex+length]
+	}
+	omesProjPath := "../Temporalio.Omes.csproj"
+
+	// Delete any existing temp csproj
+	tempCsProjPath := filepath.Join(baseDir, "Temporalio.Omes.temp.csproj")
+	if err := os.Remove(tempCsProjPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed removing temp csproj: %w", err)
+	}
+
+	// Prepare replaced csproj if using path-dependency
+	if strings.ContainsAny(version, `/\`) {
+		// Get absolute path of csproj file
+		absCsproj, err := filepath.Abs(filepath.Join(version, "src/Temporalio/Temporalio.csproj"))
+		if err != nil {
+			return nil, fmt.Errorf("cannot make absolute path from version: %w", err)
+		} else if _, err := os.Stat(absCsproj); err != nil {
+			return nil, fmt.Errorf("cannot find version path of %v: %w", absCsproj, err)
+		}
+		depLine := `<ProjectReference Include="` + html.EscapeString(absCsproj) + `" />`
+
+		// Remove whole original package reference tag
+		csproj := string(csprojBytes)
+		beginIndex := strings.Index(csproj, `<PackageReference Include="Temporalio"`)
+		packageRefStr := "</PackageReference>"
+		endIndex := strings.Index(csproj[beginIndex:], packageRefStr) + beginIndex
+		csproj = csproj[:beginIndex] + depLine + csproj[endIndex+len(packageRefStr):]
+
+		// Write new csproj
+		if err := os.WriteFile(tempCsProjPath, []byte(csproj), 0644); err != nil {
+			return nil, fmt.Errorf("failed writing temp csproj: %w", err)
+		}
+		omesProjPath = "../Temporalio.Omes.temp.csproj"
+	}
+
+	prog, err := sdkbuild.BuildDotNetProgram(ctx, sdkbuild.BuildDotNetProgramOptions{
+		BaseDir:         baseDir,
+		Version:         version,
+		DirName:         b.DirName,
+		ProgramContents: "await Temporalio.Omes.App.RunAsync(args);",
+		CsprojContents: `<Project Sdk="Microsoft.NET.Sdk">
+			<PropertyGroup>
+				<OutputType>Exe</OutputType>
+				<TargetFramework>net8.0</TargetFramework>
+			</PropertyGroup>
+			<ItemGroup>
+				<ProjectReference Include="` + omesProjPath + `" />
+			</ItemGroup>
+		</Project>`,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed preparing: %w", err)
+	}
+	return prog, nil
+}

--- a/workers/run.go
+++ b/workers/run.go
@@ -1,0 +1,183 @@
+package workers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/temporalio/features/sdkbuild"
+	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/loadgen"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func sendInterrupt(process *os.Process) error {
+	if runtime.GOOS == "windows" {
+		return process.Kill()
+	}
+	return process.Signal(syscall.SIGINT)
+}
+
+type Runner struct {
+	Builder
+	RetainTempDir             bool
+	GracefulShutdownDuration  time.Duration
+	EmbeddedServer            bool
+	EmbeddedServerAddress     string
+	TaskQueueIndexSuffixStart int
+	TaskQueueIndexSuffixEnd   int
+	ScenarioID                cmdoptions.ScenarioID
+	ClientOptions             cmdoptions.ClientOptions
+	MetricsOptions            cmdoptions.MetricsOptions
+	WorkerOptions             cmdoptions.WorkerOptions
+	LoggingOptions            cmdoptions.LoggingOptions
+	OnWorkerStarted           func()
+}
+
+func (r *Runner) Run(ctx context.Context, rootDir string) error {
+	scenarioName := r.ScenarioID.Scenario()
+	scenario := loadgen.GetScenario(scenarioName)
+	if scenario == nil {
+		return fmt.Errorf("scenario %v not found", scenarioName)
+	}
+	if r.TaskQueueIndexSuffixStart > r.TaskQueueIndexSuffixEnd {
+		return fmt.Errorf("cannot have task queue suffix start past end")
+	}
+	baseDir := filepath.Join(rootDir, "workers", r.SdkOptions.Language.String())
+
+	// Run an embedded server if requested
+	if r.EmbeddedServer || r.EmbeddedServerAddress != "" {
+		// Intentionally don't use context, will stop on defer
+		if r.ClientOptions.EnableTLS || r.ClientOptions.ClientCertPath != "" || r.ClientOptions.ClientKeyPath != "" {
+			return fmt.Errorf("cannot use TLS with embedded server")
+		} else if r.ClientOptions.Address != client.DefaultHostPort {
+			return fmt.Errorf("cannot supply non-default client address when using embedded server")
+		}
+		server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
+			ClientOptions: &client.Options{
+				HostPort:  r.EmbeddedServerAddress,
+				Namespace: r.ClientOptions.Namespace,
+			},
+			LogLevel: "error",
+		})
+		if err != nil {
+			return fmt.Errorf("failed starting embedded server: %w", err)
+		}
+		r.ClientOptions.Address = server.FrontendHostPort()
+		r.Logger.Infof("Started embedded local server at: %v", r.ClientOptions.Address)
+		defer func() {
+			r.Logger.Info("Stopping embedded local server")
+			if err := server.Stop(); err != nil {
+				r.Logger.Warnf("Failed stopping embedded local server: %v", err)
+			}
+		}()
+	}
+
+	// If there is not a prepared dir, we must build a temporary one and perform
+	// the prep. Otherwise we reload the command from the directory.
+	var prog sdkbuild.Program
+	if r.DirName == "" {
+		// Create temp dir
+		tempDir, err := os.MkdirTemp(baseDir, "omes-temp-")
+		if err != nil {
+			return fmt.Errorf("failed creating temp dir: %w", err)
+		}
+		if !r.RetainTempDir {
+			defer os.RemoveAll(tempDir)
+		}
+		r.DirName = filepath.Base(tempDir)
+
+		// Build
+		if prog, err = r.Build(ctx, baseDir); err != nil {
+			return err
+		}
+	} else {
+		var err error
+		loadDir := filepath.Join(baseDir, r.DirName)
+		switch r.SdkOptions.Language {
+		case cmdoptions.LangGo:
+			prog, err = sdkbuild.GoProgramFromDir(loadDir)
+		case cmdoptions.LangPython:
+			prog, err = sdkbuild.PythonProgramFromDir(loadDir)
+		case cmdoptions.LangJava:
+			prog, err = sdkbuild.JavaProgramFromDir(loadDir)
+		case cmdoptions.LangTypeScript:
+			prog, err = sdkbuild.TypeScriptProgramFromDir(loadDir)
+		case cmdoptions.LangDotNet:
+			prog, err = sdkbuild.DotNetProgramFromDir(loadDir)
+		default:
+			return fmt.Errorf("unrecognized language %v", r.SdkOptions.Language)
+		}
+		if err != nil {
+			return fmt.Errorf("failed preparing: %w", err)
+		}
+	}
+
+	// Build command args
+	var args []string
+	if r.SdkOptions.Language == cmdoptions.LangPython {
+		// Python needs module name first
+		args = append(args, "main")
+	} else if r.SdkOptions.Language == cmdoptions.LangTypeScript {
+		// Node also needs module
+		args = append(args, "./tslib/omes.js")
+	}
+	args = append(args, "--task-queue", loadgen.TaskQueueForRun(r.ScenarioID.Scenario(), r.ScenarioID.RunID()))
+	if r.TaskQueueIndexSuffixEnd > 0 {
+		args = append(args, "--task-queue-suffix-index-start", strconv.Itoa(r.TaskQueueIndexSuffixStart))
+		args = append(args, "--task-queue-suffix-index-end", strconv.Itoa(r.TaskQueueIndexSuffixEnd))
+	}
+	args = append(args, r.ClientOptions.ToFlags()...)
+	args = append(args, r.MetricsOptions.ToFlags()...)
+	args = append(args, r.LoggingOptions.ToFlags()...)
+	args = append(args, r.WorkerOptions.ToFlags()...)
+
+	// Start the command. Do not use the context so we can send interrupt.
+	cmd, err := prog.NewCommand(context.Background(), args...)
+	if err != nil {
+		return fmt.Errorf("failed creating command: %w", err)
+	}
+	r.Logger.Infof("Starting worker with command: %v", cmd.Args)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start: %w", err)
+	}
+	if r.OnWorkerStarted != nil {
+		r.OnWorkerStarted()
+	}
+
+	// Wait until context done or worker done
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Wait() }()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			err = fmt.Errorf("worker completed unexpectedly without error")
+		}
+		return fmt.Errorf("worker failed: %w", err)
+	case <-ctx.Done():
+		// Context cancelled, interrupt worker
+		r.Logger.Infof("Sending interrupt to worker, PID: %v", cmd.Process.Pid)
+		if err := sendInterrupt(cmd.Process); err != nil {
+			return fmt.Errorf("failed to send interrupt to worker: %w", err)
+		}
+		select {
+		case err = <-errCh:
+		case <-time.After(r.GracefulShutdownDuration):
+			if err = cmd.Process.Kill(); err == nil {
+				if err = <-errCh; err == nil {
+					err = fmt.Errorf("worker did not shutdown within graceful timeout")
+				}
+			}
+		}
+		if err != nil {
+			r.Logger.Warnf("Worker failed after interrupt: %v", err)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Move code to build and start worker from `main` into `workers` package.

No behavior change expected.

## Why?
<!-- Tell your future self why have you made these changes -->

Reusability. The [kitchensink parity test](https://github.com/temporalio/omes/pull/180) needs to start workers for testing.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
