### PR TITLE
Kitchensink client activity [Python, TS, .NET]

### DIFF
--- a/loadgen/kitchen_sink_executor_test.go
+++ b/loadgen/kitchen_sink_executor_test.go
@@ -183,10 +183,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled`),
 		},
@@ -219,10 +216,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled`),
 		},
@@ -249,10 +243,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled {"signalName":"test_signal"}`),
 		},
@@ -281,10 +272,7 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -315,10 +303,7 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -350,10 +335,7 @@ func TestKitchenSink(t *testing.T) {
 				...
 				WorkflowExecutionUpdateAccepted {"acceptedRequest":{"input":{"name":"do_actions_update"}}}`),
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -384,10 +366,7 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -419,10 +398,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionUpdateCompleted`),
 		},
@@ -446,9 +422,9 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
+				cmdoptions.LangTypeScript: "concurrent client actions are not supported",
+				cmdoptions.LangDotNet:     "concurrent client actions are not supported",
+				cmdoptions.LangPython:     "concurrent client actions are not supported",
 				cmdoptions.LangJava:       "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`
@@ -504,10 +480,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 			},
 			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava:       "client actions activity is not supported",
-				cmdoptions.LangPython:     "client actions activity is not supported",
-				cmdoptions.LangTypeScript: "client actions activity is not supported",
-				cmdoptions.LangDotNet:     "client actions activity is not supported",
+				cmdoptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`
 				WorkflowExecutionSignaled
@@ -695,7 +668,7 @@ func TestKitchenSink(t *testing.T) {
 				},
 				WorkflowInput: &WorkflowInput{
 					InitialActions: ListActionSet(
-						NewTimerAction(2000), // timer to keep workflow open long enough for client action
+						NewTimerAction(5000), // timer to keep workflow open long enough for client action
 					),
 				},
 			},

--- a/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
+++ b/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
@@ -1,16 +1,197 @@
 using Temporalio.Client;
 using Temporalio.Exceptions;
 using Temporal.Omes.KitchenSink;
+using Temporalio.Api.Enums.V1;
 
 namespace Temporalio.Omes;
 
 public class ClientActionsExecutor
 {
+    private readonly ITemporalClient _client;
+    private readonly string _workflowType = "kitchenSink";
+    private readonly string _taskQueue;
+    private object? _workflowInput = null;
+    private string _runId = "";
+
+    public string? WorkflowId { get; set; }
+
     public ClientActionsExecutor(ITemporalClient client, string workflowId, string taskQueue)
     {
+        _client = client;
+        WorkflowId = workflowId;
+        _taskQueue = taskQueue;
     }
 
-    // Always unsupported in this branch
-    public Task ExecuteClientSequence(ClientSequence _)
-        => throw new ApplicationFailureException("client actions activity is not supported", "UnsupportedOperation", nonRetryable: true);
+    public async Task ExecuteClientSequence(ClientSequence clientSeq)
+    {
+        foreach (var actionSet in clientSeq.ActionSets)
+        {
+            await ExecuteClientActionSet(actionSet);
+        }
+    }
+
+    private async Task ExecuteClientActionSet(ClientActionSet actionSet)
+    {
+        if (actionSet.Concurrent)
+        {
+            throw new ApplicationFailureException("concurrent client actions are not supported", "UnsupportedOperation", nonRetryable: true);
+        }
+
+        foreach (var action in actionSet.Actions)
+        {
+            await ExecuteClientAction(action);
+        }
+    }
+
+    private async Task ExecuteClientAction(ClientAction action)
+    {
+        if (action.DoSignal != null)
+        {
+            await ExecuteSignalAction(action.DoSignal);
+        }
+        else if (action.DoUpdate != null)
+        {
+            await ExecuteUpdateAction(action.DoUpdate);
+        }
+        else if (action.DoQuery != null)
+        {
+            await ExecuteQueryAction(action.DoQuery);
+        }
+        else if (action.NestedActions != null)
+        {
+            await ExecuteClientActionSet(action.NestedActions);
+        }
+        else
+        {
+            throw new ArgumentException("Client action must have a recognized variant");
+        }
+    }
+
+    private async Task ExecuteSignalAction(DoSignal signal)
+    {
+        string signalName;
+        object? signalArgs = null;
+
+        if (signal.DoSignalActions != null)
+        {
+            signalName = "do_actions_signal";
+            signalArgs = signal.DoSignalActions;
+        }
+        else if (signal.Custom != null)
+        {
+            signalName = signal.Custom.Name;
+            signalArgs = signal.Custom.Args?.ToArray();
+        }
+        else
+        {
+            throw new ArgumentException("DoSignal must have a recognizable variant");
+        }
+
+        var args = signalArgs == null ? Array.Empty<object>() : (signalArgs is object[] array ? array : new[] { signalArgs });
+
+        if (signal.WithStart)
+        {
+            var options = new WorkflowOptions(id: WorkflowId!, taskQueue: _taskQueue);
+            options.SignalWithStart(signalName, args);
+
+            var handle = await _client.StartWorkflowAsync(
+                _workflowType,
+                _workflowInput == null ? Array.Empty<object>() : new[] { _workflowInput },
+                options);
+
+            WorkflowId = handle.Id;
+            _runId = handle.RunId ?? "";
+        }
+        else
+        {
+            var handle = _client.GetWorkflowHandle(WorkflowId!);
+            await handle.SignalAsync(signalName, args);
+        }
+    }
+
+    private async Task ExecuteUpdateAction(DoUpdate update)
+    {
+        string updateName;
+        object? updateArgs;
+        if (update.DoActions != null)
+        {
+            updateName = "do_actions_update";
+            updateArgs = update.DoActions;
+        }
+        else if (update.Custom != null)
+        {
+            updateName = update.Custom.Name;
+            updateArgs = update.Custom.Args.Count > 0 ? update.Custom.Args : null;
+        }
+        else
+        {
+            throw new ArgumentException("DoUpdate must have a recognizable variant");
+        }
+
+        try
+        {
+            var args = updateArgs == null ? Array.Empty<object>() : (updateArgs is object[] array ? array : new[] { updateArgs });
+
+            if (update.WithStart)
+            {
+                var startOperation = WithStartWorkflowOperation.Create(
+                    _workflowType,
+                    _workflowInput == null ? Array.Empty<object>() : new[] { _workflowInput },
+                    new(id: WorkflowId!, taskQueue: _taskQueue)
+                    {
+                        IdConflictPolicy = WorkflowIdConflictPolicy.UseExisting
+                    });
+
+                await _client.ExecuteUpdateWithStartWorkflowAsync(
+                    updateName,
+                    args,
+                    new(startOperation));
+
+                var handle = await startOperation.GetHandleAsync();
+                WorkflowId = handle.Id;
+                _runId = handle.RunId ?? "";
+            }
+            else
+            {
+                var handle = _client.GetWorkflowHandle(WorkflowId!);
+                await handle.ExecuteUpdateAsync(updateName, args);
+            }
+        }
+        catch (Exception)
+        {
+            if (!update.FailureExpected)
+            {
+                throw;
+            }
+        }
+    }
+
+    private async Task ExecuteQueryAction(DoQuery query)
+    {
+        try
+        {
+            if (query.ReportState != null)
+            {
+                var handle = _client.GetWorkflowHandle(WorkflowId!);
+                await handle.QueryAsync<WorkflowState>("report_state", new object[] { query.ReportState });
+            }
+            else if (query.Custom != null)
+            {
+                var handle = _client.GetWorkflowHandle(WorkflowId!);
+                var queryArgs = query.Custom.Args.Count > 0 ? query.Custom.Args.ToArray() : null;
+                await handle.QueryAsync<object>(query.Custom.Name, queryArgs ?? Array.Empty<object>());
+            }
+            else
+            {
+                throw new ArgumentException("DoQuery must have a recognizable variant");
+            }
+        }
+        catch (Exception)
+        {
+            if (!query.FailureExpected)
+            {
+                throw;
+            }
+        }
+    }
 }

--- a/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
+++ b/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
@@ -87,8 +87,7 @@ public class ClientActionsExecutor
             throw new ArgumentException("DoSignal must have a recognizable variant");
         }
 
-        var args = signalArgs == null ? Array.Empty<object>() : (signalArgs is object[] array ? array : new[] { signalArgs });
-
+        var args = NormalizeArgsToArray(signalArgs);
         if (signal.WithStart)
         {
             var options = new WorkflowOptions(id: WorkflowId!, taskQueue: _taskQueue);
@@ -96,7 +95,7 @@ public class ClientActionsExecutor
 
             var handle = await _client.StartWorkflowAsync(
                 _workflowType,
-                _workflowInput == null ? Array.Empty<object>() : new[] { _workflowInput },
+                NormalizeArgsToArray(_workflowInput),
                 options);
 
             WorkflowId = handle.Id;
@@ -130,13 +129,12 @@ public class ClientActionsExecutor
 
         try
         {
-            var args = updateArgs == null ? Array.Empty<object>() : (updateArgs is object[] array ? array : new[] { updateArgs });
-
+            var args = NormalizeArgsToArray(updateArgs);
             if (update.WithStart)
             {
                 var startOperation = WithStartWorkflowOperation.Create(
                     _workflowType,
-                    _workflowInput == null ? Array.Empty<object>() : new[] { _workflowInput },
+                    NormalizeArgsToArray(_workflowInput),
                     new(id: WorkflowId!, taskQueue: _taskQueue)
                     {
                         IdConflictPolicy = WorkflowIdConflictPolicy.UseExisting
@@ -193,5 +191,15 @@ public class ClientActionsExecutor
                 throw;
             }
         }
+    }
+
+    private static object[] NormalizeArgsToArray(object? args)
+    {
+        return args switch
+        {
+            null => Array.Empty<object>(),
+            object[] array => array,
+            _ => new[] { args }
+        };
     }
 }

--- a/workers/python/client_action_executor.py
+++ b/workers/python/client_action_executor.py
@@ -1,16 +1,123 @@
 from typing import Any
 
 from temporalio.client import Client
-from temporalio.exceptions import ApplicationError
 
-from protos.kitchen_sink_pb2 import ClientSequence
+from protos.kitchen_sink_pb2 import (
+    ClientAction,
+    ClientActionSet,
+    ClientSequence,
+    DoQuery,
+    DoSignal,
+    DoUpdate,
+)
 
 
 class ClientActionExecutor:
     def __init__(self, client: Client, workflow_id: str, task_queue: str):
-        pass
+        self.client = client
+        self.workflow_id: str = workflow_id
+        self.workflow_type: str = "kitchenSink"
+        self.workflow_input = None
+        self.task_queue: str = task_queue
 
     async def execute_client_sequence(self, client_seq: ClientSequence):
-        raise ApplicationError(
-            "client actions activity is not supported", non_retryable=True
-        )
+        for action_set in client_seq.action_sets:
+            await self._execute_client_action_set(action_set)
+
+    async def _execute_client_action_set(self, action_set: ClientActionSet):
+        if action_set.concurrent:
+            from temporalio.exceptions import ApplicationError
+
+            raise ApplicationError(
+                "concurrent client actions are not supported", non_retryable=True
+            )
+
+        for action in action_set.actions:
+            await self._execute_client_action(action)
+
+    async def _execute_client_action(self, action: ClientAction):
+        if action.HasField("do_signal"):
+            await self._execute_signal_action(action.do_signal)
+        elif action.HasField("do_update"):
+            await self._execute_update_action(action.do_update)
+        elif action.HasField("do_query"):
+            await self._execute_query_action(action.do_query)
+        elif action.HasField("nested_actions"):
+            await self._execute_client_action_set(action.nested_actions)
+        else:
+            raise ValueError("Client action must have a recognized variant")
+
+    async def _execute_signal_action(self, signal: DoSignal):
+        if signal.HasField("do_signal_actions"):
+            signal_name = "do_actions_signal"
+            signal_args = signal.do_signal_actions
+        elif signal.HasField("custom"):
+            signal_name = signal.custom.name
+            signal_args = list(signal.custom.args) if signal.custom.args else []  # type: ignore
+        else:
+            raise ValueError("DoSignal must have a recognizable variant")
+
+        if signal.with_start:
+            handle = await self.client.start_workflow(
+                self.workflow_type,
+                self.workflow_input,
+                id=self.workflow_id,
+                task_queue=self.task_queue,
+                start_signal=signal_name,
+                start_signal_args=[signal_args],
+            )
+        else:
+            handle = self.client.get_workflow_handle(self.workflow_id)
+            await handle.signal(signal_name, signal_args)
+
+    async def _execute_update_action(self, update: DoUpdate):
+        if update.HasField("do_actions"):
+            update_name = "do_actions_update"
+            update_args = update.do_actions
+        elif update.HasField("custom"):
+            update_name = update.custom.name
+            update_args = list(update.custom.args) if update.custom.args else []  # type: ignore
+        else:
+            raise ValueError("DoUpdate must have a recognizable variant")
+
+        try:
+            if update.with_start:
+                from temporalio.client import WithStartWorkflowOperation
+                from temporalio.common import WorkflowIDConflictPolicy
+
+                start_op: WithStartWorkflowOperation = WithStartWorkflowOperation(
+                    workflow=self.workflow_type,
+                    args=[self.workflow_input],
+                    id=self.workflow_id,
+                    task_queue=self.task_queue,
+                    id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+                )
+
+                handle = await self.client.execute_update_with_start_workflow(
+                    update_name,
+                    update_args,
+                    start_workflow_operation=start_op,
+                )
+
+                workflow_handle = await start_op.workflow_handle()
+            else:
+                handle = self.client.get_workflow_handle(self.workflow_id)
+                await handle.execute_update(update_name, update_args)
+        except Exception:
+            if not update.failure_expected:
+                raise
+
+    async def _execute_query_action(self, query: DoQuery):
+        try:
+            if query.HasField("report_state"):
+                handle = self.client.get_workflow_handle(self.workflow_id)
+                await handle.query("report_state", None)
+            elif query.HasField("custom"):
+                handle = self.client.get_workflow_handle(self.workflow_id)
+                query_args = list(query.custom.args) if query.custom.args else None
+                await handle.query(query.custom.name, *query_args if query_args else [])
+            else:
+                raise ValueError("DoQuery must have a recognizable variant")
+        except Exception:
+            if not query.failure_expected:
+                raise

--- a/workers/python/client_action_executor.py
+++ b/workers/python/client_action_executor.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from temporalio.client import Client
+from temporalio.client import Client, WithStartWorkflowOperation
+from temporalio.common import WorkflowIDConflictPolicy
+from temporalio.exceptions import ApplicationError
 
 from protos.kitchen_sink_pb2 import (
     ClientAction,
@@ -26,8 +28,6 @@ class ClientActionExecutor:
 
     async def _execute_client_action_set(self, action_set: ClientActionSet):
         if action_set.concurrent:
-            from temporalio.exceptions import ApplicationError
-
             raise ApplicationError(
                 "concurrent client actions are not supported", non_retryable=True
             )
@@ -82,9 +82,6 @@ class ClientActionExecutor:
 
         try:
             if update.with_start:
-                from temporalio.client import WithStartWorkflowOperation
-                from temporalio.common import WorkflowIDConflictPolicy
-
                 start_op: WithStartWorkflowOperation = WithStartWorkflowOperation(
                     workflow=self.workflow_type,
                     args=[self.workflow_input],

--- a/workers/typescript/src/client-action-executor.ts
+++ b/workers/typescript/src/client-action-executor.ts
@@ -37,17 +37,6 @@ export class ClientActionExecutor {
     for (const action of actionSet.actions || []) {
       await this.executeClientAction(action);
     }
-
-    if (actionSet.waitForCurrentRunToFinishAtEnd) {
-      if (this.workflowId && this.runId) {
-        const handle = this.client.workflow.getHandle(this.workflowId, this.runId);
-        try {
-          await handle.result();
-        } catch (error) {
-          // Ignore continue-as-new errors
-        }
-      }
-    }
   }
 
   private async executeClientAction(action: IClientAction): Promise<void> {
@@ -150,7 +139,7 @@ export class ClientActionExecutor {
       } else {
         throw new Error('DoQuery must have a recognizable variant');
       }
-    } catch (error) {
+    } catch (error: unknown) {
       if (!query.failureExpected) {
         throw error;
       }

--- a/workers/typescript/src/client-action-executor.ts
+++ b/workers/typescript/src/client-action-executor.ts
@@ -1,12 +1,159 @@
+import { Client, WithStartWorkflowOperation } from '@temporalio/client';
 import { ApplicationFailure } from '@temporalio/common';
+import { WorkflowIdConflictPolicy } from '@temporalio/client';
 import { temporal } from './protos/root';
 import IClientSequence = temporal.omes.kitchen_sink.IClientSequence;
+import IClientActionSet = temporal.omes.kitchen_sink.IClientActionSet;
+import IClientAction = temporal.omes.kitchen_sink.IClientAction;
+import IDoSignal = temporal.omes.kitchen_sink.IDoSignal;
+import IDoUpdate = temporal.omes.kitchen_sink.IDoUpdate;
+import IDoQuery = temporal.omes.kitchen_sink.IDoQuery;
 
 export class ClientActionExecutor {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor(_client: unknown, _workflowId: string, _taskQueue: string) {}
+  private client: Client;
+  private workflowId = '';
+  private runId = '';
+  private workflowType = 'kitchenSink';
+  private workflowInput: any = null;
+  private taskQueue;
 
-  async executeClientSequence(_seq?: IClientSequence | null): Promise<void> {
-    throw ApplicationFailure.nonRetryable('client actions activity is not supported');
+  constructor(client: Client, workflowId: string, taskQueue: string) {
+    this.client = client;
+    this.workflowId = workflowId;
+    this.taskQueue = taskQueue;
+  }
+
+  async executeClientSequence(clientSeq?: IClientSequence | null): Promise<void> {
+    for (const actionSet of clientSeq?.actionSets || []) {
+      await this.executeClientActionSet(actionSet);
+    }
+  }
+
+  private async executeClientActionSet(actionSet: IClientActionSet): Promise<void> {
+    if (actionSet.concurrent) {
+      throw ApplicationFailure.nonRetryable('concurrent client actions are not supported');
+    }
+
+    for (const action of actionSet.actions || []) {
+      await this.executeClientAction(action);
+    }
+
+    if (actionSet.waitForCurrentRunToFinishAtEnd) {
+      if (this.workflowId && this.runId) {
+        const handle = this.client.workflow.getHandle(this.workflowId, this.runId);
+        try {
+          await handle.result();
+        } catch (error) {
+          // Ignore continue-as-new errors
+        }
+      }
+    }
+  }
+
+  private async executeClientAction(action: IClientAction): Promise<void> {
+    if (action.doSignal) {
+      await this.executeSignalAction(action.doSignal);
+    } else if (action.doUpdate) {
+      await this.executeUpdateAction(action.doUpdate);
+    } else if (action.doQuery) {
+      await this.executeQueryAction(action.doQuery);
+    } else if (action.nestedActions) {
+      await this.executeClientActionSet(action.nestedActions);
+    } else {
+      throw new Error('Client action must have a recognized variant');
+    }
+  }
+
+  private async executeSignalAction(signal: IDoSignal): Promise<void> {
+    let signalName: string;
+    let signalArgs: any;
+
+    if (signal.doSignalActions) {
+      signalName = 'do_actions_signal';
+      signalArgs = [signal.doSignalActions];
+    } else if (signal.custom) {
+      signalName = signal.custom.name || '';
+      signalArgs = signal.custom.args || [];
+    } else {
+      throw new Error('DoSignal must have a recognizable variant');
+    }
+
+    try {
+      if (signal.withStart) {
+        const handle = await this.client.workflow.signalWithStart(this.workflowType, {
+          workflowId: this.workflowId,
+          taskQueue: this.taskQueue,
+          args: [this.workflowInput],
+          signal: signalName,
+          signalArgs,
+          workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+        });
+        this.workflowId = handle.workflowId;
+        this.runId = handle.signaledRunId;
+      } else {
+        const handle = this.client.workflow.getHandle(this.workflowId);
+        await handle.signal(signalName, ...signalArgs);
+      }
+    } catch (error) {
+      console.error(`Signal execution failed for ${signalName}:`, error);
+      throw error;
+    }
+  }
+
+  private async executeUpdateAction(update: IDoUpdate): Promise<void> {
+    let updateName: string;
+    let updateArgs: any;
+
+    if (update.doActions) {
+      updateName = 'do_actions_update';
+      updateArgs = update.doActions;
+    } else if (update.custom) {
+      updateName = update.custom.name || '';
+      updateArgs = update.custom.args || [];
+    } else {
+      throw new Error('DoUpdate must have a recognizable variant');
+    }
+
+    try {
+      if (update.withStart) {
+        const startWorkflowOperation = new WithStartWorkflowOperation(this.workflowType, {
+          workflowId: this.workflowId,
+          taskQueue: this.taskQueue,
+          args: [this.workflowInput],
+          workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+        });
+        await this.client.workflow.executeUpdateWithStart(updateName, {
+          args: [updateArgs],
+          startWorkflowOperation,
+        });
+      } else {
+        const handle = this.client.workflow.getHandle(this.workflowId);
+        await handle.executeUpdate(updateName, { args: [updateArgs] });
+      }
+    } catch (error) {
+      console.error(`Update execution failed for ${updateName}:`, error);
+      if (!update.failureExpected) {
+        throw error;
+      }
+    }
+  }
+
+  private async executeQueryAction(query: IDoQuery): Promise<void> {
+    try {
+      if (query.reportState) {
+        const handle = this.client.workflow.getHandle(this.workflowId);
+        await handle.query('report_state', null);
+      } else if (query.custom) {
+        const handle = this.client.workflow.getHandle(this.workflowId);
+        const queryArgs = query.custom.args || [];
+        await handle.query(query.custom.name || '', ...queryArgs);
+      } else {
+        throw new Error('DoQuery must have a recognizable variant');
+      }
+    } catch (error) {
+      if (!query.failureExpected) {
+        throw error;
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Follow-up to https://github.com/temporalio/omes/pull/179 to include other SDKs.

Adds new "Client" ActivityType to execute client actions (e.g. Update, Signal) from a workflow activity to TS, .NET and Python.

The client action executor implementations were all modeled after the Go one.

---

ℹ️  Concurrent execution of the client actions is out of scope for this PR.

🫘 I couldn't get Java to work; it's out of scope for this PR now. Sorry.

⚠️ The ClientActionExecutors were mostly AI generated - with lots of manual pruning and fixing - but I can't quite vouch for them being 100% idiomatic. 

## Why?
<!-- Tell your future self why have you made these changes -->

Narrow kitchensink support gap to Go.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
