### PR TITLE
Remove worker artifact publish

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -37,62 +37,6 @@ on:
         type: string
 
 jobs:
-  publish-artifacts:
-    name: Publish ${{ inputs.lang }} artifacts
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout omes repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.omes-repo-path }}
-          ref: ${{ inputs.omes-repo-ref || github.head_ref }}
-          submodules: true
-          fetch-depth: 0
-
-      - name: Lint dockerfile
-        env:
-          LANG: ${{ inputs.lang }}
-        run: docker run --rm -i hadolint/hadolint hadolint --ignore DL3029 - < "dockerfiles/$LANG.Dockerfile"
-
-      - uses: actions/setup-go@v4
-        if: ${{ !inputs.do-push || github.event.pull_request.head.repo.fork }}
-        with:
-          go-version-file: "go.mod"
-
-      - name: Set up Docker Buildx
-        if: ${{ !inputs.do-push || github.event.pull_request.head.repo.fork }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and save image for artifacts
-        if: ${{ !inputs.do-push || github.event.pull_request.head.repo.fork }}
-        env:
-          LANG: ${{ inputs.lang }}
-          SDK_VERSION: ${{ inputs.sdk-version || 'checked-out-sdk/' }}
-          IMAGE_TAG_ARGS: ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, inputs.docker-tag-ext) || ''}}
-          TAG_LATEST_ARGS: ${{ inputs.as-latest && '--tag-as-latest' || ''}}
-        run: |
-          go run ./cmd build-worker-image --language "$LANG" \
-          --version "$SDK_VERSION" \
-          --save-image /tmp/image.tar \
-          --platform linux/amd64 \
-          $IMAGE_TAG_ARGS \
-          $TAG_LATEST_ARGS
-
-      - name: Prepare docker artifact
-        if: ${{ !inputs.do-push || github.event.pull_request.head.repo.fork }}
-        run: |
-          echo -n "${{env.SAVED_IMAGE_TAG}}" > /tmp/image_tag
-
-      - name: Upload docker artifacts
-        if: ${{ !inputs.do-push || github.event.pull_request.head.repo.fork }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: omes-${{ inputs.lang }}-docker-image
-          path: |
-            /tmp/image.tar
-            /tmp/image_tag
-
   publish-dockerhub:
     name: Publish ${{ inputs.lang }} to Docker Hub
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Removed `publish-artifacts` that published worker images to GitHub artifacts.

## Why?
<!-- Tell your future self why have you made these changes -->

Unused. We already push to the Docker registry.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
