### PR TITLE
Download Gradle into Java worker image

### DIFF
--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/$TARGETARCH eclipse-temurin:11-jammy AS build
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.12.4* git=1:2.34.1-1ubuntu1 unzip=6.0-26ubuntu3*
+      protobuf-compiler=3.12.4* git=1:2.34.1-1ubuntu1
 
 # Get go compiler
 ARG TARGETARCH


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Cache Gradle download in image.

## Why?
<!-- Tell your future self why have you made these changes -->

When starting the image, it first needs to download Gradle:
```
docker run temporaliotest/omes:java-latest --scenario workflow_with_single_noop_activity --run-id local-test-run --namespace default --server-address=host.docker.internal:7233
2025-09-19T23:47:28.872Z        INFO    workers/run.go:144      Starting worker with command: [/bin/sh ../gradlew --include-build ../ run --args '--task-queue' 'omes-local-test-run' '--server-address' 'host.docker.internal:7233' '--namespace' 'default' '--prom-handler-path' '/metrics']
Downloading https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
.............10%.............20%.............30%.............40%.............50%.............60%.............70%.............80%.............90%.............100%

Welcome to Gradle 8.10.2!
...
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
