### PR TITLE
Reusable CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,19 @@ For example, here is [scenarios/workflow_with_single_noop_activity.go](scenarios
 ```go
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: "Each iteration executes a single workflow with a noop activity.",
-		Executor: loadgen.KitchenSinkExecutor{
-			WorkflowParams: kitchensink.NewWorkflowParams(kitchensink.NopActionExecuteActivity),
-		},
-	})
+        Description: "Each iteration executes a single workflow with a noop activity.",
+        ExecutorFn: func() loadgen.Executor {
+            return loadgen.KitchenSinkExecutor{
+                TestInput: &kitchensink.TestInput{
+                    WorkflowInput: &kitchensink.WorkflowInput{
+                        InitialActions: []*kitchensink.ActionSet{
+                            kitchensink.NoOpSingleActivityActionSet(),
+                        },
+                    },
+                },
+            }
+        },
+    })
 }
 ```
 

--- a/cmd/cli/cleanup_scenario.go
+++ b/cmd/cli/cleanup_scenario.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/loadgen"
 	"go.temporal.io/api/batch/v1"
 	"go.temporal.io/api/enums/v1"
@@ -40,10 +40,10 @@ func cleanupScenarioCmd() *cobra.Command {
 type scenarioCleaner struct {
 	logger         *zap.SugaredLogger
 	pollInterval   time.Duration
-	scenario       cmdoptions.ScenarioID
-	clientOptions  cmdoptions.ClientOptions
-	metricsOptions cmdoptions.MetricsOptions
-	loggingOptions cmdoptions.LoggingOptions
+	scenario       clioptions.ScenarioID
+	clientOptions  clioptions.ClientOptions
+	metricsOptions clioptions.MetricsOptions
+	loggingOptions clioptions.LoggingOptions
 }
 
 func (c *scenarioCleaner) addCLIFlags(fs *pflag.FlagSet) {

--- a/cmd/cli/list_scenarios.go
+++ b/cmd/cli/list_scenarios.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	_ "github.com/temporalio/omes/scenarios" // Register scenarios (side-effect)
+)
+
+func Main() {
+	var rootCmd = &cobra.Command{
+		Use:   "omes",
+		Short: "A load generator for Temporal",
+	}
+
+	rootCmd.AddCommand(cleanupScenarioCmd())
+	rootCmd.AddCommand(listScenariosCmd())
+	rootCmd.AddCommand(prepareWorkerCmd())
+	rootCmd.AddCommand(runScenarioCmd())
+	rootCmd.AddCommand(runScenarioWithWorkerCmd())
+	rootCmd.AddCommand(runWorkerCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/cli/prepare_worker.go
+++ b/cmd/cli/prepare_worker.go
@@ -1,11 +1,11 @@
-package main
+package cli
 
 import (
 	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/workers"
 )
 
@@ -36,7 +36,7 @@ func prepareWorkerCmd() *cobra.Command {
 
 type workerBuilder struct {
 	workers.Builder
-	loggingOptions cmdoptions.LoggingOptions
+	loggingOptions clioptions.LoggingOptions
 }
 
 func (b *workerBuilder) addCLIFlags(fs *pflag.FlagSet) {

--- a/cmd/cli/run_scenario.go
+++ b/cmd/cli/run_scenario.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/loadgen"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
@@ -39,12 +39,12 @@ func runScenarioCmd() *cobra.Command {
 
 type scenarioRunner struct {
 	scenarioRunConfig
-	scenario       cmdoptions.ScenarioID
+	scenario       clioptions.ScenarioID
 	logger         *zap.SugaredLogger
 	connectTimeout time.Duration
-	clientOptions  cmdoptions.ClientOptions
-	metricsOptions cmdoptions.MetricsOptions
-	loggingOptions cmdoptions.LoggingOptions
+	clientOptions  clioptions.ClientOptions
+	metricsOptions clioptions.MetricsOptions
+	loggingOptions clioptions.LoggingOptions
 }
 
 type scenarioRunConfig struct {
@@ -168,4 +168,3 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	}
 	return nil
 }
-

--- a/cmd/cli/run_scenario_with_worker.go
+++ b/cmd/cli/run_scenario_with_worker.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/workers"
 )
 
@@ -35,7 +35,7 @@ func runScenarioWithWorkerCmd() *cobra.Command {
 type workerWithScenarioRunner struct {
 	workerRunner
 	scenarioRunConfig
-	metricsOptions cmdoptions.MetricsOptions
+	metricsOptions clioptions.MetricsOptions
 }
 
 func (r *workerWithScenarioRunner) addCLIFlags(fs *pflag.FlagSet) {
@@ -100,4 +100,3 @@ func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 	}
 	return nil
 }
-

--- a/cmd/cli/run_worker.go
+++ b/cmd/cli/run_worker.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -69,7 +69,6 @@ func (r *workerRunner) run(ctx context.Context) error {
 	}
 	return r.Run(ctx, workers.BaseDir(repoDir, r.SdkOptions.Language))
 }
-
 
 func withCancelOnInterrupt(ctx context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -11,7 +11,8 @@ func getRepoDir() (string, error) {
 	if !ok {
 		return "", fmt.Errorf("failed to get source file location")
 	}
-	cmdDir := filepath.Dir(filename) // cmd
+	cliDir := filepath.Dir(filename) // cli
+	cmdDir := filepath.Dir(cliDir)   // cmd
 	repoDir := filepath.Dir(cmdDir)  // project root
 	return repoDir, nil
 }

--- a/cmd/cli/util_nonwindows.go
+++ b/cmd/cli/util_nonwindows.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package cli
 
 import (
 	"os"

--- a/cmd/cli/util_windows.go
+++ b/cmd/cli/util_windows.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"os"

--- a/cmd/clioptions/client.go
+++ b/cmd/clioptions/client.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"context"

--- a/cmd/clioptions/logging.go
+++ b/cmd/clioptions/logging.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"log"

--- a/cmd/clioptions/metrics.go
+++ b/cmd/clioptions/metrics.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"context"

--- a/cmd/clioptions/scenario.go
+++ b/cmd/clioptions/scenario.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"encoding/base32"

--- a/cmd/clioptions/sdk.go
+++ b/cmd/clioptions/sdk.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"fmt"

--- a/cmd/clioptions/worker.go
+++ b/cmd/clioptions/worker.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"strconv"

--- a/cmd/clioptions/zap_adapter.go
+++ b/cmd/clioptions/zap_adapter.go
@@ -1,4 +1,4 @@
-package cmdoptions
+package clioptions
 
 import (
 	"fmt"

--- a/cmd/dev/build_helper.go
+++ b/cmd/dev/build_helper.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"go.uber.org/zap"
 )
 
@@ -23,7 +23,7 @@ type baseImageBuilder struct {
 	saveImage      string
 	tags           []string
 	labels         []string
-	loggingOptions cmdoptions.LoggingOptions
+	loggingOptions clioptions.LoggingOptions
 }
 
 func (b *baseImageBuilder) addBaseCLIFlags(fs *pflag.FlagSet) {

--- a/cmd/dev/build_worker_image.go
+++ b/cmd/dev/build_worker_image.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"golang.org/x/mod/semver"
 )
 
@@ -47,7 +47,7 @@ func buildPushWorkerImageCmd() *cobra.Command {
 
 type workerImageBuilder struct {
 	baseImageBuilder
-	sdkOptions cmdoptions.SdkOptions
+	sdkOptions clioptions.SdkOptions
 }
 
 func (b *workerImageBuilder) addCLIFlags(fs *pflag.FlagSet) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,28 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
-	_ "github.com/temporalio/omes/scenarios" // Register scenarios (side-effect)
+	"github.com/temporalio/omes/cmd/cli"
 )
 
 func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "omes",
-		Short: "A load generator for Temporal",
-	}
-
-	rootCmd.AddCommand(cleanupScenarioCmd())
-	rootCmd.AddCommand(listScenariosCmd())
-	rootCmd.AddCommand(prepareWorkerCmd())
-	rootCmd.AddCommand(runScenarioCmd())
-	rootCmd.AddCommand(runScenarioWithWorkerCmd())
-	rootCmd.AddCommand(runWorkerCmd())
-
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	cli.Main()
 }

--- a/loadgen/kitchen_sink_executor_test.go
+++ b/loadgen/kitchen_sink_executor_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	. "github.com/temporalio/omes/loadgen"
 	. "github.com/temporalio/omes/loadgen/kitchensink"
 	. "github.com/temporalio/omes/workers"
@@ -26,12 +26,12 @@ import (
 const namespace = "default"
 
 var (
-	sdks = []cmdoptions.Language{
-		cmdoptions.LangGo,
-		cmdoptions.LangJava,
-		cmdoptions.LangPython,
-		cmdoptions.LangTypeScript,
-		cmdoptions.LangDotNet,
+	sdks = []clioptions.Language{
+		clioptions.LangGo,
+		clioptions.LangJava,
+		clioptions.LangPython,
+		clioptions.LangTypeScript,
+		clioptions.LangDotNet,
 	}
 	onlySDK   = os.Getenv("SDK")
 	javaMutex sync.Mutex
@@ -41,7 +41,7 @@ type testCase struct {
 	name                    string
 	testInput               *TestInput
 	historyMatcher          HistoryMatcher
-	expectedUnsupportedErrs map[cmdoptions.Language]string
+	expectedUnsupportedErrs map[clioptions.Language]string
 }
 
 // TestKitchenSink tests specific kitchensink features across SDKs.
@@ -182,8 +182,8 @@ func TestKitchenSink(t *testing.T) {
 					),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled`),
 		},
@@ -215,8 +215,8 @@ func TestKitchenSink(t *testing.T) {
 					),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled`),
 		},
@@ -242,8 +242,8 @@ func TestKitchenSink(t *testing.T) {
 					),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionSignaled {"signalName":"test_signal"}`),
 		},
@@ -271,8 +271,8 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskScheduled {"activityType":{"name":"client"}}
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -302,8 +302,8 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskScheduled {"activityType":{"name":"client"}}
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -334,8 +334,8 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskScheduled {"activityType":{"name":"client"}}
 				...
 				WorkflowExecutionUpdateAccepted {"acceptedRequest":{"input":{"name":"do_actions_update"}}}`),
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -365,8 +365,8 @@ func TestKitchenSink(t *testing.T) {
 				ActivityTaskScheduled {"activityType":{"name":"client"}}
 				ActivityTaskStarted
 				ActivityTaskCompleted`),
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 		},
 		{
@@ -397,8 +397,8 @@ func TestKitchenSink(t *testing.T) {
 					),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`WorkflowExecutionUpdateCompleted`),
 		},
@@ -421,11 +421,11 @@ func TestKitchenSink(t *testing.T) {
 					),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangTypeScript: "concurrent client actions are not supported",
-				cmdoptions.LangDotNet:     "concurrent client actions are not supported",
-				cmdoptions.LangPython:     "concurrent client actions are not supported",
-				cmdoptions.LangJava:       "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangTypeScript: "concurrent client actions are not supported",
+				clioptions.LangDotNet:     "concurrent client actions are not supported",
+				clioptions.LangPython:     "concurrent client actions are not supported",
+				clioptions.LangJava:       "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`
 				ActivityTaskScheduled {"activityType":{"name":"client"}}
@@ -479,8 +479,8 @@ func TestKitchenSink(t *testing.T) {
 						}),
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangJava: "client actions activity is not supported",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangJava: "client actions activity is not supported",
 			},
 			historyMatcher: PartialHistoryMatcher(`
 				WorkflowExecutionSignaled
@@ -738,12 +738,12 @@ func TestKitchenSink(t *testing.T) {
 						&Action{Variant: nil}), // unsupported action
 				},
 			},
-			expectedUnsupportedErrs: map[cmdoptions.Language]string{
-				cmdoptions.LangGo:         "unrecognized action",
-				cmdoptions.LangJava:       "unrecognized action",
-				cmdoptions.LangPython:     "unrecognized action",
-				cmdoptions.LangTypeScript: "unrecognized action",
-				cmdoptions.LangDotNet:     "unrecognized action",
+			expectedUnsupportedErrs: map[clioptions.Language]string{
+				clioptions.LangGo:         "unrecognized action",
+				clioptions.LangJava:       "unrecognized action",
+				clioptions.LangPython:     "unrecognized action",
+				clioptions.LangTypeScript: "unrecognized action",
+				clioptions.LangDotNet:     "unrecognized action",
 			},
 		},
 	} {
@@ -773,11 +773,11 @@ func TestKitchenSink(t *testing.T) {
 func testForSDK(
 	t *testing.T,
 	tc testCase,
-	sdk cmdoptions.Language,
+	sdk clioptions.Language,
 	env *TestEnvironment,
 ) {
 	// Use mutex to ensure only one Java test runs at a time/a Gradle limitation.
-	if sdk == cmdoptions.LangJava {
+	if sdk == clioptions.LangJava {
 		javaMutex.Lock()
 		defer javaMutex.Unlock()
 	}
@@ -805,7 +805,7 @@ func testUnsupportedFeature(
 	env *TestEnvironment,
 	executor *KitchenSinkExecutor,
 	scenarioInfo ScenarioInfo,
-	sdk cmdoptions.Language,
+	sdk clioptions.Language,
 	expectedErr string,
 ) {
 	testExecutor := &kitchenSinkTestWrapper{
@@ -825,7 +825,7 @@ func testSupportedFeature(
 	executor *KitchenSinkExecutor,
 	scenarioInfo ScenarioInfo,
 	tc testCase,
-	sdk cmdoptions.Language,
+	sdk clioptions.Language,
 ) {
 	testExecutor := &kitchenSinkTestWrapper{
 		executor: executor,
@@ -850,7 +850,7 @@ func testSupportedFeature(
 
 type kitchenSinkTestWrapper struct {
 	executor *KitchenSinkExecutor
-	sdk      cmdoptions.Language
+	sdk      clioptions.Language
 }
 
 func (w *kitchenSinkTestWrapper) Run(ctx context.Context, info ScenarioInfo) error {

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -69,7 +69,7 @@ var registeredScenarios = make(map[string]*Scenario)
 
 // MustRegisterScenario registers a scenario in the global static registry.
 // Panics if registration fails.
-// The file name of the caller is be used as the scenario name.
+// The file name of the caller is used as the scenario name.
 func MustRegisterScenario(scenario Scenario) {
 	_, file, _, ok := runtime.Caller(1)
 	if !ok {

--- a/scenarios/ebb_and_flow_test.go
+++ b/scenarios/ebb_and_flow_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/workers"
 )
@@ -69,7 +69,7 @@ func TestEbbAndFlow(t *testing.T) {
 	t.Run("Run executor", func(t *testing.T) {
 		executor := newEbbAndFlowExecutor()
 
-		res, err := env.RunExecutorTest(t, executor, scenarioInfo, cmdoptions.LangGo)
+		res, err := env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully")
 
 		state = executor.Snapshot().(ebbAndFlowState)
@@ -93,7 +93,7 @@ func TestEbbAndFlow(t *testing.T) {
 
 		resumeScenarioInfo := scenarioInfo
 
-		res, err := env.RunExecutorTest(t, executor, resumeScenarioInfo, cmdoptions.LangGo)
+		res, err := env.RunExecutorTest(t, executor, resumeScenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully")
 
 		state = executor.Snapshot().(ebbAndFlowState)
@@ -117,7 +117,7 @@ func TestEbbAndFlow(t *testing.T) {
 		resumeScenarioInfo := scenarioInfo
 		resumeScenarioInfo.Configuration.Duration = 0 // ie no more time left
 
-		_, err = env.RunExecutorTest(t, executor, resumeScenarioInfo, cmdoptions.LangGo)
+		_, err = env.RunExecutorTest(t, executor, resumeScenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully")
 	})
 }

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/workers"
 )
@@ -38,7 +38,7 @@ func TestThroughputStress(t *testing.T) {
 	t.Run("Run executor", func(t *testing.T) {
 		executor := newThroughputStressExecutor()
 
-		_, err := env.RunExecutorTest(t, executor, scenarioInfo, cmdoptions.LangGo)
+		_, err := env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully")
 
 		state := executor.Snapshot().(tpsState)
@@ -55,7 +55,7 @@ func TestThroughputStress(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = env.RunExecutorTest(t, executor, scenarioInfo, cmdoptions.LangGo)
+		_, err = env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully when resuming from middle")
 	})
 
@@ -69,7 +69,7 @@ func TestThroughputStress(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = env.RunExecutorTest(t, executor, scenarioInfo, cmdoptions.LangGo)
+		_, err = env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully when resuming from end")
 	})
 }

--- a/workers/build.go
+++ b/workers/build.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 
 	"github.com/temporalio/features/sdkbuild"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"go.uber.org/zap"
 )
 
 type Builder struct {
 	DirName    string
-	SdkOptions cmdoptions.SdkOptions
+	SdkOptions clioptions.SdkOptions
 	Logger     *zap.SugaredLogger
 	stdout     io.Writer
 	stderr     io.Writer
@@ -44,15 +44,15 @@ func (b *Builder) Build(ctx context.Context, baseDir string) (sdkbuild.Program, 
 	}
 
 	switch b.SdkOptions.Language {
-	case cmdoptions.LangGo:
+	case clioptions.LangGo:
 		return b.buildGo(ctx, baseDir)
-	case cmdoptions.LangPython:
+	case clioptions.LangPython:
 		return b.buildPython(ctx, baseDir)
-	case cmdoptions.LangJava:
+	case clioptions.LangJava:
 		return b.buildJava(ctx, baseDir)
-	case cmdoptions.LangTypeScript:
+	case clioptions.LangTypeScript:
 		return b.buildTypeScript(ctx, baseDir)
-	case cmdoptions.LangDotNet:
+	case clioptions.LangDotNet:
 		return b.buildDotNet(ctx, baseDir)
 	default:
 		return nil, fmt.Errorf("unrecognized language %v", b.SdkOptions.Language)
@@ -267,6 +267,6 @@ func (b *Builder) buildDotNet(ctx context.Context, baseDir string) (sdkbuild.Pro
 	return prog, nil
 }
 
-func BaseDir(repoDir string, lang cmdoptions.Language) string {
+func BaseDir(repoDir string, lang clioptions.Language) string {
 	return filepath.Join(repoDir, "workers", lang.String())
 }

--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/spf13/cobra"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/workers/go/ebbandflow"
 	"github.com/temporalio/omes/workers/go/kitchensink"
 	"go.temporal.io/sdk/activity"
@@ -21,10 +21,10 @@ type App struct {
 	taskQueueIndexSuffixStart int
 	taskQueueIndexSuffixEnd   int
 
-	loggingOptions cmdoptions.LoggingOptions
-	clientOptions  cmdoptions.ClientOptions
-	metricsOptions cmdoptions.MetricsOptions
-	workerOptions  cmdoptions.WorkerOptions
+	loggingOptions clioptions.LoggingOptions
+	clientOptions  clioptions.ClientOptions
+	metricsOptions clioptions.MetricsOptions
+	workerOptions  clioptions.WorkerOptions
 }
 
 func (a *App) Run(cmd *cobra.Command, args []string) {
@@ -53,7 +53,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) {
 	}
 }
 
-func runWorkers(client client.Client, taskQueues []string, options cmdoptions.WorkerOptions) error {
+func runWorkers(client client.Client, taskQueues []string, options clioptions.WorkerOptions) error {
 	errCh := make(chan error, len(taskQueues))
 	ebbFlowActivities := ebbandflow.Activities{}
 	clientActivities := kitchensink.ClientActivities{
@@ -127,7 +127,7 @@ func Main() {
 		if app.logger != nil {
 			app.logger.Fatal(err)
 		} else {
-			cmdoptions.BackupLogger.Fatal(err)
+			clioptions.BackupLogger.Fatal(err)
 		}
 	}
 }

--- a/workers/run.go
+++ b/workers/run.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/temporalio/features/sdkbuild"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -25,11 +25,11 @@ type Runner struct {
 	TaskQueueName             string
 	TaskQueueIndexSuffixStart int
 	TaskQueueIndexSuffixEnd   int
-	ScenarioID                cmdoptions.ScenarioID
-	ClientOptions             cmdoptions.ClientOptions
-	MetricsOptions            cmdoptions.MetricsOptions
-	WorkerOptions             cmdoptions.WorkerOptions
-	LoggingOptions            cmdoptions.LoggingOptions
+	ScenarioID                clioptions.ScenarioID
+	ClientOptions             clioptions.ClientOptions
+	MetricsOptions            clioptions.MetricsOptions
+	WorkerOptions             clioptions.WorkerOptions
+	LoggingOptions            clioptions.LoggingOptions
 	OnWorkerStarted           func()
 }
 
@@ -91,15 +91,15 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 		var err error
 		loadDir := filepath.Join(baseDir, r.DirName)
 		switch r.SdkOptions.Language {
-		case cmdoptions.LangGo:
+		case clioptions.LangGo:
 			prog, err = sdkbuild.GoProgramFromDir(loadDir)
-		case cmdoptions.LangPython:
+		case clioptions.LangPython:
 			prog, err = sdkbuild.PythonProgramFromDir(loadDir)
-		case cmdoptions.LangJava:
+		case clioptions.LangJava:
 			prog, err = sdkbuild.JavaProgramFromDir(loadDir)
-		case cmdoptions.LangTypeScript:
+		case clioptions.LangTypeScript:
 			prog, err = sdkbuild.TypeScriptProgramFromDir(loadDir)
-		case cmdoptions.LangDotNet:
+		case clioptions.LangDotNet:
 			prog, err = sdkbuild.DotNetProgramFromDir(loadDir)
 		default:
 			return fmt.Errorf("unrecognized language %v", r.SdkOptions.Language)
@@ -111,10 +111,10 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 
 	// Build command args
 	var args []string
-	if r.SdkOptions.Language == cmdoptions.LangPython {
+	if r.SdkOptions.Language == clioptions.LangPython {
 		// Python needs module name first
 		args = append(args, "main")
-	} else if r.SdkOptions.Language == cmdoptions.LangTypeScript {
+	} else if r.SdkOptions.Language == clioptions.LangTypeScript {
 		// Node also needs module
 		args = append(args, "./tslib/omes.js")
 	}

--- a/workers/test_env.go
+++ b/workers/test_env.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/omes/cmd/cmdoptions"
+	"github.com/temporalio/omes/cmd/clioptions"
 	"github.com/temporalio/omes/loadgen"
 	"go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -168,7 +168,7 @@ func (env *TestEnvironment) RunExecutorTest(
 	t *testing.T,
 	executor loadgen.Executor,
 	scenarioInfo loadgen.ScenarioInfo,
-	sdk cmdoptions.Language,
+	sdk clioptions.Language,
 ) (TestResult, error) {
 	testLogger := zaptest.NewLogger(t).Core()
 	observeLogger, observedLogs := observer.New(zap.DebugLevel)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Moved CLI commands to exported package:

- new package `cli`
- renamed `cmdoptions` to `clioptions` to match

## Why?
<!-- Tell your future self why have you made these changes -->

This allows writing a thin Omes CLI wrapper application that defines its own scenario; but still provide all the Omes CLI options as if it was an "internal" scenario.

Of course this only works if the scenario uses the kitchensink executor.

```go
package main
 
import (
    "github.com/temporalio/omes/cmd/cli"
     _ "examples/custom-scenario/scenarios" // register our custom scenarios
)

func main() {
    cli.Main()
}
```

Using Omes programmatically as a library was already possible; but the CLI use case was not.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
