### PR TITLE
pipe npm install/build failures to stdout/stderr

### DIFF
--- a/workers/build.go
+++ b/workers/build.go
@@ -169,6 +169,8 @@ func (b *Builder) buildTypeScript(ctx context.Context, baseDir string) (sdkbuild
 
 	cmd = exec.Command("npm", "run", "build")
 	cmd.Dir = baseDir
+	cmd.Stdout = b.stdout
+	cmd.Stderr = b.stderr
 	err = cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("npm run build in ./workers/typescript failed: %w", err)


### PR DESCRIPTION
## What was changed
pipe npm install/build failures to stdout/stderr

## Why?
help debugging
