### PR TITLE
ignore parent directory build props in `build.go`

### DIFF
--- a/workers/build.go
+++ b/workers/build.go
@@ -255,6 +255,7 @@ func (b *Builder) buildDotNet(ctx context.Context, baseDir string) (sdkbuild.Pro
 			<PropertyGroup>
 				<OutputType>Exe</OutputType>
 				<TargetFramework>net8.0</TargetFramework>
+				<ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
 			</PropertyGroup>
 			<ItemGroup>
 				<ProjectReference Include="` + omesProjPath + `" />


### PR DESCRIPTION
## What was changed
.NET worker ignores parent Directory.Build.Props in `build.go`

## Why?
Need to do this in `build.go` because it creates a template directory build props 
