### PR TITLE
VLN-520: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/all-docker-images.yml
+++ b/.github/workflows/all-docker-images.yml
@@ -1,4 +1,8 @@
 name: Build all language docker images
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     # TODO: Can eventually support repo refs too rather than just versions if/when we need that.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Continuous Integration
 
+permissions:
+  contents: read
+  actions: write
+  checks: write
+
 env:
   MISE_VERSION: v2025.8.1
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,4 +1,8 @@
 name: Build docker images
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added workflow-level permissions to limit the GITHUB_TOKEN to the checks, actions, and contents scopes required by the test, lint, artifact upload, and reusable workflow jobs.
- `.github/workflows/all-docker-images.yml`: Declared workflow-level GITHUB_TOKEN permissions restricting access to repository contents when invoking reusable docker image builds.
- `.github/workflows/docker-images.yml`: Set explicit workflow permissions so reusable docker image publishing only receives read access to repository contents.