### PR TITLE
Pass all non-default flags

### DIFF
--- a/workers/run.go
+++ b/workers/run.go
@@ -187,7 +187,7 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 
 func passthrough(fs *pflag.FlagSet, prefix string) (flags []string) {
 	fs.VisitAll(func(f *pflag.Flag) {
-		if f.DefValue == f.Value.String() {
+		if !f.Changed {
 			return
 		}
 		flags = append(flags, fmt.Sprintf("--%s=%s",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixed a bug where explicitly set flags were not passed to the worker.

Before
```
% go run ./cmd run-worker --scenario workflow_on_many_task_queues --language go --run-id test --namespace test
2025-10-31T18:17:23.442-0700	INFO	workers/run.go:146	Starting worker with command: [./program --task-queue omes-test]
```

After
```
go run ./cmd run-worker --scenario workflow_on_many_task_queues --language go --run-id test --namespace test
2025-10-31T18:17:42.389-0700	INFO	workers/run.go:146	Starting worker with command: [./program --task-queue omes-test --namespace=test]
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
