### PR TITLE
Fix Go worker autoscale behavior

### DIFF
--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -56,6 +56,8 @@ func (a *App) Run(cmd *cobra.Command, args []string) {
 func makePollerBehavior(simple, auto int) worker.PollerBehavior {
 	if auto > 0 {
 		return worker.NewPollerBehaviorAutoscaling(worker.PollerBehaviorAutoscalingOptions{
+			// TODO: remove InitialNumberOfPollers after https://github.com/temporalio/sdk-go/pull/2105
+			InitialNumberOfPollers: auto,
 			MaximumNumberOfPollers: auto,
 		})
 	}


### PR DESCRIPTION
## What was changed
Set InitialNumberOfPollers in Go PollerBehaviorAutoscalingOptions to work around https://github.com/temporalio/sdk-go/pull/2105.

## Why?
Be able to autoscale pollers.
