### PR TITLE
Wait for ExecuteChildWorkflowAction to complete by default

### DIFF
--- a/loadgen/kitchen_sink_executor_test.go
+++ b/loadgen/kitchen_sink_executor_test.go
@@ -144,20 +144,21 @@ func TestKitchenSink(t *testing.T) {
 									WorkflowType: "kitchenSink",
 									Input: []*common.Payload{
 										ConvertToPayload(&WorkflowInput{
-											InitialActions: ListActionSet(NewTimerAction(1 * time.Millisecond)),
+											InitialActions: ListActionSet(NewEmptyReturnResultAction()),
 										})},
-									AwaitableChoice: &AwaitableChoice{
-										Condition: &AwaitableChoice_Abandon{
-											Abandon: &emptypb.Empty{},
-										},
-									},
 								},
 							},
 						}),
 				},
 			},
 			historyMatcher: PartialHistoryMatcher(`
-				StartChildWorkflowExecutionInitiated {"workflowId":"my-child"}`),
+				StartChildWorkflowExecutionInitiated {"workflowId":"my-child"}
+				ChildWorkflowExecutionStarted
+				WorkflowTaskScheduled
+				WorkflowTaskStarted
+				WorkflowTaskCompleted
+				ChildWorkflowExecutionCompleted
+			`),
 		},
 		{
 			name: "ExecActivity/Client/Signal/DoActions",

--- a/workers/dotnet/Temporalio.Omes/KitchenSinkWorkflow.cs
+++ b/workers/dotnet/Temporalio.Omes/KitchenSinkWorkflow.cs
@@ -319,7 +319,7 @@ public class KitchenSinkWorkflow
             }
             else
             {
-                await awaitableTask;
+                await afterCompletedFn(awaitableTask);
             }
         }
         catch (Exception e) when (TemporalException.IsCanceledException(e))

--- a/workers/python/kitchen_sink.py
+++ b/workers/python/kitchen_sink.py
@@ -305,7 +305,7 @@ async def handle_awaitable_choice(
             task.cancel()
             did_cancel = True
         else:
-            await task
+            await after_completed_fn(task)
     except asyncio.CancelledError:
         if not did_cancel:
             raise

--- a/workers/typescript/src/workflows/kitchen_sink.ts
+++ b/workers/typescript/src/workflows/kitchen_sink.ts
@@ -118,7 +118,7 @@ export async function kitchenSink(input: WorkflowInput | undefined): Promise<IPa
         await afterCompleted(cancellablePromise);
         cancelScope.cancel();
       } else {
-        await cancellablePromise;
+        await afterCompleted(cancellablePromise);
       }
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Make .NET, Python and TS kitchensink workflows wait for child workflow execution completion.

Go and Java already do the right thing.

## Why?
<!-- Tell your future self why have you made these changes -->

The default wait `AwaitableChoice` policy is `waitFinish`, but these impls only wait for the start, not completion.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
