### PR TITLE
fix: Worker arguments contains 'worker-' prefix

### DIFF
--- a/workers/run.go
+++ b/workers/run.go
@@ -127,8 +127,8 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 	}
 	args = append(args, passthrough(r.ClientOptions.FlagSet(), "")...)
 	args = append(args, passthrough(r.LoggingOptions.FlagSet(), "")...)
-	args = append(args, passthrough(r.MetricsOptions.FlagSet("worker-"), "worker-")...)
-	args = append(args, passthrough(r.WorkerOptions.FlagSet(), "worker-")...)
+	args = append(args, passthrough(r.MetricsOptions.FlagSet("worker-"), "")...)
+	args = append(args, passthrough(r.WorkerOptions.FlagSet(), "")...)
 
 	cmd, err := prog.NewCommand(context.Background(), args...)
 	if err != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The parameters passed to the golang worker were wrong and now they are correct

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/omes/issues/279

2. How was this tested:
I've tested the change executing KEDA e2e tests with this version and it runs as expected
```bash
2026-01-10T13:24:07.823Z	INFO	workers/run.go:146	Starting worker with command: [./program --task-queue omes-test --server-address=temporal-temporal-test.temporal-test-ns.svc.cluster.local:7233 --worker-build-id=1.1.1]
2026-01-10T13:24:07.840Z	INFO	clioptions/client.go:128	Client connected to temporal-temporal-test.temporal-test-ns.svc.cluster.local:7233, namespace: default
2026-01-10T13:24:07.903Z	INFO	internal/internal_worker.go:1322	Started Worker	{"Namespace": "default", "TaskQueue": "omes-test", "WorkerID": "14@temporal-test-59fb68ccd5-9fgkh@", "BuildID": "1.1.1"}
```

3. Any docs updates needed?
No
