### PR TITLE
remove worker- prefix for build-id worker flag

### DIFF
--- a/cmd/clioptions/worker.go
+++ b/cmd/clioptions/worker.go
@@ -25,7 +25,7 @@ func (m *WorkerOptions) FlagSet() *pflag.FlagSet {
 		return m.fs
 	}
 	m.fs = pflag.NewFlagSet("worker_options", pflag.ExitOnError)
-	m.fs.StringVar(&m.BuildID, "worker-build-id", "", "Build ID")
+	m.fs.StringVar(&m.BuildID, "build-id", "", "Build ID")
 	m.fs.IntVar(&m.MaxConcurrentActivityPollers, "worker-max-concurrent-activity-pollers", 0, "Max concurrent activity pollers")
 	m.fs.IntVar(&m.MaxConcurrentWorkflowPollers, "worker-max-concurrent-workflow-pollers", 0, "Max concurrent workflow pollers")
 	m.fs.IntVar(&m.MaxConcurrentActivities, "worker-max-concurrent-activities", 0, "Max concurrent activities")


### PR DESCRIPTION
## What was changed
DWISOTT - fixes broken worker flag passthrough
