### PR TITLE
Fix incorrect syntax in .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @temporalio/sdk
-* @temporalio/server
+*  @temporalio/server @temporalio/sdk


### PR DESCRIPTION
## What changed

- Rewrite CODEOWNERS rule as a single line, as required per GitHub [CODEOWNERS spec](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax).