### PR TITLE
Add wait after search attribute registration

### DIFF
--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -315,8 +315,8 @@ func (s *ScenarioInfo) RegisterDefaultSearchAttributes(ctx context.Context) erro
 		}
 	} else {
 		// TODO: Alan, remove this after new search attributed mapper change is implemented.
-		s.Logger.Infof("Search attributes registered, waiting 2 minutes for propagation before starting load")
-		time.Sleep(2 * time.Minute)
+		s.Logger.Infof("Search attributes registered, waiting 1 minute for propagation before starting load")
+		time.Sleep(time.Minute)
 	}
 	return nil
 }


### PR DESCRIPTION
## What was changed
Add a wait after registering search attributes.

## Why?
There is a race condition in server's search attribute cache where a newly registered search attribute can be present in frontend but not in history node. This will be fixed in an upcoming change. We will revert this after the fix.

