### PR TITLE
fix: handle nullable WorkflowId in dotnet KitchenSinkWorkflow

### DIFF
--- a/workers/dotnet/Temporalio.Omes/KitchenSinkWorkflow.cs
+++ b/workers/dotnet/Temporalio.Omes/KitchenSinkWorkflow.cs
@@ -520,7 +520,7 @@ public class ClientActivitiesImpl
     public async Task Client(ExecuteActivityAction.Types.ClientActivity clientActivity)
     {
         var activityInfo = ActivityExecutionContext.Current.Info;
-        var workflowId = activityInfo.WorkflowId;
+        var workflowId = activityInfo.WorkflowId ?? throw new InvalidOperationException("Expected non-null workflow ID in client activity");
         var taskQueue = activityInfo.TaskQueue;
 
         var executor = new ClientActionsExecutor(_client, workflowId, taskQueue, _errOnUnimplemented);


### PR DESCRIPTION
## Summary
- SDK PR temporalio/sdk-dotnet#609 (standalone activity support) made `ActivityInfo.WorkflowId` nullable (`string?`)
- Omes dotnet worker has `TreatWarningsAsErrors` enabled, so CS8604 (possible null reference) becomes a hard build error