### PR TITLE
make workflow id nullable

### DIFF
--- a/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
+++ b/workers/dotnet/Temporalio.Omes/ClientActionsExecutor.cs
@@ -16,7 +16,7 @@ public class ClientActionsExecutor
 
     public string? WorkflowId { get; set; }
 
-    public ClientActionsExecutor(ITemporalClient client, string workflowId, string taskQueue, bool errOnUnimplemented = false)
+    public ClientActionsExecutor(ITemporalClient client, string? workflowId, string taskQueue, bool errOnUnimplemented = false)
     {
         _client = client;
         WorkflowId = workflowId;


### PR DESCRIPTION
## What was changed
SDK PR
https://github.com/temporalio/sdk-dotnet/pull/609 (standalone activity support) made ActivityInfo.WorkflowId nullable (string?). The omes .NET worker has `TreatWarningsAsErrors` enabled, so CS8604 (possible null reference) becomes a hard build error.

This causes omes runs that build .NET worker from source to fail.