### PR TITLE
 Declare Docker credentials for reusable image workflow

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -5,6 +5,11 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PAT:
+        required: true
     inputs:
       push-command:
         description: Push command to run (e.g., 'build-push-worker-image' or 'build-push-cli-image')


### PR DESCRIPTION
## What was changed
Declare Docker credentials for reusable image workflow

## Why?
The SDK repositories need to pass DOCKER_SDK_PAT as the Docker password expected by this reusable workflow. GitHub only allows explicit secret mapping when the callee declares the accepted secret names.

2. How was this tested:
Manually triggered this workflow from `sdk-go` : https://github.com/temporalio/sdk-go/actions/runs/26530223238/job/78144597858
