### PR TITLE
Expose devserver ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ mise.toml
 # Ignore Gradle project-specific cache directory
 .gradle
 .devserver/
+.devserver.lock
 
 # Ignore Gradle build output directory
 workers/java/bin

--- a/devserver/config_test.go
+++ b/devserver/config_test.go
@@ -25,6 +25,17 @@ func TestAllocatePorts(t *testing.T) {
 	}
 }
 
+func TestServerPorts(t *testing.T) {
+	ports := newPorts("127.0.0.1", [portCount]int{7233, 7234, 7243, 7235, 7236, 7237, 7238, 7239, 7240})
+	server := &Server{
+		frontend: "127.0.0.1:7233",
+		ports:    ports,
+	}
+
+	require.Equal(t, "127.0.0.1:7233", server.FrontendHostPort())
+	require.Equal(t, ports, server.Ports())
+}
+
 func TestDefaultOutputDirUsesRepoRoot(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module test\n"), 0644))

--- a/devserver/devserver.go
+++ b/devserver/devserver.go
@@ -67,9 +67,40 @@ type PersistenceOptions struct {
 	Driver string
 }
 
+// Ports are the service ports allocated for a running dev server.
+type Ports struct {
+	Host string
+
+	FrontendGRPC       int
+	FrontendMembership int
+	FrontendHTTP       int
+	HistoryGRPC        int
+	HistoryMembership  int
+	MatchingGRPC       int
+	MatchingMembership int
+	WorkerGRPC         int
+	WorkerMembership   int
+}
+
+func newPorts(host string, ports [portCount]int) Ports {
+	return Ports{
+		Host:               host,
+		FrontendGRPC:       ports[portFrontendGRPC],
+		FrontendMembership: ports[portFrontendMembership],
+		FrontendHTTP:       ports[portFrontendHTTP],
+		HistoryGRPC:        ports[portHistoryGRPC],
+		HistoryMembership:  ports[portHistoryMembership],
+		MatchingGRPC:       ports[portMatchingGRPC],
+		MatchingMembership: ports[portMatchingMembership],
+		WorkerGRPC:         ports[portWorkerGRPC],
+		WorkerMembership:   ports[portWorkerMembership],
+	}
+}
+
 // Server is a running Temporal dev server subprocess.
 type Server struct {
 	frontend string
+	ports    Ports
 	logger   *zap.SugaredLogger
 	workDir  string
 	cancel   context.CancelFunc
@@ -117,7 +148,8 @@ func Start(ctx context.Context, opts Options) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("devserver: allocate ports: %w", err)
 	}
-	frontendAddr := net.JoinHostPort(host, strconv.Itoa(ports[portFrontendGRPC]))
+	serverPorts := newPorts(host, ports)
+	frontendAddr := net.JoinHostPort(serverPorts.Host, strconv.Itoa(serverPorts.FrontendGRPC))
 	frontendHTTPAddr := net.JoinHostPort(host, strconv.Itoa(ports[portFrontendHTTP]))
 	dynConfigPath, err := writeDynamicConfig(workDir, frontendHTTPAddr, opts.DynamicConfigValues)
 	if err != nil {
@@ -166,6 +198,7 @@ func Start(ctx context.Context, opts Options) (*Server, error) {
 
 	s := &Server{
 		frontend: frontendAddr,
+		ports:    serverPorts,
 		logger:   opts.Logger,
 		workDir:  workDir,
 		cancel:   cancel,
@@ -184,6 +217,11 @@ func Start(ctx context.Context, opts Options) (*Server, error) {
 // gRPC service.
 func (s *Server) FrontendHostPort() string {
 	return s.frontend
+}
+
+// Ports returns the service ports allocated for the running server.
+func (s *Server) Ports() Ports {
+	return s.ports
 }
 
 // Stop signals the server to terminate and waits for it to exit. The


### PR DESCRIPTION
## What changed

Follow-up to https://github.com/temporalio/omes/pull/348; exposing allocated service ports via `Server.Ports()`.

## Why

Temporal mixedbrain currently has to infer cluster formation from `DescribeCluster` without knowing which ports each Omes devserver allocated. Returning the allocated ports lets that test wait for the specific servers it started.
