### PR TITLE
Add long_idle_workflow scenario

### DIFF
--- a/scenarios/long_idle_workflow.go
+++ b/scenarios/long_idle_workflow.go
@@ -1,0 +1,140 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/common/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+// long_idle_workflow exercises Temporal under fleets of long-lived, mostly
+// idle workflows. Each workflow alternates an idle period (a timer) with an
+// optional burst of activities, repeated `cycles-per-run` times per run, and
+// can chain `continue-as-new-iterations` follow-on runs.
+//
+// What this stresses: history retention for long-lived executions, timer
+// scheduling at low duty cycle, and the workflow fleet's steady-state cost.
+// Total fleet size is controlled by the standard `--max-concurrent` /
+// `--iterations` / `--duration` flags.
+
+const (
+	longIdleIdleDurationFlag            = "idle-duration"
+	longIdleCyclesPerRunFlag            = "cycles-per-run"
+	longIdleActivitiesPerCycleFlag      = "activities-per-cycle"
+	longIdleActivityDurationFlag        = "activity-duration"
+	longIdleContinueAsNewIterationsFlag = "continue-as-new-iterations"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: fmt.Sprintf(
+			"Run long-lived, mostly idle workflows that alternate idle periods with optional activity bursts. "+
+				"Options: '%s' (default 1m), '%s' (default 1), '%s' (default 0), '%s' (default 1s), '%s' (default 0).",
+			longIdleIdleDurationFlag,
+			longIdleCyclesPerRunFlag,
+			longIdleActivitiesPerCycleFlag,
+			longIdleActivityDurationFlag,
+			longIdleContinueAsNewIterationsFlag,
+		),
+		ExecutorFn: func() loadgen.Executor {
+			return loadgen.KitchenSinkExecutor{
+				TestInput: &kitchensink.TestInput{
+					WorkflowInput: &kitchensink.WorkflowInput{
+						InitialActions: []*kitchensink.ActionSet{},
+					},
+				},
+				PrepareTestInput: func(_ context.Context, info loadgen.ScenarioInfo, params *kitchensink.TestInput) error {
+					cfg, err := parseLongIdleConfig(&info)
+					if err != nil {
+						return err
+					}
+					params.WorkflowInput.InitialActions = buildLongIdleActions(cfg, cfg.continueAsNewIterations)
+					return nil
+				},
+			}
+		},
+	})
+}
+
+type longIdleConfig struct {
+	idleDuration            time.Duration
+	cyclesPerRun            int
+	activitiesPerCycle      int
+	activityDuration        time.Duration
+	continueAsNewIterations int
+}
+
+func parseLongIdleConfig(info *loadgen.ScenarioInfo) (*longIdleConfig, error) {
+	cfg := &longIdleConfig{
+		idleDuration:            info.ScenarioOptionDuration(longIdleIdleDurationFlag, time.Minute),
+		cyclesPerRun:            info.ScenarioOptionInt(longIdleCyclesPerRunFlag, 1),
+		activitiesPerCycle:      info.ScenarioOptionInt(longIdleActivitiesPerCycleFlag, 0),
+		activityDuration:        info.ScenarioOptionDuration(longIdleActivityDurationFlag, time.Second),
+		continueAsNewIterations: info.ScenarioOptionInt(longIdleContinueAsNewIterationsFlag, 0),
+	}
+	if cfg.idleDuration <= 0 {
+		return nil, fmt.Errorf("%s must be > 0, got %v", longIdleIdleDurationFlag, cfg.idleDuration)
+	}
+	if cfg.cyclesPerRun <= 0 {
+		return nil, fmt.Errorf("%s must be > 0, got %d", longIdleCyclesPerRunFlag, cfg.cyclesPerRun)
+	}
+	if cfg.activitiesPerCycle < 0 {
+		return nil, fmt.Errorf("%s must be >= 0, got %d", longIdleActivitiesPerCycleFlag, cfg.activitiesPerCycle)
+	}
+	if cfg.activityDuration < 0 {
+		return nil, fmt.Errorf("%s must be >= 0, got %v", longIdleActivityDurationFlag, cfg.activityDuration)
+	}
+	if cfg.continueAsNewIterations < 0 {
+		return nil, fmt.Errorf("%s must be >= 0, got %d", longIdleContinueAsNewIterationsFlag, cfg.continueAsNewIterations)
+	}
+	return cfg, nil
+}
+
+// buildLongIdleActions composes the InitialActions for one workflow run. When
+// remainingCAN > 0 the run ends with a ContinueAsNewAction whose argument is
+// the pre-baked WorkflowInput for the next run; otherwise it ends with a
+// ReturnResult.
+func buildLongIdleActions(cfg *longIdleConfig, remainingCAN int) []*kitchensink.ActionSet {
+	actions := make([]*kitchensink.Action, 0, cfg.cyclesPerRun*(1+cfg.activitiesPerCycle)+1)
+	activityStartToClose := durationpb.New(cfg.activityDuration + time.Minute)
+	for range cfg.cyclesPerRun {
+		actions = append(actions, kitchensink.NewTimerAction(cfg.idleDuration))
+		for range cfg.activitiesPerCycle {
+			actions = append(actions, &kitchensink.Action{
+				Variant: &kitchensink.Action_ExecActivity{
+					ExecActivity: &kitchensink.ExecuteActivityAction{
+						ActivityType: &kitchensink.ExecuteActivityAction_Delay{
+							Delay: durationpb.New(cfg.activityDuration),
+						},
+						StartToCloseTimeout: activityStartToClose,
+						Locality: &kitchensink.ExecuteActivityAction_Remote{
+							Remote: &kitchensink.RemoteActivityOptions{},
+						},
+					},
+				},
+			})
+		}
+	}
+
+	if remainingCAN > 0 {
+		nextInput := &kitchensink.WorkflowInput{
+			InitialActions: buildLongIdleActions(cfg, remainingCAN-1),
+		}
+		actions = append(actions, &kitchensink.Action{
+			Variant: &kitchensink.Action_ContinueAsNew{
+				ContinueAsNew: &kitchensink.ContinueAsNewAction{
+					Arguments: []*common.Payload{kitchensink.ConvertToPayload(nextInput)},
+				},
+			},
+		})
+	} else {
+		actions = append(actions, kitchensink.NewEmptyReturnResultAction())
+	}
+
+	return []*kitchensink.ActionSet{{Actions: actions}}
+}

--- a/scenarios/long_idle_workflow_test.go
+++ b/scenarios/long_idle_workflow_test.go
@@ -1,0 +1,146 @@
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/omes/cmd/clioptions"
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/workers"
+)
+
+func TestLongIdleWorkflow_ParseConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults", func(t *testing.T) {
+		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{}}
+		cfg, err := parseLongIdleConfig(info)
+		require.NoError(t, err)
+		require.Equal(t, time.Minute, cfg.idleDuration)
+		require.Equal(t, 1, cfg.cyclesPerRun)
+		require.Equal(t, 0, cfg.activitiesPerCycle)
+		require.Equal(t, time.Second, cfg.activityDuration)
+		require.Equal(t, 0, cfg.continueAsNewIterations)
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{
+			longIdleIdleDurationFlag:            "5ms",
+			longIdleCyclesPerRunFlag:            "3",
+			longIdleActivitiesPerCycleFlag:      "2",
+			longIdleActivityDurationFlag:        "250ms",
+			longIdleContinueAsNewIterationsFlag: "4",
+		}}
+		cfg, err := parseLongIdleConfig(info)
+		require.NoError(t, err)
+		require.Equal(t, 5*time.Millisecond, cfg.idleDuration)
+		require.Equal(t, 3, cfg.cyclesPerRun)
+		require.Equal(t, 2, cfg.activitiesPerCycle)
+		require.Equal(t, 250*time.Millisecond, cfg.activityDuration)
+		require.Equal(t, 4, cfg.continueAsNewIterations)
+	})
+
+	t.Run("rejects invalid values", func(t *testing.T) {
+		cases := map[string]map[string]string{
+			"non-positive idle-duration": {longIdleIdleDurationFlag: "0"},
+			"non-positive cycles":        {longIdleCyclesPerRunFlag: "0"},
+			"negative activities":        {longIdleActivitiesPerCycleFlag: "-1"},
+			"negative activity-duration": {longIdleActivityDurationFlag: "-1s"},
+			"negative CAN iterations":    {longIdleContinueAsNewIterationsFlag: "-1"},
+		}
+		for name, opts := range cases {
+			t.Run(name, func(t *testing.T) {
+				_, err := parseLongIdleConfig(&loadgen.ScenarioInfo{ScenarioOptions: opts})
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestLongIdleWorkflow_BuildActions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no continue-as-new ends with return result", func(t *testing.T) {
+		cfg := &longIdleConfig{
+			idleDuration:       time.Millisecond,
+			cyclesPerRun:       2,
+			activitiesPerCycle: 1,
+			activityDuration:   time.Millisecond,
+		}
+		sets := buildLongIdleActions(cfg, 0)
+		require.Len(t, sets, 1)
+		actions := sets[0].Actions
+		// 2 cycles * (1 timer + 1 activity) + 1 terminal return.
+		require.Len(t, actions, 5)
+		require.NotNil(t, actions[0].GetTimer())
+		require.NotNil(t, actions[1].GetExecActivity())
+		require.NotNil(t, actions[2].GetTimer())
+		require.NotNil(t, actions[3].GetExecActivity())
+		require.NotNil(t, actions[4].GetReturnResult())
+	})
+
+	t.Run("continue-as-new chains a follow-on run", func(t *testing.T) {
+		cfg := &longIdleConfig{
+			idleDuration:       time.Millisecond,
+			cyclesPerRun:       1,
+			activitiesPerCycle: 0,
+			activityDuration:   time.Millisecond,
+		}
+		sets := buildLongIdleActions(cfg, 1)
+		require.Len(t, sets, 1)
+		actions := sets[0].Actions
+		// 1 timer + 1 continue-as-new terminal action.
+		require.Len(t, actions, 2)
+		require.NotNil(t, actions[0].GetTimer())
+		can := actions[len(actions)-1].GetContinueAsNew()
+		require.NotNil(t, can, "last action should continue-as-new when iterations remain")
+		require.Len(t, can.GetArguments(), 1, "continue-as-new carries the next run's input")
+	})
+}
+
+func TestLongIdleWorkflow(t *testing.T) {
+	t.Parallel()
+
+	env := workers.SetupTestEnvironment(t,
+		workers.WithExecutorTimeout(1*time.Minute))
+
+	baseRunID := fmt.Sprintf("liw-%d", time.Now().Unix())
+
+	t.Run("idle cycles with activity burst", func(t *testing.T) {
+		executor := loadgen.GetScenario("long_idle_workflow").ExecutorFn()
+
+		_, err := env.RunExecutorTest(t, executor, loadgen.ScenarioInfo{
+			RunID: baseRunID + "-c",
+			Configuration: loadgen.RunConfiguration{
+				Iterations:    3,
+				MaxConcurrent: 3,
+			},
+			ScenarioOptions: map[string]string{
+				longIdleIdleDurationFlag:       "1ms",
+				longIdleCyclesPerRunFlag:       "2",
+				longIdleActivitiesPerCycleFlag: "1",
+				longIdleActivityDurationFlag:   "1ms",
+			},
+		}, clioptions.LangGo)
+		require.NoError(t, err)
+	})
+
+	t.Run("continue-as-new chain", func(t *testing.T) {
+		executor := loadgen.GetScenario("long_idle_workflow").ExecutorFn()
+
+		_, err := env.RunExecutorTest(t, executor, loadgen.ScenarioInfo{
+			RunID: baseRunID + "-can",
+			Configuration: loadgen.RunConfiguration{
+				Iterations:    2,
+				MaxConcurrent: 2,
+			},
+			ScenarioOptions: map[string]string{
+				longIdleIdleDurationFlag:            "1ms",
+				longIdleContinueAsNewIterationsFlag: "2",
+			},
+		}, clioptions.LangGo)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Stacked PRs:
 * #369
 * #368
 * __->__#367


--- --- ---

### Add long_idle_workflow scenario


Exercises long-lived, mostly idle workflows with optional periodic activity
bursts and continue-as-new chains. Stresses history retention, idle timer
scheduling, and steady-state fleet cost.
