### PR TITLE
Restructure cmd/ into conventional cmd/omes + cmd/dev layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           timeout 30 bash -c 'until nc -z 127.0.0.1 10233; do sleep 1; done' || (echo "Server failed to start" && exit 1)
       - name: Start ${{ matrix.sdk }} worker image
         run: |
-          go run ./cmd run-scenario \
+          go run ./cmd/omes run-scenario \
             --scenario workflow_with_single_noop_activity \
             --log-level debug \
             --server-address 127.0.0.1:10233 \
@@ -163,7 +163,7 @@ jobs:
       - name: Smoke test throughput_stress to confirm build is usable against ${{ matrix.sdk }} worker
         timeout-minutes: 10
         run: |
-          go run ./cmd run-scenario \
+          go run ./cmd/omes run-scenario \
             --scenario throughput_stress \
             --log-level debug \
             --server-address 127.0.0.1:10233 \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Omes includes a process metrics sidecar - a Go-based HTTP server that monitors C
 
 **Example:**
 ```sh
-go run ./cmd run-worker --language python --run-id my-run \
+go run ./cmd/omes run-worker --language python --run-id my-run \
     --worker-process-metrics-address :9091 \
     --worker-metrics-version-tag v1.24.0
 ```
@@ -125,7 +125,7 @@ You can do that like follows. If you want an embedded server rather than one you
 pass `--embedded-server`.
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go
+go run ./cmd/omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go
 ```
 
 Notes:
@@ -136,7 +136,7 @@ Notes:
 ### Run a worker for a specific language SDK
 
 ```sh
-go run ./cmd run-worker --run-id local-test-run --language go
+go run ./cmd/omes run-worker --run-id local-test-run --language go
 ```
 
 Notes:
@@ -149,7 +149,7 @@ Notes:
 ### Run a test scenario
 
 ```sh
-go run ./cmd run-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
+go run ./cmd/omes run-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
 ```
 
 Notes:
@@ -163,7 +163,7 @@ Notes:
 ### Cleanup after scenario run
 
 ```sh
-go run ./cmd cleanup-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
+go run ./cmd/omes cleanup-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
 ```
 
 ### Running a specific version of the SDK
@@ -173,7 +173,7 @@ a version number like `v1.24.0` or you can also pass a local path to use a local
 This is useful while testing unreleased or in-development versions of the SDK.
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go --version /path/to/go-sdk
+go run ./cmd/omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go --version /path/to/go-sdk
 ```
 
 ### Building and publishing docker images
@@ -244,7 +244,7 @@ the harness to drive load. Consequently, it too needs to build your project + ha
 To run a project:
 1) Run your project worker:
 ```sh
-go run ./cmd run-worker \
+go run ./cmd/omes run-worker \
   --language python \
   --project-name helloworld \
   --run-id local-project-test \
@@ -255,7 +255,7 @@ Make sure to point your `server-address` to a running Temporal server. Alternati
 
 2) Run the project scenario
 ```sh
-go run ./cmd run-scenario \
+go run ./cmd/omes run-scenario \
   --scenario project \
   --iterations 1 \
   --server-address <your server address> \
@@ -267,7 +267,7 @@ go run ./cmd run-scenario \
 For local all-in-one development, run the worker and scenario together:
 
 ```sh
-go run ./cmd run-scenario-with-worker \
+go run ./cmd/omes run-scenario-with-worker \
   --scenario project \
   --iterations 1 \
   --language python \
@@ -323,7 +323,7 @@ The configuration is done via a JSON file, which is passed to the scenario with 
 
 ```
 echo '{"count":{"type":"fixed","value":5},"groups":{"high":{"weight":2,"sleepDuration":{"type":"uniform","min":"2s","max":"4s"}},"low":{"weight":3,"sleepDuration":{"type":"discrete","weights":{"5s":3,"10s":1}}}}}' > sleep.json
-go run ./cmd run-scenario-with-worker --scenario throughput_stress --language go --option sleep-activity-json=@sleep.json --run-id default-run-id
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option sleep-activity-json=@sleep.json --run-id default-run-id
 ```
 
 This runs 5 sleep activities per iteration, where "high" has a weight of 2 and sleeps for a random duration between 2-4s,
@@ -345,7 +345,7 @@ The throughput_stress scenario can generate Nexus load if the scenario is starte
 1. Start the scenario with the given run-id:
 
   ```
-  go run ./cmd run-scenario-with-worker --scenario throughput_stress --language go --option nexus-endpoint=my-nexus-endpoint --run-id default-run-id
+  go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option nexus-endpoint=my-nexus-endpoint --run-id default-run-id
   ```
 
 ### Fuzzer
@@ -358,26 +358,26 @@ run by a client inside the scenario executor.
 You can run the fuzzer with new random actions like so:
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs
+go run ./cmd/omes run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs
 ```
 
 The fuzzer automatically creates a Nexus endpoint and generates Nexus operations. To use an existing endpoint instead:
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario fuzzer --iterations 1 --language go --option nexus-endpoint=my-endpoint
+go run ./cmd/omes run-scenario-with-worker --scenario fuzzer --iterations 1 --language go --option nexus-endpoint=my-endpoint
 ```
 
 By default, the scenario will spit out a `last_fuzz_run.proto` binary file containing the generated
 actions. To re-run the same set of actions, you can pass in such a file like so:
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs --option input-file=last_fuzz_run.proto
+go run ./cmd/omes run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs --option input-file=last_fuzz_run.proto
 ```
 
 Or you can run with a specific seed (seeds are printed at the start of the scenario):
 
 ```sh
-go run ./cmd run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs --option seed=131962944538087455
+go run ./cmd/omes run-scenario-with-worker --scenario fuzzer --iterations 1 --language cs --option seed=131962944538087455
 ```
 
 However, the fuzzer is also sensitive to its configuration, and thus the seed will only produce

--- a/cmd/dev/test.go
+++ b/cmd/dev/test.go
@@ -179,7 +179,7 @@ func runJavaHarnessTests(ctx context.Context, repoDir string) error {
 
 func testWorkerLocally(ctx context.Context, repoDir, language, sdkVersion string) error {
 	args := []string{
-		"go", "run", "./cmd", "run-scenario-with-worker",
+		"go", "run", "./cmd/omes", "run-scenario-with-worker",
 		"--scenario", testScenario,
 		"--log-level", "debug",
 		"--language", language,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"github.com/temporalio/omes/cmd/cli"
-)
-
-func main() {
-	cli.Main()
-}

--- a/cmd/omes/cleanup_scenario.go
+++ b/cmd/omes/cleanup_scenario.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"context"

--- a/cmd/omes/envfallback.go
+++ b/cmd/omes/envfallback.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"

--- a/cmd/omes/list_scenarios.go
+++ b/cmd/omes/list_scenarios.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"

--- a/cmd/omes/main.go
+++ b/cmd/omes/main.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	_ "github.com/temporalio/omes/scenarios/project" // Register project scenario
 )
 
-func Main() {
+func main() {
 	var rootCmd = &cobra.Command{
 		Use:   "omes",
 		Short: "A load generator for Temporal",

--- a/cmd/omes/prepare_worker.go
+++ b/cmd/omes/prepare_worker.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"context"

--- a/cmd/omes/run_scenario_with_worker.go
+++ b/cmd/omes/run_scenario_with_worker.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"context"

--- a/cmd/omes/run_worker.go
+++ b/cmd/omes/run_worker.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"context"

--- a/cmd/omes/util.go
+++ b/cmd/omes/util.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"crypto/rand"

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -37,7 +37,7 @@ COPY workers ./workers/
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 # Install protoc-gen-go for kitchen-sink-gen build
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0

--- a/dockerfiles/dotnet.Dockerfile
+++ b/dockerfiles/dotnet.Dockerfile
@@ -36,7 +36,7 @@ COPY workers/proto/harness ./workers/proto/harness
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -17,7 +17,7 @@ COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -28,7 +28,7 @@ COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -38,7 +38,7 @@ COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 ARG PROJECT_NAME=""

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -22,7 +22,7 @@ COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -33,7 +33,7 @@ COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum versions.env ./
 
 # Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd
+RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 


### PR DESCRIPTION
Stacked PRs:
 * #378
 * #377
 * #376
 * #375
 * #374
 * #373
 * #372
 * __->__#371
 * #370


--- --- ---

### Restructure cmd/ into conventional cmd/omes + cmd/dev layout


User-facing change: the CLI is now invoked as `./cmd/omes` (previously
`./cmd`) -- e.g. `go run ./cmd/omes run-scenario ...`. README, CI, the worker
Dockerfiles, and cmd/dev/test.go are updated; any external scripts that call
`go run ./cmd` must switch to `./cmd/omes`.

Per Go convention, cmd/ is a container of binary subdirectories, each named
after the binary it produces. Previously the omes binary's main lived at the
cmd/ root (built via ./cmd, producing a binary named 'cmd' that Docker had to
rename with -o), with its implementation factored into a separate package cli
plus a one-line cmd/main.go shim purely to keep the cmd/ root tidy.

Move the implementation into cmd/omes as package main (func main), delete the
cli package indirection and the shim. The omes binary now builds via
./cmd/omes and is named 'omes' automatically.

Testing: `go build ./...` passes; `go run ./cmd/omes --help` and
`go run ./cmd/omes list-scenarios` work.