### PR TITLE
Move workers orchestration package to internal/workerctl

### DIFF
--- a/cmd/omes/prepare_worker.go
+++ b/cmd/omes/prepare_worker.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/temporalio/omes/clioptions"
-	"github.com/temporalio/omes/workers"
+	"github.com/temporalio/omes/internal/workerctl"
 )
 
 func prepareWorkerCmd() *cobra.Command {
@@ -22,7 +22,7 @@ func prepareWorkerCmd() *cobra.Command {
 			if err != nil {
 				b.Logger.Fatal(fmt.Errorf("failed to get root directory: %w", err))
 			}
-			baseDir := workers.BaseDir(repoDir, b.SdkOptions.Language)
+			baseDir := workerctl.BaseDir(repoDir, b.SdkOptions.Language)
 			if _, err := b.Build(cmd.Context(), baseDir); err != nil {
 				b.Logger.Fatal(err)
 			}
@@ -35,7 +35,7 @@ func prepareWorkerCmd() *cobra.Command {
 }
 
 type workerBuilder struct {
-	workers.Builder
+	workerctl.Builder
 	loggingOptions clioptions.LoggingOptions
 }
 

--- a/cmd/omes/run_scenario_with_worker.go
+++ b/cmd/omes/run_scenario_with_worker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/temporalio/omes/clioptions"
-	"github.com/temporalio/omes/workers"
+	"github.com/temporalio/omes/internal/workerctl"
 )
 
 func runScenarioWithWorkerCmd() *cobra.Command {
@@ -61,7 +61,7 @@ func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 			workerErrCh <- fmt.Errorf("failed to get root directory: %w", err)
 			return
 		}
-		workerErrCh <- r.Run(ctx, workers.BaseDir(repoDir, r.SdkOptions.Language))
+		workerErrCh <- r.Run(ctx, workerctl.BaseDir(repoDir, r.SdkOptions.Language))
 	}()
 	select {
 	case err := <-workerErrCh:

--- a/cmd/omes/run_worker.go
+++ b/cmd/omes/run_worker.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/temporalio/omes/internal/workerctl"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func runWorkerCmd() *cobra.Command {
@@ -41,7 +41,7 @@ func runWorkerCmd() *cobra.Command {
 }
 
 type workerRunner struct {
-	workers.Runner
+	workerctl.Runner
 	builder workerBuilder
 }
 
@@ -73,7 +73,7 @@ func (r *workerRunner) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get root directory: %w", err)
 	}
-	return r.Run(ctx, workers.BaseDir(repoDir, r.SdkOptions.Language))
+	return r.Run(ctx, workerctl.BaseDir(repoDir, r.SdkOptions.Language))
 }
 
 func withCancelOnInterrupt(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -31,6 +31,7 @@ COPY clioptions ./clioptions
 COPY loadgen ./loadgen
 COPY metrics ./metrics
 COPY scenarios ./scenarios
+COPY internal ./internal
 COPY devserver ./devserver
 COPY versions ./versions
 COPY workers ./workers/

--- a/dockerfiles/dotnet.Dockerfile
+++ b/dockerfiles/dotnet.Dockerfile
@@ -30,7 +30,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY workers/proto/harness ./workers/proto/harness
 COPY go.mod go.sum ./

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -12,7 +12,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 

--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -23,7 +23,7 @@ COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -33,7 +33,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -17,7 +17,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -28,7 +28,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
-COPY workers/*.go ./workers/
+COPY internal ./internal
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum versions.env ./
 

--- a/internal/workerctl/build.go
+++ b/internal/workerctl/build.go
@@ -1,4 +1,4 @@
-package workers
+package workerctl
 
 import (
 	"context"

--- a/internal/workerctl/log.go
+++ b/internal/workerctl/log.go
@@ -1,4 +1,4 @@
-package workers
+package workerctl
 
 import (
 	"bytes"

--- a/internal/workerctl/run.go
+++ b/internal/workerctl/run.go
@@ -1,4 +1,4 @@
-package workers
+package workerctl
 
 import (
 	"context"

--- a/internal/workertest/env.go
+++ b/internal/workertest/env.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
 	"github.com/temporalio/omes/devserver"
+	"github.com/temporalio/omes/internal/workerctl"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/versions"
-	"github.com/temporalio/omes/workers"
 	"go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/sdk/client"
@@ -108,7 +108,7 @@ func SetupTestEnvironment(t *testing.T, opts ...TestEnvOption) *TestEnvironment 
 		Ref:                 serverRef,
 		Namespace:           testNamespace,
 		DynamicConfigValues: cfg.dynamicConfig,
-		Output:              workers.NewLogWriter(serverLogger),
+		Output:              workerctl.NewLogWriter(serverLogger),
 		Logger:              serverLogger,
 	})
 	require.NoError(t, err, "Failed to start dev server")

--- a/internal/workertest/workerpool.go
+++ b/internal/workertest/workerpool.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workerctl"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +53,7 @@ func (w *workerPool) ensureWorkerBuilt(
 	w.mutex.Unlock()
 
 	once.Do(func() {
-		baseDir := workers.BaseDir(w.env.repoDir, sdk)
+		baseDir := workerctl.BaseDir(w.env.repoDir, sdk)
 		buildDir := filepath.Join(baseDir, w.env.buildDirName())
 
 		w.mutex.Lock()
@@ -64,7 +64,7 @@ func (w *workerPool) ensureWorkerBuilt(
 		})
 		w.mutex.Unlock()
 
-		builder := workers.Builder{
+		builder := workerctl.Builder{
 			DirName:    w.env.buildDirName(),
 			SdkOptions: clioptions.SdkOptions{Language: sdk},
 			Logger:     logger.Named(fmt.Sprintf("%s-builder", sdk)),
@@ -98,9 +98,9 @@ func (w *workerPool) startWorker(
 
 	go func() {
 		defer close(workerDone)
-		baseDir := workers.BaseDir(w.env.repoDir, sdk)
-		runner := &workers.Runner{
-			Builder: workers.Builder{
+		baseDir := workerctl.BaseDir(w.env.repoDir, sdk)
+		runner := &workerctl.Runner{
+			Builder: workerctl.Builder{
 				DirName:    w.env.buildDirName(),
 				SdkOptions: clioptions.SdkOptions{Language: sdk},
 				Logger:     logger.Named(fmt.Sprintf("%s-worker-builder", sdk)),

--- a/scenarios/project/build.go
+++ b/scenarios/project/build.go
@@ -6,20 +6,20 @@ import (
 
 	"github.com/temporalio/features/sdkbuild"
 	"github.com/temporalio/omes/clioptions"
-	"github.com/temporalio/omes/workers"
+	"github.com/temporalio/omes/internal/workerctl"
 	"go.uber.org/zap"
 )
 
 // buildProject builds a project test program for the given language.
 func buildProject(ctx context.Context, repoRoot string, p projectScenarioOptions, logger *zap.SugaredLogger) (sdkbuild.Program, error) {
-	b := workers.Builder{
+	b := workerctl.Builder{
 		DirName:     fmt.Sprintf("project-build-runner-%s", p.projectName),
 		SdkOptions:  p.sdkOpts,
 		ProjectName: p.projectName,
 		Logger:      logger,
 	}
 
-	baseDir := workers.BaseDir(repoRoot, p.sdkOpts.Language)
+	baseDir := workerctl.BaseDir(repoRoot, p.sdkOpts.Language)
 	switch p.sdkOpts.Language {
 	case clioptions.LangPython:
 		return b.Build(ctx, baseDir)

--- a/scenarios/project/project_test.go
+++ b/scenarios/project/project_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/temporalio/features/sdkbuild"
 	"github.com/temporalio/omes/clioptions"
 	"github.com/temporalio/omes/devserver"
+	"github.com/temporalio/omes/internal/workerctl"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/versions"
-	"github.com/temporalio/omes/workers"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.uber.org/zap/zaptest"
 )
@@ -194,7 +194,7 @@ func startProjectWorker(
 	t.Helper()
 	require.NotEmpty(t, opts.projectName)
 
-	builder := workers.Builder{
+	builder := workerctl.Builder{
 		ProjectName: opts.projectName,
 		SdkOptions:  opts.sdkOpts,
 		Logger:      info.Logger.Named(fmt.Sprintf("%s-worker-builder", opts.sdkOpts.Language)),
@@ -206,7 +206,7 @@ func startProjectWorker(
 		builder.DirName = filepath.Base(prog.Dir())
 	}
 
-	runner := &workers.Runner{
+	runner := &workerctl.Runner{
 		Builder:                  builder,
 		TaskQueueName:            loadgen.TaskQueueForRun(info.RunID),
 		GracefulShutdownDuration: 5 * time.Second,
@@ -224,7 +224,7 @@ func startProjectWorker(
 	workerErrCh := make(chan error, 1)
 	go func() {
 		defer close(workerErrCh)
-		workerErrCh <- runner.Run(ctx, workers.BaseDir(info.RootPath, opts.sdkOpts.Language))
+		workerErrCh <- runner.Run(ctx, workerctl.BaseDir(info.RootPath, opts.sdkOpts.Language))
 	}()
 	return workerErrCh
 }


### PR DESCRIPTION
Stacked PRs:
 * #378
 * #377
 * #376
 * #375
 * #374
 * __->__#373
 * #372
 * #371
 * #370


--- --- ---

### Move workers orchestration package to internal/workerctl


The root workers package (build.go, log.go, run.go) is application logic for
building and running worker subprocesses, with no consumer outside the root
module. Application code that isn't part of a public API belongs under
internal/, where the import boundary is compiler-enforced. It also could not
stay at workers/, since that directory is the documented polyglot
worker-source home (workers/<lang>/...).

Move it to internal/workerctl (package workerctl) and update importers. The
workers/ directory now contains only the per-language worker source trees.

Testing: `go build ./...` and `go vet ./...` pass for both modules.