### PR TITLE
Narrow cli.Dockerfile's workers COPY to what's actually needed

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -32,7 +32,10 @@ COPY loadgen ./loadgen
 COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers ./workers/
+# kitchen-sink-gen needs the proto tree; the CLI build needs the harness/api
+# replace target. The rest of workers/ (language workers) is not needed here.
+COPY workers/proto ./workers/proto
+COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI


### PR DESCRIPTION
Stacked PRs:
 * #378
 * #377
 * __->__#376
 * #375
 * #374
 * #373
 * #372
 * #371
 * #370


--- --- ---

### Narrow cli.Dockerfile's workers COPY to what's actually needed


The CLI image copied the entire workers/ tree (all language worker sources)
but only needs workers/proto (for the kitchen-sink-gen protoc build) and
workers/go/harness/api (the go.mod replace target for the ./cmd/omes build).
Copy just those two, trimming the build context and making the dependency
explicit. Verified by building the CLI image with podman.