### PR TITLE
Extract workers test helpers into internal/workertest

### DIFF
--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -12,6 +12,7 @@ COPY scenarios ./scenarios
 COPY metrics ./metrics
 COPY devserver ./devserver
 COPY versions ./versions
+COPY internal ./internal
 COPY workers/*.go ./workers/
 COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./

--- a/internal/workertest/env.go
+++ b/internal/workertest/env.go
@@ -1,4 +1,4 @@
-package workers
+package workertest
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/temporalio/omes/devserver"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/versions"
+	"github.com/temporalio/omes/workers"
 	"go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/sdk/client"
@@ -107,7 +108,7 @@ func SetupTestEnvironment(t *testing.T, opts ...TestEnvOption) *TestEnvironment 
 		Ref:                 serverRef,
 		Namespace:           testNamespace,
 		DynamicConfigValues: cfg.dynamicConfig,
-		Output:              &logWriter{logger: serverLogger},
+		Output:              workers.NewLogWriter(serverLogger),
 		Logger:              serverLogger,
 	})
 	require.NoError(t, err, "Failed to start dev server")

--- a/internal/workertest/historyrequire.go
+++ b/internal/workertest/historyrequire.go
@@ -1,4 +1,4 @@
-package workers
+package workertest
 
 import (
 	"encoding/json"

--- a/internal/workertest/workerpool.go
+++ b/internal/workertest/workerpool.go
@@ -1,4 +1,4 @@
-package workers
+package workertest
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/temporalio/omes/clioptions"
 	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/workers"
 	"go.uber.org/zap"
 )
 
@@ -52,7 +53,7 @@ func (w *workerPool) ensureWorkerBuilt(
 	w.mutex.Unlock()
 
 	once.Do(func() {
-		baseDir := BaseDir(w.env.repoDir, sdk)
+		baseDir := workers.BaseDir(w.env.repoDir, sdk)
 		buildDir := filepath.Join(baseDir, w.env.buildDirName())
 
 		w.mutex.Lock()
@@ -63,7 +64,7 @@ func (w *workerPool) ensureWorkerBuilt(
 		})
 		w.mutex.Unlock()
 
-		builder := Builder{
+		builder := workers.Builder{
 			DirName:    w.env.buildDirName(),
 			SdkOptions: clioptions.SdkOptions{Language: sdk},
 			Logger:     logger.Named(fmt.Sprintf("%s-builder", sdk)),
@@ -97,9 +98,9 @@ func (w *workerPool) startWorker(
 
 	go func() {
 		defer close(workerDone)
-		baseDir := BaseDir(w.env.repoDir, sdk)
-		runner := &Runner{
-			Builder: Builder{
+		baseDir := workers.BaseDir(w.env.repoDir, sdk)
+		runner := &workers.Runner{
+			Builder: workers.Builder{
 				DirName:    w.env.buildDirName(),
 				SdkOptions: clioptions.SdkOptions{Language: sdk},
 				Logger:     logger.Named(fmt.Sprintf("%s-worker-builder", sdk)),

--- a/loadgen/kitchen_sink_executor_test.go
+++ b/loadgen/kitchen_sink_executor_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	. "github.com/temporalio/omes/internal/workertest"
 	. "github.com/temporalio/omes/loadgen"
 	. "github.com/temporalio/omes/loadgen/kitchensink"
-	. "github.com/temporalio/omes/workers"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"

--- a/scenarios/ebb_and_flow_test.go
+++ b/scenarios/ebb_and_flow_test.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func TestEbbAndFlow(t *testing.T) {
 	t.Parallel()
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(2*time.Minute))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(2*time.Minute))
 
 	sleepActivityJson := `{
 		"count": {

--- a/scenarios/long_idle_workflow_test.go
+++ b/scenarios/long_idle_workflow_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func TestLongIdleWorkflow_ParseConfig(t *testing.T) {
@@ -103,8 +103,8 @@ func TestLongIdleWorkflow_BuildActions(t *testing.T) {
 func TestLongIdleWorkflow(t *testing.T) {
 	t.Parallel()
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(1*time.Minute))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute))
 
 	baseRunID := fmt.Sprintf("liw-%d", time.Now().Unix())
 

--- a/scenarios/out_of_order_signals_test.go
+++ b/scenarios/out_of_order_signals_test.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
 	"github.com/temporalio/omes/loadgen/kitchensink"
-	"github.com/temporalio/omes/workers"
 )
 
 // oooSignalKvs extracts the SetWorkflowState key/value map carried by a single
@@ -132,8 +132,8 @@ func TestOutOfOrderSignals_BuildOrderedAwaitActions(t *testing.T) {
 func TestOutOfOrderSignals(t *testing.T) {
 	t.Parallel()
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(1*time.Minute))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute))
 
 	baseRunID := fmt.Sprintf("ooo-%d", time.Now().Unix())
 

--- a/scenarios/serverless_burst_test.go
+++ b/scenarios/serverless_burst_test.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func TestServerlessBurst(t *testing.T) {
 	t.Parallel()
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(1*time.Minute))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute))
 
 	baseRunID := fmt.Sprintf("sb-%d", time.Now().Unix())
 

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func TestThroughputStress(t *testing.T) {
@@ -16,9 +16,9 @@ func TestThroughputStress(t *testing.T) {
 
 	runID := fmt.Sprintf("tps-%d", time.Now().Unix())
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(1*time.Minute),
-		workers.WithNexusEndpoint(runID))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute),
+		workertest.WithNexusEndpoint(runID))
 
 	scenarioInfo := loadgen.ScenarioInfo{
 		RunID: runID,

--- a/scenarios/workflow_with_many_timers_test.go
+++ b/scenarios/workflow_with_many_timers_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
-	"github.com/temporalio/omes/workers"
 )
 
 func TestWorkflowWithManyTimers_ParseConfig(t *testing.T) {
@@ -125,8 +125,8 @@ func TestWorkflowWithManyTimers_BuildActions(t *testing.T) {
 func TestWorkflowWithManyTimers(t *testing.T) {
 	t.Parallel()
 
-	env := workers.SetupTestEnvironment(t,
-		workers.WithExecutorTimeout(1*time.Minute))
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute))
 
 	baseRunID := fmt.Sprintf("wmt-%d", time.Now().Unix())
 

--- a/workers/build.go
+++ b/workers/build.go
@@ -42,10 +42,10 @@ func (b *Builder) Build(ctx context.Context, baseDir string) (sdkbuild.Program, 
 	}
 
 	if b.stdout == nil {
-		b.stdout = &logWriter{logger: b.Logger}
+		b.stdout = NewLogWriter(b.Logger)
 	}
 	if b.stderr == nil {
-		b.stderr = &logWriter{logger: b.Logger}
+		b.stderr = NewLogWriter(b.Logger)
 	}
 
 	switch b.SdkOptions.Language {

--- a/workers/log.go
+++ b/workers/log.go
@@ -6,13 +6,18 @@ import (
 	"go.uber.org/zap"
 )
 
-// logWriter implements io.Writer and streams output line by line to a logger
-type logWriter struct {
+// LogWriter implements io.Writer and streams output line by line to a logger
+type LogWriter struct {
 	logger *zap.SugaredLogger
 	buffer bytes.Buffer
 }
 
-func (w *logWriter) Write(p []byte) (n int, err error) {
+// NewLogWriter returns a LogWriter that streams output line by line to logger.
+func NewLogWriter(logger *zap.SugaredLogger) *LogWriter {
+	return &LogWriter{logger: logger}
+}
+
+func (w *LogWriter) Write(p []byte) (n int, err error) {
 	w.buffer.Write(p)
 
 	for {

--- a/workers/run.go
+++ b/workers/run.go
@@ -157,8 +157,8 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 
 	// Direct logging output to provided logger, if available.
 	if r.LoggingOptions.PreparedLogger != nil {
-		cmd.Stdout = &logWriter{logger: r.LoggingOptions.PreparedLogger}
-		cmd.Stderr = &logWriter{logger: r.LoggingOptions.PreparedLogger}
+		cmd.Stdout = NewLogWriter(r.LoggingOptions.PreparedLogger)
+		cmd.Stderr = NewLogWriter(r.LoggingOptions.PreparedLogger)
 	}
 
 	// Start the command. Do not use the context so we can send interrupt.


### PR DESCRIPTION
Stacked PRs:
 * #388
 * #387
 * #386
 * #385
 * #384
 * __->__#383


--- --- ---

### Extract workers test helpers into internal/workertest


workers/test_env.go, test_workers.go, and test_historyrequire.go were
package workers (production) files: the test_ prefix is not special to Go
(only _test.go is excluded from builds), so this test-support code compiled
into the shipped binary and forced production-only edges from package workers
into loadgen/devserver/versions that only the test harness needs.

Move them to a dedicated internal/workertest package (env.go, workerpool.go,
historyrequire.go). The helpers reference a few production symbols (Builder,
Runner, BaseDir, and the previously-unexported logWriter), so export logWriter
as LogWriter with a NewLogWriter constructor and qualify the rest. Update the
consumers (loadgen and scenario tests) to import internal/workertest.

Testing: `go build ./...` and `go vet ./...` pass; the loadgen and scenario
test packages compile against the new import path.
