### PR TITLE
Narrow cli.Dockerfile's workers COPY to what's actually needed

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -33,7 +33,10 @@ COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY internal ./internal
 COPY devserver ./devserver
-COPY workers ./workers/
+# kitchen-sink-gen needs the proto tree; the CLI build needs the harness/api
+# replace target. The rest of workers/ (language workers) is not needed here.
+COPY workers/proto ./workers/proto
+COPY workers/go/harness/api ./workers/go/harness/api
 COPY go.mod go.sum ./
 
 # Build the CLI


### PR DESCRIPTION
Stacked PRs:
 * #388
 * #387
 * __->__#386
 * #385
 * #384


--- --- ---

### Narrow cli.Dockerfile's workers COPY to what's actually needed


The CLI image copied the entire workers/ tree (all language worker sources)
but only needs workers/proto (for the kitchen-sink-gen protoc build) and
workers/go/harness/api (the go.mod replace target for the ./cmd/omes build).
Copy just those two, trimming the build context and making the dependency
explicit. Verified by building the CLI image with podman.
