### PR TITLE
Cache Go dependency downloads in cli.Dockerfile

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -25,7 +25,15 @@ RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y \
      fi
 ENV PATH="$PATH:/root/.cargo/bin"
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source. kitchen-sink-gen needs the proto tree; the rest of workers/
+# (language workers) is not needed here.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
@@ -33,11 +41,7 @@ COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY internal ./internal
 COPY devserver ./devserver
-# kitchen-sink-gen needs the proto tree; the CLI build needs the harness/api
-# replace target. The rest of workers/ (language workers) is not needed here.
 COPY workers/proto ./workers/proto
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum ./
 
 # Build the CLI
 RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes


### PR DESCRIPTION
Stacked PRs:
 * #388
 * __->__#387
 * #386
 * #385
 * #384


--- --- ---

### Cache Go dependency downloads in cli.Dockerfile


Previously the Dockerfile copied source then go.mod/go.sum and built in one
shot, so any source change invalidated the layer and re-downloaded every
module. Copy go.mod/go.sum (plus the workers/go/harness/api replace target,
required for the module graph to resolve) first and run `go mod download` as
its own layer, then copy source and build. Dependency downloads now cache
independently of source edits. Verified by building the CLI image with podman.
