### PR TITLE
Add CI check for building from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 **/node_modules
+workers/*/omes-temp-*/
+workers/*/prepared/
 workers/typescript/lib
 workers/typescript/tsconfig.tsbuildinfo
 workers/typescript/harness/dist*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,43 @@ jobs:
             --image-tag "${{ matrix.sdk }}-local-sdk-path-test"
           )
           go run ./cmd/dev build-worker-image "${args[@]}"
+      - name: Start ${{ matrix.sdk }} worker image built from local SDK path
+        run: |
+          docker run \
+            --rm \
+            -i -p 10233:10233 omes:${{ matrix.sdk }}-local-sdk-path-test \
+            --scenario workflow_with_single_noop_activity \
+            --log-level debug \
+            --language ${{ matrix.sdk }} \
+            --run-id ${{ github.run_id }}-${{ matrix.sdk }}-source \
+            --embedded-server-address 0.0.0.0:10233 &
+      - name: Wait for ${{ matrix.sdk }} source-built worker image to start
+        run: |
+          timeout 30 bash -c 'until nc -z 127.0.0.1 10233; do sleep 1; done' || (echo "Server failed to start" && exit 1)
+      - name: Smoke test workflow_with_single_noop_activity against ${{ matrix.sdk }} source-built worker
+        run: |
+          go run ./cmd run-scenario \
+            --scenario workflow_with_single_noop_activity \
+            --log-level debug \
+            --server-address 127.0.0.1:10233 \
+            --run-id ${{ github.run_id }}-${{ matrix.sdk }}-source \
+            --connect-timeout 1m \
+            --iterations 5
+      - name: Smoke test throughput_stress against ${{ matrix.sdk }} source-built worker
+        timeout-minutes: 10
+        run: |
+          go run ./cmd run-scenario \
+            --scenario throughput_stress \
+            --log-level debug \
+            --server-address 127.0.0.1:10233 \
+            --run-id ${{ github.run_id }}-${{ matrix.sdk }}-source \
+            --connect-timeout 1m \
+            --iterations 2 \
+            --timeout 5m \
+            --option internal-iterations=2 \
+            --option continue-as-new-after-iterations=1 \
+            --option sleep-time=1ms \
+            --option visibility-count-timeout=2m
 
   build-project:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           timeout 30 bash -c 'until nc -z 127.0.0.1 10233; do sleep 1; done' || (echo "Server failed to start" && exit 1)
       - name: Smoke test workflow_with_single_noop_activity against ${{ matrix.sdk }} source-built worker
         run: |
-          go run ./cmd run-scenario \
+          go run ./cmd/omes run-scenario \
             --scenario workflow_with_single_noop_activity \
             --log-level debug \
             --server-address 127.0.0.1:10233 \
@@ -238,7 +238,7 @@ jobs:
       - name: Smoke test throughput_stress against ${{ matrix.sdk }} source-built worker
         timeout-minutes: 10
         run: |
-          go run ./cmd run-scenario \
+          go run ./cmd/omes run-scenario \
             --scenario throughput_stress \
             --log-level debug \
             --server-address 127.0.0.1:10233 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,44 @@ jobs:
             --option sleep-time=1ms \
             --option visibility-count-timeout=2m
 
+  build-worker-from-source:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sdk: go
+            sdk_repo: sdk-go
+          - sdk: java
+            sdk_repo: sdk-java
+          - sdk: python
+            sdk_repo: sdk-python
+          - sdk: ruby
+            sdk_repo: sdk-ruby
+          - sdk: typescript
+            sdk_repo: sdk-typescript
+          - sdk: dotnet
+            sdk_repo: sdk-dotnet
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+      - name: Checkout ${{ matrix.sdk }} SDK
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: temporalio/${{ matrix.sdk_repo }}
+          submodules: recursive
+          path: checked-out-sdk
+      - name: Build ${{ matrix.sdk }} worker image from local SDK path
+        run: |
+          args=(
+            --language "${{ matrix.sdk }}"
+            --version checked-out-sdk/
+            --image-tag "${{ matrix.sdk }}-local-sdk-path-test"
+          )
+          go run ./cmd/dev build-worker-image "${args[@]}"
+
   build-project:
     runs-on: ubuntu-latest
     strategy:

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -60,6 +60,7 @@ FROM --platform=linux/$TARGETARCH ruby:3.3-slim-bullseye
 ENV BUNDLE_APP_CONFIG=.bundle
 
 COPY --from=build /app/temporal-omes /app/temporal-omes
+COPY --from=build /app/repo /app/repo
 COPY --from=build /app/workers/ruby /app/workers/ruby
 
 # Put the language and dir, but let other options (like required scenario and run-id) be given by user

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -2,10 +2,22 @@
 ARG TARGETARCH
 FROM --platform=linux/$TARGETARCH ruby:3.3-bullseye AS build
 
+# Install protobuf compiler
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends --assume-yes \
+    protobuf-compiler=3.12.4-1+deb11u1 libprotobuf-dev=3.12.4-1+deb11u1
+
 # Get go compiler
 ARG TARGETARCH
 RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go1.21.12.linux-${TARGETARCH}.tar.gz
+
+# Install Rust for compiling the Ruby SDK native extension when building from source.
+# hadolint ignore=DL4006
+RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="$PATH:/root/.cargo/bin"
 
 WORKDIR /app
 

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -6,6 +6,7 @@ FROM --platform=linux/$TARGETARCH ruby:3.3-bullseye AS build
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
+    clang=1:11.0-51+nmu5 \
     protobuf-compiler=3.12.4-1+deb11u1 libprotobuf-dev=3.12.4-1+deb11u1
 
 # Get go compiler

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -44,18 +44,21 @@ COPY ${SDK_DIR} ./repo
 # Read BUILD_CORE_RELEASE env var. This builds TS worker with core bridge in release mode.
 # This is only relevant if building from source (if using a published version, the worker is already
 # built in release mode).
-ARG BUILD_CORE_RELEASE=false
+ARG BUILD_CORE_RELEASE=1
 ENV BUILD_CORE_RELEASE=${BUILD_CORE_RELEASE}
 
 # Copy the worker files
 COPY workers/proto ./workers/proto
 COPY workers/typescript ./workers/typescript
 
-# Pin pnpm through Corepack because sdkbuild invokes `corepack pnpm`.
+# Pin pnpm through Corepack because sdkbuild invokes `corepack pnpm` and
+# TypeScript SDK repo scripts invoke bare `pnpm`.
 RUN . ./versions.env \
  && test -n "${PNPM_VERSION}" \
+ && corepack enable \
  && corepack prepare "pnpm@${PNPM_VERSION}" --activate \
- && corepack pnpm --version
+ && corepack pnpm --version \
+ && pnpm --version
 
 # prepare-worker builds the TypeScript workspace itself: it installs npm deps,
 # runs the root build, and generates the prepared sdkbuild package.

--- a/workers/build.go
+++ b/workers/build.go
@@ -298,6 +298,12 @@ func (b *Builder) buildDotNet(ctx context.Context, baseDir string) (sdkbuild.Pro
 }
 
 func (b *Builder) buildRuby(ctx context.Context, baseDir string) (sdkbuild.Program, error) {
+	if strings.ContainsAny(b.SdkOptions.Version, `/\`) {
+		if err := b.prepareRubySDKSource(ctx, b.SdkOptions.Version); err != nil {
+			return nil, err
+		}
+	}
+
 	options := sdkbuild.BuildRubyProgramOptions{
 		BaseDir:   baseDir,
 		SourceDir: baseDir,
@@ -312,6 +318,39 @@ func (b *Builder) buildRuby(ctx context.Context, baseDir string) (sdkbuild.Progr
 		return nil, fmt.Errorf("failed preparing: %w", err)
 	}
 	return prog, nil
+}
+
+func (b *Builder) prepareRubySDKSource(ctx context.Context, version string) error {
+	sdkPath, err := filepath.Abs(version)
+	if err != nil {
+		return fmt.Errorf("unable to make sdk path absolute: %w", err)
+	}
+
+	gemPath := filepath.Join(sdkPath, "temporalio")
+	if _, err := os.Stat(filepath.Join(gemPath, "Rakefile")); err != nil {
+		gemPath = sdkPath
+	}
+	if _, err := os.Stat(filepath.Join(gemPath, "Rakefile")); err != nil {
+		return nil
+	}
+
+	bundleDir := filepath.Join(gemPath, ".bundle")
+	if err := os.MkdirAll(bundleDir, 0755); err != nil {
+		return fmt.Errorf("failed creating Ruby SDK .bundle dir: %w", err)
+	}
+	bundleConfig := "---\nBUNDLE_PATH: \"vendor/bundle\"\n"
+	if err := os.WriteFile(filepath.Join(bundleDir, "config"), []byte(bundleConfig), 0644); err != nil {
+		return fmt.Errorf("failed writing Ruby SDK .bundle/config: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "bundle", "install")
+	cmd.Dir = gemPath
+	cmd.Stdout = b.stdout
+	cmd.Stderr = b.stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed installing Ruby SDK dependencies: %w", err)
+	}
+	return nil
 }
 
 func BaseDir(repoDir string, lang clioptions.Language) string {


### PR DESCRIPTION
## What was changed
Add a CI job to check builds from source.

Couple fixes from the CI failures:
- Enable `corepack` in the TS dockerfile
- install rust in ruby dockerfile

## Why?
We have no validation currently for builds from source.