### PR TITLE
Normalize the CLI-build block across all Dockerfiles

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -32,22 +32,18 @@ COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
 RUN go mod download
 
-# Copy CLI source. kitchen-sink-gen needs the proto tree; the rest of workers/
-# (language workers) is not needed here.
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
 COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY internal ./internal
-COPY devserver ./devserver
-COPY workers/proto ./workers/proto
-
-# Build the CLI
 RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
-# Install protoc-gen-go for kitchen-sink-gen build
+# Install protoc-gen-go and build kitchen-sink-gen, which needs the proto tree.
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
+COPY workers/proto ./workers/proto
 
 # Build kitchen-sink-gen (statically linked)
 RUN cd loadgen/kitchen-sink-gen && \

--- a/dockerfiles/dotnet.Dockerfile
+++ b/dockerfiles/dotnet.Dockerfile
@@ -22,20 +22,21 @@ ENV PATH="$PATH:/root/.cargo/bin:/usr/local/go/bin"
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
-COPY scenarios ./scenarios
 COPY metrics ./metrics
-COPY devserver ./devserver
+COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY workers/proto/harness ./workers/proto/harness
-COPY go.mod go.sum ./
-
-# Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 
@@ -44,6 +45,7 @@ ARG SDK_DIR=.gitignore
 COPY ${SDK_DIR} ./repo
 
 # Copy the worker files
+COPY workers/proto/harness ./workers/proto/harness
 COPY workers/dotnet ./workers/dotnet
 
 # Prepare the worker

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -4,18 +4,20 @@ FROM --platform=linux/$TARGETARCH golang:1.25 AS build
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
-COPY scenarios ./scenarios
 COPY metrics ./metrics
-COPY devserver ./devserver
+COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum ./
-
-# Build the CLI
 RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
@@ -26,6 +28,12 @@ COPY ${SDK_DIR} ./repo
 
 # Copy the worker files
 COPY workers/go ./workers/go
+
+# The worker's `go mod tidy` (run by prepare-worker below) resolves the omes
+# module's full test-import graph, which reaches devserver via
+# loadgen.test -> internal/workertest -> devserver. devserver lives at the repo
+# root rather than under internal/, so it isn't picked up by `COPY internal`.
+COPY devserver ./devserver
 
 # Build the worker
 RUN CGO_ENABLED=0 ./temporal-omes prepare-worker --language go --dir-name prepared --version "$SDK_VERSION"

--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -12,22 +12,25 @@ RUN apt-get update \
 ARG TARGETARCH
 RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
     && tar -C /usr/local -xzf go1.21.12.linux-${TARGETARCH}.tar.gz
+ENV PATH="$PATH:/usr/local/go/bin"
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
 COPY metrics ./metrics
 COPY scenarios ./scenarios
-COPY devserver ./devserver
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum ./
-
-# Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -18,26 +18,28 @@ RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
 # hadolint ignore=DL4006
 RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y
 
-ENV PATH="$PATH:/root/.cargo/bin"
+ENV PATH="$PATH:/root/.cargo/bin:/usr/local/go/bin"
 
 # Install uv
 COPY --from=uv /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
-COPY scenarios ./scenarios
 COPY metrics ./metrics
-COPY devserver ./devserver
+COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum ./
-
-# Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -18,23 +18,25 @@ RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
 # hadolint ignore=DL4006
 RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y
 
-ENV PATH="$PATH:/root/.cargo/bin"
+ENV PATH="$PATH:/root/.cargo/bin:/usr/local/go/bin"
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
-COPY scenarios ./scenarios
 COPY metrics ./metrics
-COPY devserver ./devserver
+COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum ./
-
-# Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -16,23 +16,25 @@ RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
 
 # Need Rust to compile core if not already built
 RUN wget -q -O - https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:/usr/local/go/bin:${PATH}"
 
 WORKDIR /app
 
-# Copy CLI build dependencies
+# Download Go dependencies first so this layer caches independently of source
+# changes. The harness/api replace target must be present for `go mod download`
+# to resolve the module graph.
+COPY go.mod go.sum ./
+COPY workers/go/harness/api ./workers/go/harness/api
+RUN go mod download
+
+# Copy CLI source and build the CLI.
 COPY cmd ./cmd
 COPY clioptions ./clioptions
 COPY loadgen ./loadgen
-COPY scenarios ./scenarios
 COPY metrics ./metrics
-COPY devserver ./devserver
+COPY scenarios ./scenarios
 COPY internal ./internal
-COPY workers/go/harness/api ./workers/go/harness/api
-COPY go.mod go.sum versions.env ./
-
-# Build the CLI
-RUN CGO_ENABLED=0 /usr/local/go/bin/go build -o temporal-omes ./cmd/omes
+RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 
@@ -49,6 +51,7 @@ ENV BUILD_CORE_RELEASE=${BUILD_CORE_RELEASE}
 # Copy the worker files
 COPY workers/proto ./workers/proto
 COPY workers/typescript ./workers/typescript
+COPY versions.env ./
 
 # Pin pnpm through Corepack because sdkbuild invokes `corepack pnpm` and
 # TypeScript SDK repo scripts invoke bare `pnpm`.


### PR DESCRIPTION
Stacked PRs:
 * __->__#401
 * #400
 * #399
 * #398
 * #397


--- --- ---

### Normalize the CLI-build block across all Dockerfiles


All seven Dockerfiles build the omes CLI with the same set of inputs, but the
duplicated block had drifted: java had metrics/scenarios in a different order,
dotnet folded an unrelated workers/proto/harness copy into it, typescript
appended versions.env, and the build invoked go via different paths
(go vs /usr/local/go/bin/go). That divergence is what let the earlier COPY-set
regression hide.

Unify them on one byte-identical block (the cached go-mod-download pattern):
- ensure go is on PATH in every image so the build line is identical
- move per-language extras out of the shared block into each file's
  language-specific section (cli: workers/proto for kitchen-sink-gen;
  typescript: versions.env; dotnet: workers/proto/harness)

The shared block is now identical across all seven (verified by hash). Built
cli, go, and ruby images with podman to cover both base-image patterns
(golang-native and go-installed-on-PATH).