### PR TITLE
Add failure-tolerant run mode (ContinueOnIterationFailure)

### DIFF
--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -3,6 +3,7 @@ package loadgen
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"go.temporal.io/sdk/client"
@@ -21,6 +22,10 @@ type genericRun struct {
 	logger   *zap.SugaredLogger
 	// Timer capturing E2E execution of each scenario run iteration.
 	executeTimer client.MetricsTimer
+	// Iteration outcome tallies, used for the end-of-run summary. failed counts
+	// only terminal failures tolerated via ContinueOnIterationFailure.
+	completed atomic.Int64
+	failed    atomic.Int64
 }
 
 func (g *GenericExecutor) Run(ctx context.Context, info ScenarioInfo) error {
@@ -130,11 +135,28 @@ func (g *genericRun) Run(ctx context.Context) error {
 			defer func() {
 				g.executeTimer.Record(time.Since(iterStart))
 
+				// Swallow the error for the spawn loop only, so a tolerated failure
+				// doesn't stop new iterations from starting. It is not ignored: it is
+				// counted (g.failed) and surfaced via OnIterationFailure, and the run
+				// still fails at the end if the tally is nonzero.
+				iterErr := err
+				if iterErr != nil && g.config.ContinueOnIterationFailure {
+					err = nil
+				}
+
 				select {
 				case <-ctx.Done():
 				case doneCh <- err:
-					if err == nil && g.config.OnCompletion != nil {
-						g.config.OnCompletion(ctx, run)
+					if iterErr == nil {
+						g.completed.Add(1)
+						if g.config.OnCompletion != nil {
+							g.config.OnCompletion(ctx, run)
+						}
+					} else {
+						g.failed.Add(1)
+						if g.config.OnIterationFailure != nil {
+							g.config.OnIterationFailure(ctx, run, iterErr)
+						}
 					}
 				}
 			}()
@@ -182,6 +204,17 @@ func (g *genericRun) Run(ctx context.Context) error {
 	}
 	if runErr != nil {
 		return fmt.Errorf("run finished with error after %v: %w", time.Since(startTime), runErr)
+	}
+	// ContinueOnIterationFailure changed only when the run stops (it ran to
+	// completion instead of aborting on the first failure); the verdict is
+	// unchanged — any terminal iteration failure fails the run. Per-iteration
+	// outcomes were tallied into the snapshot, so the caller can read the
+	// success/failure counts and apply its own policy on top.
+	if failed := g.failed.Load(); failed > 0 {
+		completed := g.completed.Load()
+		g.logger.Infof("Run completed in %v: %d iterations succeeded, %d failed",
+			time.Since(startTime), completed, failed)
+		return fmt.Errorf("run completed with %d of %d iterations failed", failed, completed+failed)
 	}
 	g.logger.Infof("Run completed in %v", time.Since(startTime))
 	return nil

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -238,6 +238,46 @@ func TestExecutorRetries(t *testing.T) {
 	})
 }
 
+func TestRunContinueOnIterationFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var completed, failed []int
+
+		err := execute(&GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				if run.Iteration%2 == 0 {
+					return errors.New("deliberate fail from test")
+				}
+				return nil
+			}},
+			RunConfiguration{
+				Iterations:                 6,
+				MaxConcurrent:              1,
+				ContinueOnIterationFailure: true,
+				OnCompletion: func(ctx context.Context, run *Run) {
+					mu.Lock()
+					defer mu.Unlock()
+					completed = append(completed, run.Iteration)
+				},
+				OnIterationFailure: func(ctx context.Context, run *Run, err error) {
+					mu.Lock()
+					defer mu.Unlock()
+					failed = append(failed, run.Iteration)
+				},
+			},
+		)
+
+		// Every iteration runs (tolerated failures don't abort), but the verdict is
+		// unchanged: the run still fails because iterations failed.
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "3 of 6 iterations failed")
+		mu.Lock()
+		defer mu.Unlock()
+		require.ElementsMatch(t, []int{1, 3, 5}, completed)
+		require.ElementsMatch(t, []int{2, 4, 6}, failed)
+	})
+}
+
 func TestExecutorRetriesLimit(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		totalTracker := newIterationTracker()

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -239,6 +239,17 @@ type RunConfiguration struct {
 	OnCompletion func(context.Context, *Run)
 	// HandleExecuteError, if set, is called when Execute returns an error, allowing transformation of errors.
 	HandleExecuteError func(context.Context, *Run, error) error
+	// ContinueOnIterationFailure, if set, keeps the run going after an iteration
+	// terminally fails (i.e. exhausts MaxIterationAttempts) instead of aborting on
+	// the first failure. The failed iteration is reported via OnIterationFailure
+	// and new iterations keep starting until the duration or iteration limit is
+	// reached. This is the mechanism for failure-tolerant runs; the policy for how
+	// many failures are acceptable belongs to the caller. Default is false.
+	ContinueOnIterationFailure bool
+	// OnIterationFailure, if set, is invoked when an iteration terminally fails
+	// (after exhausting retries). It is the hook callers use to tally failures
+	// when running with ContinueOnIterationFailure.
+	OnIterationFailure func(context.Context, *Run, error)
 }
 
 func (r *RunConfiguration) ApplyDefaults() {

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -62,6 +62,9 @@ const (
 type tpsState struct {
 	// CompletedIterations is the number of iteration that have been completed.
 	CompletedIterations int `json:"completedIterations"`
+	// FailedIterations is the number of iterations that terminally failed while
+	// the run tolerated failures (RunConfiguration.ContinueOnIterationFailure).
+	FailedIterations int `json:"failedIterations"`
 	// LastCompletedIterationAt is the time when the last iteration was completed. Helpful for debugging.
 	LastCompletedIterationAt time.Time `json:"lastCompletedIterationAt"`
 	// AccumulatedDuration is the total execution time across all runs (original + resumes).
@@ -236,6 +239,15 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 		info.Logger.Debugf("Completed iteration %d", run.Iteration)
 	}
 
+	// Tally terminal iteration failures into the state so the failed count is
+	// carried in the snapshot. This only fires when the run tolerates failures
+	// (RunConfiguration.ContinueOnIterationFailure); otherwise the first failure
+	// aborts the run before this is reached.
+	info.Configuration.OnIterationFailure = func(ctx context.Context, run *loadgen.Run, err error) {
+		t.updateStateOnIterationFailure()
+		info.Logger.Warnf("Iteration %d failed (tolerated): %v", run.Iteration, err)
+	}
+
 	// Start the scenario run.
 	//
 	// NOTE: When resuming, it can happen that there are no more iterations/time left to run more iterations.
@@ -359,8 +371,16 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 	}
 
 	// Post-scenario: ensure there are no failed or terminated workflows for this run.
-	if err := loadgen.VerifyNoFailedWorkflows(ctx, info, loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID); err != nil {
-		tpsErrors = append(tpsErrors, err)
+	//
+	// Skipped when tolerating iteration failures: this is a binary zero-failure
+	// gate that yields no count, whereas a tolerant run's verdict comes from the
+	// counted iteration-failure tally (snapshot FailedIterations) plus the caller's
+	// policy. This block is only reached when no iteration failed anyway — a
+	// tolerated failure makes ksExec.Run return a failure verdict and we return early.
+	if !info.Configuration.ContinueOnIterationFailure {
+		if err := loadgen.VerifyNoFailedWorkflows(ctx, info, loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID); err != nil {
+			tpsErrors = append(tpsErrors, err)
+		}
 	}
 
 	return errors.Join(tpsErrors...)
@@ -377,6 +397,12 @@ func (t *tpsExecutor) updateStateOnIterationCompletion() {
 	defer t.lock.Unlock()
 	t.state.CompletedIterations += 1
 	t.state.LastCompletedIterationAt = time.Now()
+}
+
+func (t *tpsExecutor) updateStateOnIterationFailure() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.state.FailedIterations += 1
 }
 
 func (t *tpsExecutor) createActions(run *loadgen.Run) []*ActionSet {


### PR DESCRIPTION
## What

Adds an opt-in, failure-tolerant run mode to the generic executor. `ContinueOnIterationFailure` changes **only when a run stops** — it runs every iteration to completion instead of aborting on the first terminal failure — and surfaces per-iteration success/failure counts so a caller can layer its own policy on top. The **verdict contract is unchanged**: if any iteration terminally fails, the run still returns a failure.

- **`loadgen` — `RunConfiguration.ContinueOnIterationFailure`** (default `false`, behavior unchanged when unset): when set, an iteration that terminally fails (after exhausting `MaxIterationAttempts`) no longer aborts the run; the executor keeps starting new iterations until the duration/iteration limit is reached. The failure is not ignored — it is counted, and the run **still fails at the end** if any iteration failed.
- **`loadgen` — `RunConfiguration.OnIterationFailure` hook**: invoked when an iteration terminally fails, mirroring the existing `OnCompletion` hook. It is how a caller tallies failures. The executor also tracks succeeded/failed counts and returns a failure verdict (`run completed with N of M iterations failed`) at end-of-run when the failed tally is nonzero.
- **`scenarios/throughput_stress`**: tallies terminal failures into a new `FailedIterations` field carried in the snapshot (alongside `CompletedIterations`). It skips the binary zero-failed-workflow gate (`VerifyNoFailedWorkflows`) when tolerating failures — that check yields no count, so the counted iteration-failure tally is the authoritative signal; the block is only reached when no iteration failed anyway, since a tolerated failure makes the executor return a failure verdict and the scenario returns early.

**Why the counts, if the run still fails?** The default verdict (any failure ⇒ fail) is preserved so nothing silently passes. A caller that wants a *more granular* verdict — e.g. "the load stayed up and fewer than X% of iterations failed" — reads `failedIterations`/`completedIterations` from the snapshot and applies its own threshold on top. omes provides the mechanism and the counts; the tolerance policy lives with the caller.

## Why

Part of the bench-go → omes migration ([RE-257](https://temporalio.atlassian.net/browse/RE-257)). The release-validation suite intentionally disrupts the cell (rollout / rolling-restart / chaos / scale-to-zero), so the standing load hits transient iteration failures that must not abort the whole run the way the current all-or-nothing behavior does. This lets the run continue through the disruption and report the failure counts, while still failing by default — the foundation for a failure-rate verdict.

## Testing

- `go test ./loadgen/ -run 'TestRun|TestExecutor'` — all executor tests pass, including a new `TestRunContinueOnIterationFailure`: with `ContinueOnIterationFailure` set and half the iterations failing, every iteration runs and both hooks fire for the right iterations, **and the run still returns a failure** (`3 of 6 iterations failed`).
- `go build ./loadgen/... ./scenarios/... ./cmd/...` — clean. `go vet` shows only pre-existing, unrelated notes.
- Default-path behavior is unchanged: with `ContinueOnIterationFailure` unset, a terminal failure aborts the run exactly as before (covered by existing `TestRunFailIterations`/`TestRunFailDuration`).

## Consumer / follow-up

The saas-cicd side that consumes this — reading `failedIterations` into the load result and applying the release-validation verdict from the counts — is a companion PR. Note the saas-cicd branch currently builds against this omes only under the `protoregistry.conflictPolicy=warn` ldflag workaround for the nexus-rpc proto annotation collision (ext 8233) with the bergundy annotations embedded in `saas-infra-plane/api`; the durable fix (saas-infra-plane regenerating against `nexus-rpc/nexus-proto-annotations`) is tracked separately.

[RE-257]: https://temporalio.atlassian.net/browse/RE-257
