### PR TITLE
Add nexus-operation-with-standalone-activity to throughput_stress

### DIFF
--- a/docs/throughput-stress.md
+++ b/docs/throughput-stress.md
@@ -89,3 +89,16 @@ is any.
 | `=false` | either | no Nexus load; standalone Nexus not included |
 
 Asking for `include-standalone-nexus=true` while Nexus is off is a contradiction, and fails the run.
+
+## Nexus operation with a standalone activity
+
+`include-nexus-standalone-activity` adds a standalone activity backed Nexus operation.
+It is driven two ways each iteration: As an in-workflow Nexus operation, and — when standalone Nexus is part of the run —
+as a standalone Nexus operation.
+
+This is **opt-in and off by default**; pass `--option include-nexus-standalone-activity=true`.
+It requires `nexus-enabled` and also needs server support for standalone activities and activity
+completion callbacks (dynamic config `activity.enableStandalone` and `activity.enableCallbacks`) and a
+Nexus callback URL; if those are off the operation fails clearly rather than being skipped.
+
+Currently only supported and run by Go workers.

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -63,6 +63,10 @@ const (
 	// standalone activities in throughput_stress. It is independent of plain
 	// standalone activity load and follows the namespace capability by default.
 	IncludeStandaloneActivityOperatorCommandsFlag = "include-standalone-activity-operator-commands"
+	// IncludeNexusStandaloneActivityFlag enables Nexus operations backed by a standalone activity.
+	// Opt-in and off by default (only the Go worker implements the operation); requires Nexus load
+	// (nexus-enabled) and server support for standalone activities + activity completion callbacks.
+	IncludeNexusStandaloneActivityFlag = "include-nexus-standalone-activity"
 	// PayloadDistributionJsonFlag is a JSON string (or @file) configuring a weighted
 	// activity payload-size distribution. See loadgen.PayloadConfig for details.
 	PayloadDistributionJsonFlag = "payload-distribution-json"
@@ -99,6 +103,7 @@ type tpsConfig struct {
 	IncludeStandaloneNexus                    bool
 	IncludeStandaloneActivity                 bool
 	IncludeStandaloneActivityOperatorCommands bool
+	IncludeNexusStandaloneActivity            bool
 	Payload                                   *loadgen.PayloadConfig
 }
 
@@ -137,6 +142,7 @@ func init() {
 				func(c loadgen.Capabilities) bool {
 					return c.Namespace.GetStandaloneActivityOperatorCommands()
 				})
+			o.Bool(IncludeNexusStandaloneActivityFlag, false, "Include a Nexus operation that starts a standalone activity (Go worker only).")
 			o.String(PayloadDistributionJsonFlag, "", "JSON payload-size distribution; use @<file> to read from a file.")
 		},
 		ExecutorFn: func() loadgen.Executor { return newThroughputStressExecutor() },
@@ -233,6 +239,10 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config.IncludeStandaloneActivity = info.OptionBool(IncludeStandaloneActivityFlag)
 	config.IncludeStandaloneActivityOperatorCommands = info.OptionBool(
 		IncludeStandaloneActivityOperatorCommandsFlag)
+	config.IncludeNexusStandaloneActivity = info.OptionBool(IncludeNexusStandaloneActivityFlag)
+	if config.IncludeNexusStandaloneActivity && !config.NexusEnabled {
+		return fmt.Errorf("%s requires %s", IncludeNexusStandaloneActivityFlag, NexusEnabledFlag)
+	}
 
 	if payloadStr := info.OptionString(PayloadDistributionJsonFlag); payloadStr != "" {
 		config.Payload, err = loadgen.ParseAndValidatePayloadConfig(payloadStr)
@@ -271,6 +281,7 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 	if !nexus.Enabled {
 		// Standalone operations are part of Nexus load, so they go with it.
 		t.config.IncludeStandaloneNexus = false
+		t.config.IncludeNexusStandaloneActivity = false
 	} else {
 		info.Logger.Infof("Using nexus endpoint %q", nexus.Endpoint)
 	}
@@ -572,6 +583,14 @@ func (t *tpsExecutor) createActionsChunk(
 					t.createStandaloneNexusOperationAction("echo-sync"),
 				)
 			}
+			if t.config.IncludeNexusStandaloneActivity {
+				asyncActions = append(asyncActions, t.createNexusStandaloneActivityAction())
+				if t.config.IncludeStandaloneNexus {
+					asyncActions = append(asyncActions,
+						t.createStandaloneNexusOperationAction("standalone-activity"),
+					)
+				}
+			}
 		}
 
 		// Add standalone activities, if configured.
@@ -857,6 +876,18 @@ func (t *tpsExecutor) createNexusAttachCallbacksAction() *Action {
 			},
 		},
 	}}
+}
+
+// createNexusStandaloneActivityAction invokes a standalone activity backed Nexus operation from within the workflow.
+func (t *tpsExecutor) createNexusStandaloneActivityAction() *Action {
+	return &Action{
+		Variant: &Action_NexusOperation{
+			NexusOperation: &ExecuteNexusOperation{
+				Endpoint:  t.config.NexusEndpoint,
+				Operation: "standalone-activity",
+			},
+		},
+	}
 }
 
 func (t *tpsExecutor) createStandaloneNexusOperationAction(operation string) *Action {

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -145,6 +145,99 @@ func TestThroughputStressFeatureAutoEnable(t *testing.T) {
 	require.Equal(t, 1, executor.Snapshot().(tpsState).CompletedIterations)
 }
 
+func TestThroughputStressNexusStandaloneActivity(t *testing.T) {
+	t.Parallel()
+
+	runID := fmt.Sprintf("tps-nsa-%d", time.Now().Unix())
+
+	// Enable the activity-backed operation and standalone-Nexus completion path.
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute),
+		workertest.WithDynamicConfig(map[string]any{
+			"activity.enableStandalone":       true,
+			"activity.enableCallbacks":        true,
+			"nexusoperation.enableStandalone": true,
+			"history.enableCHASMCallbacks":    true,
+		}))
+
+	scenarioInfo := loadgen.ScenarioInfo{
+		RunID: runID,
+		Configuration: loadgen.RunConfiguration{
+			Iterations: 1,
+		},
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
+			IterFlag:                           "1",
+			ContinueAsNewAfterIterFlag:         "1",
+			SleepTimeFlag:                      "1ms",
+			VisibilityVerificationTimeoutFlag:  "10s",
+			NexusEnabledFlag:                   "true",
+			IncludeNexusStandaloneActivityFlag: "true",
+		}),
+	}
+
+	executor := newThroughputStressExecutor()
+	_, err := env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
+	require.NoError(t, err, "Executor should complete successfully with nexus standalone activity enabled")
+
+	require.True(t, executor.config.IncludeNexusStandaloneActivity,
+		"nexus standalone activity should be enabled")
+	require.Equal(t, 1, executor.Snapshot().(tpsState).CompletedIterations)
+}
+
+func TestThroughputStressNexusStandaloneActivityActions(t *testing.T) {
+	t.Parallel()
+
+	exec := newThroughputStressExecutor()
+	exec.config = &tpsConfig{
+		InternalIterations:             1,
+		ContinueAsNewAfterIter:         0,
+		NexusEnabled:                   true,
+		NexusEndpoint:                  "test-endpoint",
+		IncludeStandaloneNexus:         true,
+		IncludeNexusStandaloneActivity: true,
+		SleepTime:                      time.Millisecond,
+		RngSeed:                        1,
+	}
+	exec.rng = rand.New(rand.NewSource(1))
+
+	run := (&loadgen.ScenarioInfo{
+		RunID:       "tps-nsa-actions",
+		ExecutionID: "exec",
+		Logger:      zap.NewNop().Sugar(),
+	}).NewRun(0)
+
+	var inWorkflow, standalone bool
+	var walk func(actions []*ks.Action)
+	walk = func(actions []*ks.Action) {
+		for _, a := range actions {
+			if op := a.GetNexusOperation(); op.GetOperation() == "standalone-activity" {
+				inWorkflow = true
+			}
+			// Find the nested standalone-Nexus client action.
+			if seq := a.GetExecActivity().GetClient().GetClientSequence(); seq != nil {
+				for _, set := range seq.GetActionSets() {
+					for _, ca := range set.GetActions() {
+						if sn := ca.GetDoStandaloneNexusOperation(); sn.GetOperation() == "standalone-activity" {
+							standalone = true
+						}
+					}
+				}
+			}
+			if nested := a.GetNestedActionSet(); nested != nil {
+				walk(nested.GetActions())
+			}
+		}
+	}
+	for _, set := range exec.createActions(run) {
+		walk(set.GetActions())
+	}
+
+	require.True(t, inWorkflow,
+		`expected an in-workflow Nexus operation action with Operation "standalone-activity"`)
+	require.True(t, standalone,
+		`expected a DoStandaloneNexusOperation client action with Operation "standalone-activity"`)
+}
+
 func TestThroughputStressConfigurePayload(t *testing.T) {
 	t.Parallel()
 

--- a/workers/go/apps/lambda/worker.go
+++ b/workers/go/apps/lambda/worker.go
@@ -116,7 +116,7 @@ func configureLambdaWorker(opts *lambdaworker.Options) error {
 	ebbFlowActivities := ebbandflow.Activities{}
 
 	service := nexus.NewService(kitchensink.KitchenSinkServiceName)
-	for _, op := range []nexus.RegisterableOperation{kitchensink.EchoSyncOperation, kitchensink.EchoAsyncOperation} {
+	for _, op := range []nexus.RegisterableOperation{kitchensink.EchoSyncOperation, kitchensink.EchoAsyncOperation, kitchensink.StandaloneActivityNexusOperation} {
 		if err := service.Register(op); err != nil {
 			return fmt.Errorf("failed to register nexus operation: %w", err)
 		}

--- a/workers/go/apps/worker/worker.go
+++ b/workers/go/apps/worker/worker.go
@@ -34,6 +34,7 @@ func buildWorker(client sdkclient.Client, context harness.WorkerContext) sdkwork
 	for _, op := range []nexus.RegisterableOperation{
 		kitchensink.EchoSyncOperation,
 		kitchensink.EchoAsyncOperation,
+		kitchensink.StandaloneActivityNexusOperation,
 	} {
 		if err := service.Register(op); err != nil {
 			panic(err)

--- a/workers/go/workerlib/kitchensink/kitchen_sink.go
+++ b/workers/go/workerlib/kitchensink/kitchen_sink.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/temporalio/omes/loadgen/kitchensink"
 	"go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -644,3 +646,49 @@ var EchoAsyncOperation = temporalnexus.NewWorkflowRunOperation("echo-async", Nex
 		ID: opts.RequestID,
 	}, nil
 })
+
+// StandaloneActivityNexusOperationName is the registered name of StandaloneActivityNexusOperation.
+const StandaloneActivityNexusOperationName = "standalone-activity"
+
+// StandaloneActivityNexusOperation starts a standalone "noop" activity.
+var StandaloneActivityNexusOperation = temporalnexus.MustNewTemporalOperation(
+	temporalnexus.TemporalOperationOptions[*kitchensink.NexusHandlerInput, string]{
+		Name:  StandaloneActivityNexusOperationName,
+		Start: startStandaloneActivityNexusOperation,
+	},
+)
+
+// startStandaloneActivityNexusOperation starts the registered "noop" activity.
+func startStandaloneActivityNexusOperation(
+	ctx context.Context,
+	nc temporalnexus.NexusClient,
+	_ *kitchensink.NexusHandlerInput,
+	opts temporalnexus.StartTemporalOperationOptions,
+) (temporalnexus.TemporalOperationResult[string], error) {
+	activityOpts := client.StartActivityOptions{
+		// Reuse the Nexus request ID so retries attach to the original activity.
+		ID:                       "nexus-standalone-activity-" + opts.RequestID,
+		StartToCloseTimeout:      30 * time.Second,
+		ActivityIDConflictPolicy: enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+	}
+
+	res, err := temporalnexus.StartUntypedActivity[string](ctx, nc, activityOpts, "noop")
+	if err != nil {
+		// Treat namespace handover as retryable.
+		var notActive *serviceerror.NamespaceNotActive
+		if errors.As(err, &notActive) {
+			return res, nexus.HandlerErrorf(nexus.HandlerErrorTypeUnavailable, "%s", err.Error())
+		}
+		// Fail fast and prevent retries when the server can't run this: standalone activities
+		// disabled (Unimplemented) or activity completion callbacks disabled (InvalidArgument).
+		var unimplemented *serviceerror.Unimplemented
+		var invalidArg *serviceerror.InvalidArgument
+		if errors.As(err, &unimplemented) || errors.As(err, &invalidArg) {
+			return res, nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest,
+				"cannot start standalone activity; standalone activities (activity.enableStandalone) and "+
+					"activity completion callbacks (activity.enableCallbacks) must be enabled: %s", err.Error())
+		}
+		return res, fmt.Errorf("StartActivity failed: %w", err)
+	}
+	return res, nil
+}


### PR DESCRIPTION
## What was changed

Adds an opt-in `throughput_stress` feature option, `--option include-nexus-standalone-activity`, that exercises **a standalone activity backed Nexus operation** and resolves the operation via the activity's **completion callback**. The single operation is driven through **two invocation paths**:

- **In-workflow Nexus operation** — the kitchen sink workflow invokes it via the `ExecuteNexusOperation` action (operation `standalone-activity`).
- **Standalone Nexus operation** — invoked outside any workflow via the `DoStandaloneNexusOperation` client action. Added only when standalone Nexus is already part of the run.

## Why

`throughput_stress` already covered standalone activities and standalone Nexus operations separately, but not the standalone activity backed Nexus operation which is resolved by the activity's completion callback. 

## Notes for review

- **Server requirements:** standalone activities (`activity.enableStandalone`), activity completion callbacks (`activity.enableCallbacks`), and a Nexus callback URL (`component.nexusoperations.useSystemCallbackURL`, which defaults on). These are dynamic-config gates, so they must be enabled on every server version the load reaches — including all versions in a rolling-upgrade (mixed-version) run.
- **Verification:** both modules build + vet; `TestThroughputStressNexusStandaloneActivity` passes end-to-end against the dev server (standalone activities + activity completion callbacks enabled); the full existing `TestThroughputStress*` suite still passes.