### PR TITLE
Error-handling cleanup: surface swallowed failures, branch on values not strings

### DIFF
--- a/clioptions/client.go
+++ b/clioptions/client.go
@@ -64,7 +64,7 @@ func (c *ClientOptions) loadTLSConfig() (*tls.Config, error) {
 		}
 		cert, err := tls.LoadX509KeyPair(c.ClientCertPath, c.ClientKeyPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load certs: %s", err)
+			return nil, fmt.Errorf("failed to load certs: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		return tlsConfig, nil

--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -173,11 +173,14 @@ func (g *genericRun) Run(ctx context.Context) error {
 
 				backoff, retry := run.ShouldRetry(err)
 				if retry {
+					// Transient: this attempt is superseded by the retry and
+					// never propagated, so log it here as the only record.
 					err = fmt.Errorf("iteration %v encountered error: %w", run.Iteration, err)
 					g.logger.Error(err)
 				} else {
+					// Terminal: propagated via doneCh and reported by Run's
+					// caller, so don't also log it here.
 					err = fmt.Errorf("iteration %v failed: %w", run.Iteration, err)
-					g.logger.Error(err)
 					break retryLoop
 				}
 

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -404,22 +404,10 @@ func (s *ScenarioInfo) RegisterDefaultSearchAttributes(ctx context.Context) erro
 		},
 		Namespace: s.Namespace,
 	})
-	// Throw an error if the attributes could not be registered, but ignore already exists errs
-	alreadyExistsStrings := []string{
-		"already exists",
-		"attributes mapping unavailble",
-	}
-	if err != nil {
-		isAlreadyExistsErr := false
-		for _, s := range alreadyExistsStrings {
-			if strings.Contains(err.Error(), s) {
-				isAlreadyExistsErr = true
-				break
-			}
-		}
-		if !isAlreadyExistsErr {
-			return fmt.Errorf("failed to register search attributes: %w", err)
-		}
+	// Throw an error if the attributes could not be registered, but ignore the
+	// case where they already exist (re-registration on a reused namespace).
+	if err != nil && status.Code(err) != codes.AlreadyExists {
+		return fmt.Errorf("failed to register search attributes: %w", err)
 	}
 	return nil
 }

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -546,14 +546,13 @@ func (r *Run) ExecuteKitchenSinkWorkflow(ctx context.Context, options *KitchenSi
 			err := executor.ExecuteClientSequence(cancelCtx, clientSeq)
 			if err != nil {
 				clientActionsErrPtr.Store(&err)
-				r.Logger.Error("Client actions failed: ", clientActionsErrPtr)
+				r.Logger.Error("Client actions failed: ", err)
 				cancel()
 
 				// TODO: Remove or change to "always terminate when exiting early" flag
-				err := r.Client.TerminateWorkflow(
-					ctx, options.StartOptions.ID, "", "client actions failed", nil)
-				if err != nil {
-					return
+				if terminateErr := r.Client.TerminateWorkflow(
+					ctx, options.StartOptions.ID, "", "client actions failed", nil); terminateErr != nil {
+					r.Logger.Errorf("Failed to terminate workflow after client actions failure: %v", terminateErr)
 				}
 			}
 		}()

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -376,10 +376,12 @@ func (e *ebbAndFlowExecutor) spawnWorkflowWithActivities(
 	// Wait for workflow completion
 	var result ebbandflow.WorkflowOutput
 	err = wf.Get(ctx, &result)
-	if err != nil {
-		e.Logger.Errorf("ebbAndFlowTrack workflow failed for iteration %d: %v", iteration, err)
-	}
+	// The batch has settled either way, so drain it from the backlog the
+	// controller tracks; only a successful workflow counts as completed.
 	e.completedActivities.Add(activities)
+	if err != nil {
+		return fmt.Errorf("ebbAndFlowTrack workflow failed for iteration %d: %w", iteration, err)
+	}
 	e.incrementTotalCompletedWorkflow()
 
 	return nil

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -230,7 +230,9 @@ func (e *ebbAndFlowExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo)
 			config.MinBacklog, config.MaxBacklog, config.Period, e.Configuration.Duration)
 	}
 
-	e.RegisterDefaultSearchAttributes(ctx)
+	if err := e.RegisterDefaultSearchAttributes(ctx); err != nil {
+		return fmt.Errorf("failed to register search attributes: %w", err)
+	}
 
 	var started, completed, backlog, target int64
 	lastIteration := time.Now()


### PR DESCRIPTION
## What

A focused error-handling cleanup across the omes Go code, prompted by an audit against our Go error-handling conventions (don't drop errors, log XOR return, branch on values not strings, propagate at boundaries). Each fix is its own commit. Scope was limited to **High** and **Medium** severity findings — bugs and correctness issues — not the broad stylistic layer (noise-prefix messages, capitalized error strings).

## Changes (one commit each)

**1. Return dropped search-attribute registration error (`scenarios/ebb_and_flow.go`)**
`spawnWorkflowWithActivities` called `RegisterDefaultSearchAttributes(ctx)` and ignored its `error`. A registration failure was lost and only surfaced later as an obscure workflow-start error. The sibling caller in `generic_executor.go` already checks this return value.

**2. Surface failed `ebbAndFlowTrack` workflows instead of swallowing them (`scenarios/ebb_and_flow.go`)**
`wf.Get` failures were logged and then `return nil`, so they never reached the `MaxConsecutiveErrors` guard, and a failed workflow was still counted as completed — inflating `TotalCompletedWorkflows`, which post-scenario verification relies on. Now the error is returned and the completion count is gated on success. The backlog still drains on either outcome, so the rate controller's behavior is unchanged.

**3. Fix dropped terminate error and pointer log (`loadgen/scenario.go`)**
In `ExecuteKitchenSinkWorkflow`'s client-actions goroutine, the failure log printed the `atomic.Pointer[error]` value (an address) rather than the error, and the result of the cleanup `TerminateWorkflow` call was silently discarded. Now it logs the actual error, and logs the terminate failure (the goroutine has no return path to propagate it).

**4. Stop double-handling terminal iteration errors (`loadgen/generic_executor.go`)**
The per-iteration goroutine logged a terminal failure *and* sent it on `doneCh`, where `Run` returns it wrapped for its caller to report — the same error handled twice. The terminal branch now propagates only. The retry-branch log is kept on purpose: that error is superseded by the retry and never returned, so the log is its only record.

**5. Branch on gRPC status code, not error string (`loadgen/scenario.go`)**
`RegisterDefaultSearchAttributes` decided whether to ignore an "already exists" failure via `strings.Contains(err.Error(), ...)`. Replaced with `status.Code(err) == codes.AlreadyExists`, matching `ensureNexusEndpoint` in the same file. The second match string was a typo (`"unavailble"`) that could never match the real message, so no working behavior is lost.

**6. Wrap cert-load error with `%w` (`clioptions/client.go`)**
`loadTLSConfig` used `%s` to format the cert-load error, severing the unwrap chain at this library-ish boundary. Switched to `%w`, matching the two sibling wraps in the same function.

## Testing

- `go build` clean across all first-party packages.
- `go test ./clioptions/ ./scenarios/` — pass.
- `go test ./loadgen/` worker-free unit tests (cover the `generic_executor` change) — pass.
- `SDK=go go test ./loadgen/ -run TestKitchenSink` — pass (`ok … 25.5s`); exercises the `ExecuteKitchenSinkWorkflow` and `RegisterDefaultSearchAttributes` paths against a real devserver.

Note: a no-`SDK` `go test ./loadgen/` fails locally because `TestKitchenSink` runs the full SDK matrix (Go/Java/Python/Ruby/TS/.NET) and only the Go worker toolchain is built here. That's environmental and pre-existing — CI sets `SDK` per the test's own skip logic.

