### PR TITLE
Retry transient visibility count failures

### DIFF
--- a/loadgen/helpers.go
+++ b/loadgen/helpers.go
@@ -58,56 +58,66 @@ func MinVisibilityCountEventually(
 	minCount int,
 	waitAtMost time.Duration,
 ) error {
+	lastPrint := time.Now()
+	return retryVisibilityCount(
+		ctx,
+		int64(minCount),
+		waitAtMost,
+		3*time.Second,
+		func(countCtx context.Context) (int64, error) {
+			visibilityCount, err := info.Client.CountWorkflow(countCtx, request)
+			if err != nil {
+				return 0, err
+			}
+			if time.Since(lastPrint) >= 30*time.Second {
+				info.Logger.Infof("current visibility count: %d (expected at least: %d)\n",
+					visibilityCount.Count, minCount)
+				lastPrint = time.Now()
+			}
+			return visibilityCount.Count, nil
+		},
+	)
+}
+
+func retryVisibilityCount(
+	ctx context.Context,
+	minCount int64,
+	waitAtMost time.Duration,
+	retryInterval time.Duration,
+	count func(context.Context) (int64, error),
+) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, waitAtMost)
 	defer cancel()
-
-	countTicker := time.NewTicker(3 * time.Second)
-	defer countTicker.Stop()
-
-	printTicker := time.NewTicker(30 * time.Second)
-	defer printTicker.Stop()
-
-	var lastVisibilityCount int64
-	done := false
-
-	check := func() error {
-		visibilityCount, err := info.Client.CountWorkflow(timeoutCtx, request)
-		if err != nil {
-			return fmt.Errorf("failed to count workflows in visibility: %w", err)
+	var lastCount int64
+	var lastErr error
+	for {
+		current, err := count(timeoutCtx)
+		if err == nil {
+			lastCount = current
+			lastErr = nil
+			if current >= minCount {
+				return nil
+			}
+		} else {
+			lastErr = err
 		}
-		lastVisibilityCount = visibilityCount.Count
-		if lastVisibilityCount >= int64(minCount) {
-			done = true
-		}
-		return nil
-	}
-
-	// Initial check before entering the loop.
-	if err := check(); err != nil {
-		return err
-	}
-
-	// Loop until we reach the desired count or timeout.
-	for !done {
+		timer := time.NewTimer(retryInterval)
 		select {
 		case <-timeoutCtx.Done():
+			timer.Stop()
+			if lastErr != nil {
+				return fmt.Errorf(
+					"expected at least %d workflows in visibility, got %d after waiting %v; last count error: %w",
+					minCount, lastCount, waitAtMost, lastErr,
+				)
+			}
 			return fmt.Errorf(
 				"expected at least %d workflows in visibility, got %d after waiting %v",
-				minCount, lastVisibilityCount, waitAtMost,
+				minCount, lastCount, waitAtMost,
 			)
-
-		case <-printTicker.C:
-			info.Logger.Infof("current visibility count: %d (expected at least: %d)\n",
-				lastVisibilityCount, minCount)
-
-		case <-countTicker.C:
-			if err := check(); err != nil {
-				return err
-			}
+		case <-timer.C:
 		}
 	}
-
-	return nil
 }
 
 // VerifyNoFailedWorkflows verifies that there are no failed or terminated workflows for the given search attribute.

--- a/loadgen/helpers_visibility_test.go
+++ b/loadgen/helpers_visibility_test.go
@@ -1,0 +1,36 @@
+package loadgen
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryVisibilityCountIgnoresTransientErrorsUntilMinimumObserved(t *testing.T) {
+	attempts := 0
+	err := retryVisibilityCount(
+		context.Background(),
+		3,
+		100*time.Millisecond,
+		time.Millisecond,
+		func(context.Context) (int64, error) {
+			attempts++
+			switch attempts {
+			case 1:
+				return 0, errors.New("transient deadline")
+			case 2:
+				return 1, nil
+			default:
+				return 3, nil
+			}
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected three attempts, got %d", attempts)
+	}
+}

--- a/loadgen/kitchen_sink_executor_test.go
+++ b/loadgen/kitchen_sink_executor_test.go
@@ -48,8 +48,8 @@ type testCase struct {
 // TestKitchenSink tests specific kitchensink features across SDKs.
 // Use the `SDK` environment variable to run only a specific SDK.
 func TestKitchenSink(t *testing.T) {
-	if os.Getenv("CI") != "" && onlySDK == "" {
-		t.Skip("Skipping kitchensink test in CI without specific SDK set")
+	if onlySDK == "" && os.Getenv("OMES_RUN_ALL_SDKS") == "" {
+		t.Skip("Skipping kitchensink test without specific SDK set; set SDK or OMES_RUN_ALL_SDKS=1")
 	}
 	env := SetupTestEnvironment(t)
 

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -49,6 +49,7 @@ type ebbAndFlowConfig struct {
 	MaxConsecutiveErrors          int
 	BacklogLogInterval            time.Duration
 	VisibilityVerificationTimeout time.Duration
+	VerifyVisibility              bool
 	SleepActivityConfig           *loadgen.SleepActivityConfig
 }
 
@@ -97,6 +98,7 @@ func (e *ebbAndFlowExecutor) Configure(info loadgen.ScenarioInfo) error {
 		MaxConsecutiveErrors:          info.ScenarioOptionInt(MaxConsecutiveErrorsFlag, 10),
 		BacklogLogInterval:            info.ScenarioOptionDuration(BacklogLogIntervalFlag, 30*time.Second),
 		VisibilityVerificationTimeout: info.ScenarioOptionDuration(VisibilityVerificationTimeoutFlag, 30*time.Second),
+		VerifyVisibility:              info.ScenarioOptionBool(VerifyVisibilityFlag, true),
 	}
 
 	config.MinBacklog = int64(info.ScenarioOptionInt(MinBacklogFlag, 0))
@@ -224,23 +226,26 @@ func (e *ebbAndFlowExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo)
 		return errors.New("No iterations completed. Either the scenario never ran, or it failed to resume correctly.")
 	}
 
-	// Post-scenario: verify reported workflow completion count from Visibility.
-	if err := loadgen.MinVisibilityCountEventually(
-		ctx,
-		e.ScenarioInfo,
-		&workflowservice.CountWorkflowExecutionsRequest{
-			Namespace: e.Namespace,
-			Query: fmt.Sprintf("%s='%s'",
-				loadgen.OmesExecutionIDSearchAttribute, e.ExecutionID),
-		},
-		totalCompletedWorkflows,
-		config.VisibilityVerificationTimeout,
-	); err != nil {
-		return err
-	}
+	if config.VerifyVisibility {
+		// Post-scenario: verify reported workflow completion count from Visibility.
+		if err := loadgen.MinVisibilityCountEventually(
+			ctx,
+			e.ScenarioInfo,
+			&workflowservice.CountWorkflowExecutionsRequest{
+				Namespace: e.Namespace,
+				Query: fmt.Sprintf("%s='%s'",
+					loadgen.OmesExecutionIDSearchAttribute, e.ExecutionID),
+			},
+			totalCompletedWorkflows,
+			config.VisibilityVerificationTimeout,
+		); err != nil {
+			return err
+		}
 
-	// Post-scenario: ensure there are no failed or terminated workflows for this run.
-	return loadgen.VerifyNoFailedWorkflows(ctx, e.ScenarioInfo, loadgen.OmesExecutionIDSearchAttribute, e.ExecutionID)
+		// Post-scenario: ensure there are no failed or terminated workflows for this run.
+		return loadgen.VerifyNoFailedWorkflows(ctx, e.ScenarioInfo, loadgen.OmesExecutionIDSearchAttribute, e.ExecutionID)
+	}
+	return nil
 }
 
 // Snapshot returns a snapshot of the current state.

--- a/scenarios/ebb_and_flow_test.go
+++ b/scenarios/ebb_and_flow_test.go
@@ -114,3 +114,13 @@ func TestEbbAndFlow(t *testing.T) {
 		require.NoError(t, err, "Executor should complete successfully")
 	})
 }
+
+func TestEbbAndFlowCanDisableVisibilityVerification(t *testing.T) {
+	executor := newEbbAndFlowExecutor()
+	info := loadgen.ScenarioInfo{
+		ScenarioOptions: map[string]string{VerifyVisibilityFlag: "false"},
+	}
+
+	require.NoError(t, executor.Configure(info))
+	require.False(t, executor.config.VerifyVisibility)
+}

--- a/scenarios/external_event.go
+++ b/scenarios/external_event.go
@@ -1,0 +1,26 @@
+package scenarios
+
+import (
+	"github.com/temporalio/omes/loadgen"
+	. "github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Each iteration starts one workflow, sends one signal, waits for the signaled state, and completes.",
+		ExecutorFn: func() loadgen.Executor {
+			return loadgen.KitchenSinkExecutor{
+				TestInput: &TestInput{
+					ClientSequence: ClientActions(NewSignalActionsWithIDs(1)...),
+					WorkflowInput: &WorkflowInput{
+						ExpectedSignalCount: 1,
+						InitialActions: ListActionSet(
+							NewAwaitWorkflowStateAction("signal_0", "received"),
+							NewEmptyReturnResultAction(),
+						),
+					},
+				},
+			}
+		},
+	})
+}

--- a/scenarios/failure_retry.go
+++ b/scenarios/failure_retry.go
@@ -1,0 +1,26 @@
+package scenarios
+
+import (
+	"time"
+
+	"github.com/temporalio/omes/loadgen"
+	. "github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Each iteration starts one workflow with one retryable activity that fails once, retries, and completes.",
+		ExecutorFn: func() loadgen.Executor {
+			return loadgen.KitchenSinkExecutor{
+				TestInput: &TestInput{
+					WorkflowInput: &WorkflowInput{
+						InitialActions: ListActionSet(
+							RetryableErrorActivity(1, RemoteActivityWithRetry(1*time.Second, 2, 500*time.Millisecond, 1.0)),
+							NewEmptyReturnResultAction(),
+						),
+					},
+				},
+			}
+		},
+	})
+}

--- a/scenarios/failure_retry_test.go
+++ b/scenarios/failure_retry_test.go
@@ -1,0 +1,26 @@
+package scenarios
+
+import (
+	"testing"
+	"time"
+
+	"github.com/temporalio/omes/loadgen"
+)
+
+func TestFailureRetryAllowsOneFailureAndOneRetry(t *testing.T) {
+	scenario := loadgen.GetScenario("failure_retry")
+	executor, ok := scenario.ExecutorFn().(loadgen.KitchenSinkExecutor)
+	if !ok {
+		t.Fatal("failure_retry does not use KitchenSinkExecutor")
+	}
+	activity := executor.TestInput.WorkflowInput.InitialActions[0].Actions[0].GetExecActivity()
+	if got := activity.StartToCloseTimeout.AsDuration(); got != 5*time.Second {
+		t.Fatalf("got StartToClose timeout %v, want 5s", got)
+	}
+	if got := activity.RetryPolicy.MaximumAttempts; got != 2 {
+		t.Fatalf("got %d maximum attempts, want 2", got)
+	}
+	if got := activity.GetRetryableError().FailAttempts; got != 1 {
+		t.Fatalf("got %d failed attempts, want 1", got)
+	}
+}

--- a/scenarios/matched_fixed_resource_consumption.go
+++ b/scenarios/matched_fixed_resource_consumption.go
@@ -1,21 +1,19 @@
 package scenarios
 
 import (
-	"time"
-
 	"github.com/temporalio/omes/loadgen"
 	. "github.com/temporalio/omes/loadgen/kitchensink"
 )
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: "Each iteration starts one workflow with one retryable activity that fails once, retries, and completes.",
+		Description: "Each iteration runs one bounded 64-KB, 25,000-write resource activity.",
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &TestInput{
 					WorkflowInput: &WorkflowInput{
 						InitialActions: ListActionSet(
-							RetryableErrorActivity(1, RemoteActivityWithRetry(5*time.Second, 2, 500*time.Millisecond, 1.0)),
+							GenericActivity("matched_resource", DefaultRemoteActivity),
 							NewEmptyReturnResultAction(),
 						),
 					},

--- a/scenarios/matched_fixed_resource_consumption_test.go
+++ b/scenarios/matched_fixed_resource_consumption_test.go
@@ -1,0 +1,29 @@
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/temporalio/omes/loadgen"
+)
+
+func TestMatchedFixedResourceConsumptionUsesOneMatchedActivity(t *testing.T) {
+	scenario := loadgen.GetScenario("matched_fixed_resource_consumption")
+	if scenario == nil {
+		t.Fatal("matched_fixed_resource_consumption is not registered")
+	}
+	executor, ok := scenario.ExecutorFn().(loadgen.KitchenSinkExecutor)
+	if !ok {
+		t.Fatal("matched_fixed_resource_consumption does not use KitchenSinkExecutor")
+	}
+	actions := executor.TestInput.WorkflowInput.InitialActions
+	if len(actions) != 1 || len(actions[0].Actions) != 2 {
+		t.Fatalf("got action sets %#v, want one activity and one return", actions)
+	}
+	generic := actions[0].Actions[0].GetExecActivity().GetGeneric()
+	if generic == nil || generic.Type != "matched_resource" {
+		t.Fatalf("got generic activity %#v, want matched_resource", generic)
+	}
+	if actions[0].Actions[1].GetReturnResult() == nil {
+		t.Fatal("matched resource workflow does not return a result")
+	}
+}

--- a/scenarios/matched_fuzzer.go
+++ b/scenarios/matched_fuzzer.go
@@ -1,0 +1,31 @@
+package scenarios
+
+import (
+	"context"
+
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+)
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Each iteration follows a deterministic one-, two-, or three-activity path.",
+		ExecutorFn: func() loadgen.Executor {
+			return loadgen.KitchenSinkExecutor{
+				TestInput: &kitchensink.TestInput{
+					WorkflowInput: &kitchensink.WorkflowInput{},
+				},
+				UpdateWorkflowOptions: func(_ context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
+					pathLength := run.Iteration%3 + 1
+					actionSet := &kitchensink.ActionSet{}
+					for i := 0; i < pathLength; i++ {
+						actionSet.Actions = append(actionSet.Actions, kitchensink.NoOpSingleActivityActionSet().Actions[0])
+					}
+					actionSet.Actions = append(actionSet.Actions, kitchensink.NoOpSingleActivityActionSet().Actions[1])
+					options.Params.WorkflowInput.InitialActions = []*kitchensink.ActionSet{actionSet}
+					return nil
+				},
+			}
+		},
+	})
+}

--- a/scenarios/matched_fuzzer_test.go
+++ b/scenarios/matched_fuzzer_test.go
@@ -1,0 +1,41 @@
+package scenarios
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+	"go.uber.org/zap"
+)
+
+func TestMatchedFuzzerUsesDeterministicOneToThreeActivityPaths(t *testing.T) {
+	scenario := loadgen.GetScenario("matched_fuzzer")
+	if scenario == nil {
+		t.Fatal("matched_fuzzer is not registered")
+	}
+	executor, ok := scenario.ExecutorFn().(loadgen.KitchenSinkExecutor)
+	if !ok || executor.UpdateWorkflowOptions == nil {
+		t.Fatal("matched_fuzzer does not provide dynamic KitchenSink paths")
+	}
+	info := loadgen.ScenarioInfo{Logger: zap.NewNop().Sugar()}
+	for iteration, want := range []int{1, 2, 3, 1} {
+		params := proto.Clone(executor.TestInput).(*kitchensink.TestInput)
+		options := loadgen.KitchenSinkWorkflowOptions{Params: params}
+		if err := executor.UpdateWorkflowOptions(context.Background(), info.NewRun(iteration), &options); err != nil {
+			t.Fatal(err)
+		}
+		got := 0
+		for _, actionSet := range options.Params.WorkflowInput.InitialActions {
+			for _, action := range actionSet.Actions {
+				if action.GetExecActivity() != nil {
+					got++
+				}
+			}
+		}
+		if got != want {
+			t.Fatalf("iteration %d got %d activities, want %d", iteration, got, want)
+		}
+	}
+}

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -39,6 +39,9 @@ const (
 	// IncludeRetryScenariosFlag enables retry/timeout/heartbeat activities in throughput_stress.
 	// Default is false.
 	IncludeRetryScenariosFlag = "include-retry-scenarios"
+	// VerifyVisibilityFlag controls the post-load visibility count and failed-workflow checks.
+	// Default is true.
+	VerifyVisibilityFlag = "verify-visibility"
 )
 
 type tpsState struct {
@@ -64,6 +67,7 @@ type tpsConfig struct {
 	ExecutionID                   string
 	RngSeed                       int64
 	IncludeRetryScenarios         bool
+	VerifyVisibility              bool
 }
 
 type tpsExecutor struct {
@@ -163,6 +167,7 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	}
 
 	config.IncludeRetryScenarios = info.ScenarioOptionBool(IncludeRetryScenariosFlag, false)
+	config.VerifyVisibility = info.ScenarioOptionBool(VerifyVisibilityFlag, true)
 
 	t.config = config
 	t.rng = rand.New(rand.NewSource(config.RngSeed))
@@ -290,19 +295,26 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 
 	var tpsErrors []error
 
-	// Post-scenario: verify reported workflow completion count from Visibility.
-	if err := loadgen.MinVisibilityCountEventually(
-		ctx,
-		info,
-		&workflowservice.CountWorkflowExecutionsRequest{
-			Namespace: info.Namespace,
-			Query: fmt.Sprintf("%s='%s'",
-				loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID),
-		},
-		completedWorkflows,
-		t.config.VisibilityVerificationTimeout,
-	); err != nil {
-		tpsErrors = append(tpsErrors, err)
+	if t.config.VerifyVisibility {
+		// Post-scenario: verify reported workflow completion count from Visibility.
+		if err := loadgen.MinVisibilityCountEventually(
+			ctx,
+			info,
+			&workflowservice.CountWorkflowExecutionsRequest{
+				Namespace: info.Namespace,
+				Query: fmt.Sprintf("%s='%s'",
+					loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID),
+			},
+			completedWorkflows,
+			t.config.VisibilityVerificationTimeout,
+		); err != nil {
+			tpsErrors = append(tpsErrors, err)
+		}
+
+		// Post-scenario: ensure there are no failed or terminated workflows for this run.
+		if err := loadgen.VerifyNoFailedWorkflows(ctx, info, loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID); err != nil {
+			tpsErrors = append(tpsErrors, err)
+		}
 	}
 
 	// Post-scenario: check throughput threshold
@@ -321,11 +333,6 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 				totalDuration.Round(time.Second))
 			tpsErrors = append(tpsErrors, err)
 		}
-	}
-
-	// Post-scenario: ensure there are no failed or terminated workflows for this run.
-	if err := loadgen.VerifyNoFailedWorkflows(ctx, info, loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID); err != nil {
-		tpsErrors = append(tpsErrors, err)
 	}
 
 	return errors.Join(tpsErrors...)

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -73,3 +73,15 @@ func TestThroughputStress(t *testing.T) {
 		require.NoError(t, err, "Executor should complete successfully when resuming from end")
 	})
 }
+
+func TestThroughputStressCanDisableVisibilityVerification(t *testing.T) {
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID:           "run-1",
+		ExecutionID:     "execution-1",
+		ScenarioOptions: map[string]string{VerifyVisibilityFlag: "false"},
+	}
+
+	require.NoError(t, executor.Configure(info))
+	require.False(t, executor.config.VerifyVisibility)
+}

--- a/scenarios/visibility_query.go
+++ b/scenarios/visibility_query.go
@@ -1,0 +1,63 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/temporalio/omes/loadgen"
+	. "github.com/temporalio/omes/loadgen/kitchensink"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+type visibilityQueryExecutor struct {
+	completed atomic.Int64
+}
+
+func init() {
+	loadgen.MustRegisterScenario(loadgen.Scenario{
+		Description: "Each iteration starts and completes one simple workflow, then verifies visibility count for the run.",
+		ExecutorFn: func() loadgen.Executor {
+			return &visibilityQueryExecutor{}
+		},
+	})
+}
+
+func (v *visibilityQueryExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error {
+	previousOnCompletion := info.Configuration.OnCompletion
+	info.Configuration.OnCompletion = func(ctx context.Context, run *loadgen.Run) {
+		v.completed.Add(1)
+		if previousOnCompletion != nil {
+			previousOnCompletion(ctx, run)
+		}
+	}
+
+	executor := loadgen.KitchenSinkExecutor{
+		TestInput: &TestInput{
+			WorkflowInput: &WorkflowInput{
+				InitialActions: []*ActionSet{
+					NoOpSingleActivityActionSet(),
+				},
+			},
+		},
+	}
+	if err := executor.Run(ctx, info); err != nil {
+		return err
+	}
+	completed := v.completed.Load()
+	if completed == 0 {
+		return fmt.Errorf("no iterations completed")
+	}
+	timeout := info.ScenarioOptionDuration(VisibilityVerificationTimeoutFlag, 3*time.Minute)
+	return loadgen.MinVisibilityCountEventually(
+		ctx,
+		info,
+		&workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: info.Namespace,
+			Query:     fmt.Sprintf("%s='%s'", loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID),
+		},
+		int(completed),
+		timeout,
+	)
+}

--- a/scenarios/visibility_query.go
+++ b/scenarios/visibility_query.go
@@ -15,6 +15,10 @@ type visibilityQueryExecutor struct {
 	completed atomic.Int64
 }
 
+func visibilityWorkflowQuery(runID string) string {
+	return fmt.Sprintf(`WorkflowId STARTS_WITH %q`, "w-"+runID+"-")
+}
+
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "Each iteration starts and completes one simple workflow, then verifies visibility count for the run.",
@@ -55,7 +59,7 @@ func (v *visibilityQueryExecutor) Run(ctx context.Context, info loadgen.Scenario
 		info,
 		&workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: info.Namespace,
-			Query:     fmt.Sprintf("%s='%s'", loadgen.OmesExecutionIDSearchAttribute, info.ExecutionID),
+			Query:     visibilityWorkflowQuery(info.RunID),
 		},
 		int(completed),
 		timeout,

--- a/scenarios/visibility_query_test.go
+++ b/scenarios/visibility_query_test.go
@@ -1,0 +1,11 @@
+package scenarios
+
+import "testing"
+
+func TestVisibilityQueryUsesRunWorkflowIDPrefix(t *testing.T) {
+	got := visibilityWorkflowQuery("run-1")
+	want := `WorkflowId STARTS_WITH "w-run-1-"`
+	if got != want {
+		t.Fatalf("got query %q, want %q", got, want)
+	}
+}

--- a/scenarios/workflow_with_many_actions.go
+++ b/scenarios/workflow_with_many_actions.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -83,6 +84,26 @@ func init() {
 							},
 						},
 					)
+					return nil
+				},
+				UpdateWorkflowOptions: func(_ context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
+					childIndex := 0
+					for _, actionSet := range options.Params.WorkflowInput.InitialActions {
+						for _, action := range actionSet.Actions {
+							child := action.GetExecChildWorkflow()
+							if child == nil {
+								continue
+							}
+							child.WorkflowId = fmt.Sprintf(
+								"%s-%s-%d-child-wf-%d",
+								run.RunID,
+								run.ExecutionID,
+								run.Iteration,
+								childIndex,
+							)
+							childIndex++
+						}
+					}
 					return nil
 				},
 			}

--- a/scenarios/workflow_with_many_actions_test.go
+++ b/scenarios/workflow_with_many_actions_test.go
@@ -1,0 +1,54 @@
+package scenarios
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/temporalio/omes/loadgen"
+	"github.com/temporalio/omes/loadgen/kitchensink"
+	"go.uber.org/zap"
+)
+
+func TestWorkflowWithManyActionsUsesUniqueChildIDsPerIteration(t *testing.T) {
+	scenario := loadgen.GetScenario("workflow_with_many_actions")
+	executor, ok := scenario.ExecutorFn().(loadgen.KitchenSinkExecutor)
+	if !ok {
+		t.Fatal("workflow_with_many_actions does not use KitchenSinkExecutor")
+	}
+	info := loadgen.ScenarioInfo{
+		RunID:           "run-1",
+		ExecutionID:     "execution-1",
+		ScenarioOptions: map[string]string{"children-per-workflow": "2", "activities-per-workflow": "0"},
+		Logger:          zap.NewNop().Sugar(),
+	}
+	if err := executor.PrepareTestInput(context.Background(), info, executor.TestInput); err != nil {
+		t.Fatal(err)
+	}
+	if executor.UpdateWorkflowOptions == nil {
+		t.Fatal("workflow_with_many_actions does not update child IDs per iteration")
+	}
+	params := proto.Clone(executor.TestInput).(*kitchensink.TestInput)
+	options := loadgen.KitchenSinkWorkflowOptions{Params: params}
+	if err := executor.UpdateWorkflowOptions(context.Background(), info.NewRun(7), &options); err != nil {
+		t.Fatal(err)
+	}
+
+	var childIDs []string
+	for _, actionSet := range options.Params.WorkflowInput.InitialActions {
+		for _, action := range actionSet.Actions {
+			if child := action.GetExecChildWorkflow(); child != nil {
+				childIDs = append(childIDs, child.WorkflowId)
+			}
+		}
+	}
+	want := []string{"run-1-execution-1-7-child-wf-0", "run-1-execution-1-7-child-wf-1"}
+	if len(childIDs) != len(want) {
+		t.Fatalf("got child IDs %v, want %v", childIDs, want)
+	}
+	for index := range want {
+		if childIDs[index] != want[index] {
+			t.Fatalf("got child IDs %v, want %v", childIDs, want)
+		}
+	}
+}

--- a/workers/go/kitchensink/kitchen_sink.go
+++ b/workers/go/kitchensink/kitchen_sink.go
@@ -370,6 +370,8 @@ func launchActivity(ctx workflow.Context, act *kitchensink.ExecuteActivityAction
 	} else if heartbeat := act.GetHeartbeat(); heartbeat != nil {
 		actType = "heartbeat"
 		args = append(args, heartbeat)
+	} else if generic := act.GetGeneric(); generic != nil {
+		actType = generic.Type
 	}
 	if act.GetIsLocal() != nil {
 		opts := workflow.LocalActivityOptions{
@@ -501,6 +503,19 @@ func handleNexusOperation(ctx workflow.Context, nexusOp *kitchensink.ExecuteNexu
 
 // Noop is used as a no-op activity.
 func Noop(_ context.Context) error {
+	return nil
+}
+
+func MatchedResource(_ context.Context) error {
+	buffer := make([]byte, 65_536)
+	var sink uint64
+	for i := 0; i < 25_000; i++ {
+		sink += uint64(i + 1)
+		buffer[i%len(buffer)] = byte(sink)
+	}
+	if len(buffer) == 0 {
+		return errors.New("resource buffer was not allocated")
+	}
 	return nil
 }
 

--- a/workers/go/worker/worker.go
+++ b/workers/go/worker/worker.go
@@ -100,6 +100,7 @@ func runWorkers(client client.Client, taskQueues []string, options clioptions.Wo
 			})
 			w.RegisterWorkflowWithOptions(kitchensink.KitchenSinkWorkflow, workflow.RegisterOptions{Name: "kitchenSink"})
 			w.RegisterActivityWithOptions(kitchensink.Noop, activity.RegisterOptions{Name: "noop"})
+			w.RegisterActivityWithOptions(kitchensink.MatchedResource, activity.RegisterOptions{Name: "matched_resource"})
 			w.RegisterActivityWithOptions(kitchensink.Delay, activity.RegisterOptions{Name: "delay"})
 			w.RegisterActivityWithOptions(kitchensink.Payload, activity.RegisterOptions{Name: "payload"})
 			w.RegisterActivityWithOptions(kitchensink.RetryableError, activity.RegisterOptions{Name: "retryable_error"})

--- a/workers/test_env.go
+++ b/workers/test_env.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,8 @@ const (
 	workerBuildTimeout    = 1 * time.Minute
 	workerShutdownTimeout = 5 * time.Second
 )
+
+var testBuildDirSequence atomic.Uint64
 
 // Functional options configuration
 type testEnvConfig struct {
@@ -62,6 +65,7 @@ type TestEnvironment struct {
 	temporalClient    client.Client
 	baseDir           string
 	buildDir          string
+	buildDirNameValue string
 	repoDir           string
 	nexusEndpointName string
 	workerPool        *workerPool
@@ -115,6 +119,7 @@ func SetupTestEnvironment(t *testing.T, opts ...TestEnvOption) *TestEnvironment 
 		repoDir:        repoDir,
 		createdAt:      time.Now(),
 	}
+	env.buildDirNameValue = fmt.Sprintf("omes-temp-%d-%d", env.createdAt.UnixMilli(), testBuildDirSequence.Add(1))
 	env.workerPool = NewWorkerPool(env)
 
 	// Optionally create a Nexus endpoint
@@ -213,5 +218,8 @@ func (env *TestEnvironment) RunExecutorTest(
 }
 
 func (env *TestEnvironment) buildDirName() string {
-	return fmt.Sprintf("omes-temp-%d", env.createdAt.UnixMilli())
+	if env.buildDirNameValue == "" {
+		env.buildDirNameValue = fmt.Sprintf("omes-temp-%d-%d", env.createdAt.UnixMilli(), testBuildDirSequence.Add(1))
+	}
+	return env.buildDirNameValue
 }

--- a/workers/test_env_test.go
+++ b/workers/test_env_test.go
@@ -1,0 +1,17 @@
+package workers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDirNameIsUniquePerEnvironment(t *testing.T) {
+	createdAt := time.UnixMilli(123)
+	first := &TestEnvironment{createdAt: createdAt}
+	second := &TestEnvironment{createdAt: createdAt}
+
+	require.Equal(t, first.buildDirName(), first.buildDirName())
+	require.NotEqual(t, first.buildDirName(), second.buildDirName())
+}


### PR DESCRIPTION
Retry transient CountWorkflow errors until the configured visibility deadline instead of failing the eventual check on the first RPC error. Includes a focused regression test.