### PR TITLE
Allow multiple server addresses

### DIFF
--- a/clioptions/client.go
+++ b/clioptions/client.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"sync/atomic"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/pflag"
@@ -15,9 +17,13 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
 )
 
 const AUTH_HEADER_ENV_VAR = "TEMPORAL_OMES_AUTH_HEADER"
+
+var manualResolverID atomic.Int64
 
 type headersProvider map[string]string
 
@@ -33,6 +39,8 @@ func newHeadersProvider(headers map[string]string) headersProvider {
 type ClientOptions struct {
 	// Address of Temporal server to connect to
 	Address string
+	// Addresses of Temporal servers to connect to
+	Addresses []string
 	// Temporal namespace
 	Namespace string
 	// Enable TLS
@@ -49,6 +57,55 @@ type ClientOptions struct {
 	DisableHostVerification bool
 
 	fs *pflag.FlagSet
+}
+
+func (c *ClientOptions) ServerAddresses() []string {
+	addresses := c.Addresses
+	if len(addresses) == 0 {
+		address := c.Address
+		if address == "" {
+			address = client.DefaultHostPort
+		}
+		addresses = []string{address}
+	}
+
+	out := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		address = strings.TrimSpace(address)
+		if address != "" {
+			out = append(out, address)
+		}
+	}
+	return out
+}
+
+func (c *ClientOptions) ServerAddress() string {
+	return strings.Join(c.ServerAddresses(), ",")
+}
+
+func (c *ClientOptions) UsesDefaultServerAddress() bool {
+	addresses := c.ServerAddresses()
+	return len(addresses) == 1 && addresses[0] == client.DefaultHostPort
+}
+
+func (c *ClientOptions) HostPort() (string, error) {
+	addresses := c.ServerAddresses()
+	if len(addresses) == 0 {
+		return "", errors.New("at least one server address is required")
+	}
+	if len(addresses) == 1 {
+		return addresses[0], nil
+	}
+
+	scheme := fmt.Sprintf("omes-manual-%d", manualResolverID.Add(1))
+	builder := manual.NewBuilderWithScheme(scheme)
+	resolverAddresses := make([]resolver.Address, len(addresses))
+	for i, address := range addresses {
+		resolverAddresses[i] = resolver.Address{Addr: address}
+	}
+	builder.InitialState(resolver.State{Addresses: resolverAddresses})
+	resolver.Register(builder)
+	return scheme + ":///temporal", nil
 }
 
 // loadTLSConfig inits a TLS config from the provided cert and key files.
@@ -92,8 +149,12 @@ func (c *ClientOptions) Dial(metrics *metrics.Metrics, logger *zap.SugaredLogger
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)
 	}
+	hostPort, err := c.HostPort()
+	if err != nil {
+		return nil, err
+	}
 	var clientOptions client.Options
-	clientOptions.HostPort = c.Address
+	clientOptions.HostPort = hostPort
 	clientOptions.Namespace = c.Namespace
 	clientOptions.ConnectionOptions.TLS = tlsCfg
 	clientOptions.Logger = NewZapAdapter(logger.Desugar())
@@ -117,7 +178,7 @@ func (c *ClientOptions) Dial(metrics *metrics.Metrics, logger *zap.SugaredLogger
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %w", err)
 	}
-	logger.Infof("Client connected to %s, namespace: %s", c.Address, c.Namespace)
+	logger.Infof("Client connected to %s, namespace: %s", c.ServerAddress(), c.Namespace)
 	return client, nil
 }
 
@@ -139,7 +200,15 @@ func (c *ClientOptions) FlagSet() *pflag.FlagSet {
 	}
 
 	c.fs = pflag.NewFlagSet("client_options", pflag.ExitOnError)
-	c.fs.StringVar(&c.Address, "server-address", client.DefaultHostPort, "Address of Temporal server")
+	defaultAddresses := c.Addresses
+	if len(defaultAddresses) == 0 {
+		address := c.Address
+		if address == "" {
+			address = client.DefaultHostPort
+		}
+		defaultAddresses = []string{address}
+	}
+	c.fs.StringArrayVar(&c.Addresses, "server-address", defaultAddresses, "Address of Temporal server; may be supplied multiple times")
 	c.fs.StringVar(&c.Namespace, "namespace", client.DefaultNamespace, "Namespace to connect to")
 	c.fs.BoolVar(&c.EnableTLS, "tls", false, "Enable TLS")
 	c.fs.StringVar(&c.ClientCertPath, "tls-cert-path", "", "Path to client TLS certificate")

--- a/clioptions/client_test.go
+++ b/clioptions/client_test.go
@@ -1,0 +1,95 @@
+package clioptions
+
+import (
+	"strings"
+	"testing"
+
+	"go.temporal.io/sdk/client"
+)
+
+func TestClientOptionsServerAddresses(t *testing.T) {
+	tests := []struct {
+		name string
+		opts ClientOptions
+		want []string
+	}{
+		{
+			name: "default",
+			want: []string{client.DefaultHostPort},
+		},
+		{
+			name: "legacy address",
+			opts: ClientOptions{Address: "127.0.0.1:7234"},
+			want: []string{"127.0.0.1:7234"},
+		},
+		{
+			name: "addresses",
+			opts: ClientOptions{Addresses: []string{"127.0.0.1:7234", "127.0.0.1:8234"}},
+			want: []string{"127.0.0.1:7234", "127.0.0.1:8234"},
+		},
+		{
+			name: "trims empty",
+			opts: ClientOptions{Addresses: []string{" 127.0.0.1:7234 ", ""}},
+			want: []string{"127.0.0.1:7234"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.opts.ServerAddresses()
+			if len(got) != len(test.want) {
+				t.Fatalf("expected %v, got %v", test.want, got)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Fatalf("expected %v, got %v", test.want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestClientOptionsRepeatedServerAddressFlag(t *testing.T) {
+	var opts ClientOptions
+	fs := opts.FlagSet()
+	if err := fs.Set("server-address", "127.0.0.1:7234"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Set("server-address", "127.0.0.1:8234"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := opts.ServerAddresses()
+	want := []string{"127.0.0.1:7234", "127.0.0.1:8234"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestClientOptionsHostPort(t *testing.T) {
+	single, err := (&ClientOptions{Addresses: []string{"127.0.0.1:7234"}}).HostPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if single != "127.0.0.1:7234" {
+		t.Fatalf("expected single address, got %q", single)
+	}
+
+	multi, err := (&ClientOptions{Addresses: []string{"127.0.0.1:7234", "127.0.0.1:8234"}}).HostPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(multi, "omes-manual-") || !strings.HasSuffix(multi, ":///temporal") {
+		t.Fatalf("expected manual resolver target, got %q", multi)
+	}
+
+	_, err = (&ClientOptions{Addresses: []string{"", " "}}).HostPort()
+	if err == nil {
+		t.Fatal("expected empty address list to fail")
+	}
+}

--- a/internal/workerctl/run.go
+++ b/internal/workerctl/run.go
@@ -48,13 +48,16 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 	if r.TaskQueueName == "" {
 		return fmt.Errorf("task queue name is required")
 	}
+	if len(r.ClientOptions.ServerAddresses()) > 1 && r.SdkOptions.Language != clioptions.LangGo {
+		return fmt.Errorf("multiple server addresses are only supported by Go workers")
+	}
 
 	// Run an embedded server if requested
 	if r.EmbeddedServer || r.EmbeddedServerAddress != "" {
 		// Intentionally don't use context, will stop on defer
 		if r.ClientOptions.EnableTLS || r.ClientOptions.ClientCertPath != "" || r.ClientOptions.ClientKeyPath != "" {
 			return fmt.Errorf("cannot use TLS with embedded server")
-		} else if r.ClientOptions.Address != client.DefaultHostPort {
+		} else if !r.ClientOptions.UsesDefaultServerAddress() {
 			return fmt.Errorf("cannot supply non-default client address when using embedded server")
 		}
 		server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
@@ -68,7 +71,7 @@ func (r *Runner) Run(ctx context.Context, baseDir string) error {
 			return fmt.Errorf("failed starting embedded server: %w", err)
 		}
 		r.ClientOptions.FlagSet().Set("server-address", server.FrontendHostPort())
-		r.Logger.Infof("Started embedded local server at: %v", r.ClientOptions.Address)
+		r.Logger.Infof("Started embedded local server at: %v", r.ClientOptions.ServerAddress())
 		defer func() {
 			r.Logger.Info("Stopping embedded local server")
 			if err := server.Stop(); err != nil {
@@ -219,10 +222,14 @@ func passthrough(fs *pflag.FlagSet, prefix string) (flags []string) {
 		if !f.Changed {
 			return
 		}
-		flags = append(flags, fmt.Sprintf("--%s=%s",
-			strings.TrimPrefix(f.Name, prefix),
-			f.Value.String(),
-		))
+		name := strings.TrimPrefix(f.Name, prefix)
+		if value, ok := f.Value.(pflag.SliceValue); ok {
+			for _, item := range value.GetSlice() {
+				flags = append(flags, fmt.Sprintf("--%s=%s", name, item))
+			}
+			return
+		}
+		flags = append(flags, fmt.Sprintf("--%s=%s", name, f.Value.String()))
 	})
 	return
 }
@@ -238,6 +245,12 @@ func passthroughExcluding(fs *pflag.FlagSet, prefix string, exclude ...string) (
 		}
 		name := strings.TrimPrefix(f.Name, prefix)
 		if excludeSet[name] {
+			return
+		}
+		if value, ok := f.Value.(pflag.SliceValue); ok {
+			for _, item := range value.GetSlice() {
+				flags = append(flags, fmt.Sprintf("--%s=%s", name, item))
+			}
 			return
 		}
 		flags = append(flags, fmt.Sprintf("--%s=%s", name, f.Value.String()))

--- a/internal/workerctl/run_test.go
+++ b/internal/workerctl/run_test.go
@@ -1,8 +1,12 @@
 package workerctl
 
 import (
+	"context"
 	"slices"
+	"strings"
 	"testing"
+
+	"github.com/temporalio/omes/clioptions"
 )
 
 func TestWithEnv(t *testing.T) {
@@ -62,5 +66,42 @@ func TestWithEnv(t *testing.T) {
 				t.Fatalf("expected %v, got %v", test.want, got)
 			}
 		})
+	}
+}
+
+func TestPassthroughPreservesRepeatedServerAddresses(t *testing.T) {
+	var opts clioptions.ClientOptions
+	fs := opts.FlagSet()
+	if err := fs.Set("server-address", "127.0.0.1:7234"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Set("server-address", "127.0.0.1:8234"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := passthrough(fs, "")
+	want := []string{
+		"--server-address=127.0.0.1:7234",
+		"--server-address=127.0.0.1:8234",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestRunnerRejectsMultipleServerAddressesForNonGoWorkers(t *testing.T) {
+	r := Runner{
+		Builder: Builder{
+			SdkOptions: clioptions.SdkOptions{Language: clioptions.LangTypeScript},
+		},
+		TaskQueueName: "omes",
+		ClientOptions: clioptions.ClientOptions{
+			Addresses: []string{"127.0.0.1:7234", "127.0.0.1:8234"},
+		},
+	}
+
+	err := r.Run(context.Background(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "multiple server addresses") {
+		t.Fatalf("expected multiple server addresses error, got %v", err)
 	}
 }

--- a/scenarios/project/project.go
+++ b/scenarios/project/project.go
@@ -84,13 +84,16 @@ func (e *projectScenarioExecutor) Run(ctx context.Context, info loadgen.Scenario
 	defer stopProjectProcess("project-server", serverCancel, serverCmd, info.Logger)
 
 	co := info.ClientOptions
+	if len(co.ServerAddresses()) != 1 {
+		return fmt.Errorf("project scenario supports exactly one server address")
+	}
 	handle, err := newProjectHandle(ctx, port, &api.InitRequest{
 		ExecutionId: info.ExecutionID,
 		RunId:       info.RunID,
 		TaskQueue:   taskQueue,
 		ConnectOptions: &api.ConnectOptions{
 			Namespace:               co.Namespace,
-			ServerAddress:           co.Address,
+			ServerAddress:           co.ServerAddress(),
 			AuthHeader:              co.AuthHeader,
 			EnableTls:               co.EnableTLS,
 			TlsCertPath:             co.ClientCertPath,

--- a/workers/go/harness/worker.go
+++ b/workers/go/harness/worker.go
@@ -60,9 +60,13 @@ func runWorkerCLI(workerFactory WorkerFactory, clientFactory ClientFactory, argv
 	}
 	defer logger.Sync()
 
+	serverAddress, err := options.clientOptions.HostPort()
+	if err != nil {
+		return err
+	}
 	config, err := buildClientConfig(clientConfigOptions{
 		Logger:                  logger,
-		ServerAddress:           options.clientOptions.Address,
+		ServerAddress:           serverAddress,
 		Namespace:               options.clientOptions.Namespace,
 		AuthHeader:              options.clientOptions.AuthHeader,
 		EnableTLS:               options.clientOptions.EnableTLS,

--- a/workers/go/harness/worker_test.go
+++ b/workers/go/harness/worker_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,31 @@ func TestRunWorkerCLIPassesSharedClientAndWorkerContext(t *testing.T) {
 		if !context.ErrOnUnimplemented {
 			t.Fatal("expected err-on-unimplemented in worker context")
 		}
+	}
+}
+
+func TestRunWorkerCLIUsesResolverForMultipleServerAddresses(t *testing.T) {
+	var gotConfig ClientConfig
+
+	err := runWorkerCLI(
+		func(client sdkclient.Client, context WorkerContext) sdkworker.Worker {
+			return fakeWorker{}
+		},
+		func(config ClientConfig) (sdkclient.Client, error) {
+			gotConfig = config
+			return clientStub{}, nil
+		},
+		[]string{
+			"--task-queue", "omes",
+			"--server-address", "127.0.0.1:7234",
+			"--server-address", "127.0.0.1:8234",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotConfig.TargetHost, "omes-manual-") || !strings.HasSuffix(gotConfig.TargetHost, ":///temporal") {
+		t.Fatalf("expected resolver target, got %q", gotConfig.TargetHost)
 	}
 }
 


### PR DESCRIPTION
## Summary

Allows `--server-address` to be supplied multiple times for Omes client calls. When more than one address is configured, Omes registers a manual gRPC resolver target so the Go SDK can round-robin across the provided Temporal frontends.

For `run-scenario-with-worker`, repeated client flags are preserved when launching the worker process. Go workers support the same multi-address resolver path inside the worker process. Non-Go worker runs fail immediately when multiple addresses are supplied, since their harnesses currently accept a single target string.

The direct non-Go worker harness CLIs are intentionally unchanged in this PR.

## Test plan

- [x] `go test ./clioptions ./internal/workerctl ./scenarios/project`
- [x] `cd workers/go/harness && go test ./...`
- [x] `go test ./cmd/omes`

Note: I also tried root `go test ./...`, but interrupted it after several minutes in long-running loadgen/scenario tests.