### PR TITLE
Bump go to 1.26.5 and run `go fix`

### DIFF
--- a/clioptions/client.go
+++ b/clioptions/client.go
@@ -153,7 +153,7 @@ func (c *ClientOptions) FlagSet() *pflag.FlagSet {
 
 type PassThroughPayloadConverter struct{}
 
-func (p *PassThroughPayloadConverter) ToPayload(value interface{}) (*common.Payload, error) {
+func (p *PassThroughPayloadConverter) ToPayload(value any) (*common.Payload, error) {
 	if valuePayload, ok := value.(*common.Payload); ok {
 		asBytes, err := proto.Marshal(valuePayload)
 		if err != nil {
@@ -170,7 +170,7 @@ func (p *PassThroughPayloadConverter) ToPayload(value interface{}) (*common.Payl
 	return nil, nil
 }
 
-func (p *PassThroughPayloadConverter) FromPayload(payload *common.Payload, valuePtr interface{}) error {
+func (p *PassThroughPayloadConverter) FromPayload(payload *common.Payload, valuePtr any) error {
 	innerPayload := &common.Payload{}
 	err := proto.Unmarshal(payload.GetData(), innerPayload)
 	if err != nil {

--- a/clioptions/zap_adapter.go
+++ b/clioptions/zap_adapter.go
@@ -19,7 +19,7 @@ func NewZapAdapter(zapLogger *zap.Logger) *ZapAdapter {
 	}
 }
 
-func (log *ZapAdapter) fields(keyvals []interface{}) []zap.Field {
+func (log *ZapAdapter) fields(keyvals []any) []zap.Field {
 	if len(keyvals)%2 != 0 {
 		return []zap.Field{zap.Error(fmt.Errorf("odd number of keyvals pairs: %v", keyvals))}
 	}
@@ -36,22 +36,22 @@ func (log *ZapAdapter) fields(keyvals []interface{}) []zap.Field {
 	return fields
 }
 
-func (log *ZapAdapter) Debug(msg string, keyvals ...interface{}) {
+func (log *ZapAdapter) Debug(msg string, keyvals ...any) {
 	log.zl.Debug(msg, log.fields(keyvals)...)
 }
 
-func (log *ZapAdapter) Info(msg string, keyvals ...interface{}) {
+func (log *ZapAdapter) Info(msg string, keyvals ...any) {
 	log.zl.Info(msg, log.fields(keyvals)...)
 }
 
-func (log *ZapAdapter) Warn(msg string, keyvals ...interface{}) {
+func (log *ZapAdapter) Warn(msg string, keyvals ...any) {
 	log.zl.Warn(msg, log.fields(keyvals)...)
 }
 
-func (log *ZapAdapter) Error(msg string, keyvals ...interface{}) {
+func (log *ZapAdapter) Error(msg string, keyvals ...any) {
 	log.zl.Error(msg, log.fields(keyvals)...)
 }
 
-func (log *ZapAdapter) With(keyvals ...interface{}) log.Logger {
+func (log *ZapAdapter) With(keyvals ...any) log.Logger {
 	return &ZapAdapter{zl: log.zl.With(log.fields(keyvals)...)}
 }

--- a/cmd/dev/github.go
+++ b/cmd/dev/github.go
@@ -30,7 +30,7 @@ func writeGitHubEnv(name string, value string) (retErr error) {
 		}
 	}()
 
-	msg := []byte(fmt.Sprintf("%s=%s\n", name, value))
+	msg := fmt.Appendf(nil, "%s=%s\n", name, value)
 	if _, err := f.Write(msg); err != nil {
 		retErr = fmt.Errorf(errFileCmdFmt, err)
 		return

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -114,8 +114,8 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 		key, value := pieces[0], pieces[1]
 
 		// If the value starts with '@', read the file and use its contents as the value.
-		if strings.HasPrefix(value, "@") {
-			filePath := strings.TrimPrefix(value, "@")
+		if after, ok := strings.CutPrefix(value, "@"); ok {
+			filePath := after
 			data, err := os.ReadFile(filePath)
 			if err != nil {
 				return fmt.Errorf("failed to read file %s: %w", filePath, err)

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -1,7 +1,7 @@
 # Build in a full featured container
 ARG TARGETARCH
 
-FROM --platform=linux/$TARGETARCH golang:1.25 AS build
+FROM --platform=linux/$TARGETARCH golang:1.26 AS build
 
 WORKDIR /app
 

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,6 +1,6 @@
 # Build in a full featured container
 ARG TARGETARCH
-FROM --platform=linux/$TARGETARCH golang:1.25 AS build
+FROM --platform=linux/$TARGETARCH golang:1.26 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/omes
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/gofrs/flock v0.13.0

--- a/internal/workertest/historyrequire.go
+++ b/internal/workertest/historyrequire.go
@@ -3,6 +3,7 @@ package workertest
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,7 +93,7 @@ func (m FullHistoryMatcher) Match(t *testing.T, actualHistoryEvents []*historypb
 	var expectedDump strings.Builder
 	maxLines := max(len(actualEvents), len(expectedEvents))
 
-	for i := 0; i < maxLines; i++ {
+	for i := range maxLines {
 		lineNumber := i + 1
 
 		var expectedEvent event
@@ -242,9 +243,7 @@ func extractFields(event *historypb.HistoryEvent) map[string]any {
 	for k, v := range raw {
 		if strings.HasSuffix(k, "Attributes") {
 			if inner, ok := v.(map[string]any); ok {
-				for ik, iv := range inner {
-					result[ik] = iv
-				}
+				maps.Copy(result, inner)
 			}
 		} else if k != "eventId" && k != "eventType" {
 			result[k] = v

--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -136,7 +136,7 @@ func (d *fixedDistribution[T]) Sample(_ *rand.Rand) (T, bool) {
 }
 
 func (d *fixedDistribution[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"type":  d.GetType(),
 		"value": renderToJSON(d.value),
 	})
@@ -255,7 +255,7 @@ func (d *discreteDistribution[T]) MarshalJSON() ([]byte, error) {
 		weights[renderToJSON(value)] = weight
 	}
 
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"type":    d.GetType(),
 		"weights": weights,
 	})
@@ -340,7 +340,7 @@ func (d *uniformDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 }
 
 func (d *uniformDistribution[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"type": d.GetType(),
 		"min":  renderToJSON(d.min),
 		"max":  renderToJSON(d.max),
@@ -398,7 +398,7 @@ func (d *zipfDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 }
 
 func (d *zipfDistribution[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"type": d.GetType(),
 		"s":    d.s,
 		"v":    d.v,
@@ -478,10 +478,7 @@ func (d *normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 		mean, stdDev := any(d.mean).(int64), any(d.stdDev).(int64)
 		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
 
-		result := mean + int64(float64(stdDev)*rng.NormFloat64())
-		if result < minVal {
-			result = minVal
-		}
+		result := max(mean+int64(float64(stdDev)*rng.NormFloat64()), minVal)
 		if result > maxVal {
 			result = maxVal
 		}
@@ -502,10 +499,7 @@ func (d *normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 		mean, stdDev := any(d.mean).(time.Duration), any(d.stdDev).(time.Duration)
 		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
 
-		result := time.Duration(int64(mean) + int64(float64(stdDev)*rng.NormFloat64()))
-		if result < minVal {
-			result = minVal
-		}
+		result := max(time.Duration(int64(mean)+int64(float64(stdDev)*rng.NormFloat64())), minVal)
 		if result > maxVal {
 			result = maxVal
 		}
@@ -516,7 +510,7 @@ func (d *normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 }
 
 func (d *normalDistribution[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"type":   d.GetType(),
 		"mean":   renderToJSON(d.mean),
 		"stdDev": renderToJSON(d.stdDev),

--- a/loadgen/helper_dist_test.go
+++ b/loadgen/helper_dist_test.go
@@ -468,7 +468,7 @@ func TestDistributionField(t *testing.T) {
 			assert.Equal(t, expected.distType, df.distType)
 
 			// Test all samples return the same value regardless of seed.
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				rng := rand.New(rand.NewSource(testSeed + int64(i)))
 				v, ok := df.Sample(rng)
 				assert.True(t, ok)

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -17,7 +17,7 @@ func TestFetchWorkerInfo(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"sdk_version": "v1.24.0",
 				"build_id":    "test-build-456",
 			})

--- a/scenarios/fixed_resource_consumption.go
+++ b/scenarios/fixed_resource_consumption.go
@@ -21,7 +21,7 @@ func parallelResourcesActions(
 	cpuYieldForMs int,
 	runForSeconds int64) *kitchensink.ActionSet {
 	actions := make([]*kitchensink.Action, numConccurrent)
-	for i := 0; i < numConccurrent; i++ {
+	for i := range numConccurrent {
 		actions[i] = kitchensink.ResourceConsumingActivity(
 			uint64(bytesToAlloc),
 			uint32(cpuYieldEveryNIters),
@@ -39,7 +39,7 @@ func parallelRandomDelays(
 	minRuntime time.Duration,
 	maxRuntime time.Duration) *kitchensink.ActionSet {
 	actions := make([]*kitchensink.Action, numConccurrent)
-	for i := 0; i < numConccurrent; i++ {
+	for i := range numConccurrent {
 		randMs := rand.Float64()*float64(maxRuntime.Milliseconds()-minRuntime.Milliseconds()) + float64(minRuntime.Milliseconds())
 		actions[i] = &kitchensink.Action{
 			Variant: &kitchensink.Action_ExecActivity{

--- a/scenarios/out_of_order_signals_test.go
+++ b/scenarios/out_of_order_signals_test.go
@@ -108,7 +108,7 @@ func TestOutOfOrderSignals_BuildOrderedAwaitActions(t *testing.T) {
 		require.Len(t, sets, 1)
 		actions := sets[0].Actions
 		require.Len(t, actions, n+1)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			await := actions[i].GetAwaitWorkflowState()
 			require.NotNil(t, await, "action %d should await workflow state", i)
 			require.Equal(t, oooEventKey(i+1), await.Key)
@@ -121,7 +121,7 @@ func TestOutOfOrderSignals_BuildOrderedAwaitActions(t *testing.T) {
 		sets := buildOrderedAwaitActions(n, time.Millisecond)
 		actions := sets[0].Actions
 		require.Len(t, actions, 2*n+1)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			require.NotNil(t, actions[2*i].GetAwaitWorkflowState())
 			require.NotNil(t, actions[2*i+1].GetExecActivity())
 		}

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -537,7 +537,7 @@ func (t *tpsExecutor) createChildWorkflowAction(run *loadgen.Run, childID int) *
 				SearchAttributes: map[string]*common.Payload{
 					loadgen.OmesExecutionIDSearchAttribute: &common.Payload{
 						Metadata: map[string][]byte{"encoding": []byte("json/plain"), "type": []byte("Keyword")},
-						Data:     []byte(fmt.Sprintf("%q", t.config.ExecutionID)), // quoted to be valid JSON string
+						Data:     fmt.Appendf(nil, "%q", t.config.ExecutionID), // quoted to be valid JSON string
 					},
 				},
 			},
@@ -709,7 +709,7 @@ func (t *tpsExecutor) createNexusAttachCallbacksAction() *Action {
 		}
 	}
 	fanout := make([]*Action, 0, numOps)
-	for i := 0; i < numOps; i++ {
+	for range numOps {
 		fanout = append(fanout, waitStartedOp())
 	}
 

--- a/scenarios/workflow_with_many_actions.go
+++ b/scenarios/workflow_with_many_actions.go
@@ -46,7 +46,7 @@ func init() {
 						return err
 					}
 					// Add children
-					for i := 0; i < children; i++ {
+					for i := range children {
 						actionSet.Actions = append(actionSet.Actions, &kitchensink.Action{
 							Variant: &kitchensink.Action_ExecChildWorkflow{
 								ExecChildWorkflow: &kitchensink.ExecuteChildWorkflowAction{
@@ -59,7 +59,7 @@ func init() {
 					}
 
 					// Add activities
-					for i := 0; i < activities; i++ {
+					for range activities {
 						actionSet.Actions = append(actionSet.Actions, &kitchensink.Action{
 							Variant: &kitchensink.Action_ExecActivity{
 								ExecActivity: &kitchensink.ExecuteActivityAction{

--- a/scenarios/workflow_with_many_timers_test.go
+++ b/scenarios/workflow_with_many_timers_test.go
@@ -67,7 +67,7 @@ func TestWorkflowWithManyTimers_BuildActions(t *testing.T) {
 		sets := buildManyTimersActions(cfg, manyTimersSeededRng("test"))
 		require.Len(t, sets, 4, "3 timer batches + 1 terminal return set")
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			require.True(t, sets[i].Concurrent, "timer batch %d should fire concurrently", i)
 			require.Len(t, sets[i].Actions, 4, "batch %d should hold concurrent-timers timers", i)
 			for _, a := range sets[i].Actions {

--- a/workers/go/go.mod
+++ b/workers/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/omes/workers/go
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/temporalio/omes v1.0.0

--- a/workers/go/harness/worker.go
+++ b/workers/go/harness/worker.go
@@ -203,7 +203,7 @@ func runWorkers(workers []sdkworker.Worker, stopCh <-chan struct{}) error {
 		return nil
 	}
 
-	workerStopCh := make(chan interface{})
+	workerStopCh := make(chan any)
 	var stopOnce sync.Once
 	stopWorkers := func() {
 		stopOnce.Do(func() {

--- a/workers/go/harness/worker_test.go
+++ b/workers/go/harness/worker_test.go
@@ -13,10 +13,10 @@ import (
 type fakeWorker struct {
 	sdkworker.Worker
 
-	run func(<-chan interface{}) error
+	run func(<-chan any) error
 }
 
-func (f fakeWorker) Run(stopCh <-chan interface{}) error {
+func (f fakeWorker) Run(stopCh <-chan any) error {
 	if f.run == nil {
 		return nil
 	}
@@ -72,10 +72,10 @@ func TestRunWorkersStopsRemainingWorkersOnFailure(t *testing.T) {
 	stopped := make(chan struct{}, 1)
 
 	err := runWorkers([]sdkworker.Worker{
-		fakeWorker{run: func(<-chan interface{}) error {
+		fakeWorker{run: func(<-chan any) error {
 			return context.Canceled
 		}},
-		fakeWorker{run: func(stopCh <-chan interface{}) error {
+		fakeWorker{run: func(stopCh <-chan any) error {
 			select {
 			case <-stopCh:
 				stopped <- struct{}{}

--- a/workers/go/workerlib/kitchensink/kitchen_sink.go
+++ b/workers/go/workerlib/kitchensink/kitchen_sink.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -62,7 +63,7 @@ func KitchenSinkWorkflow(ctx workflow.Context, params *kitchensink.WorkflowInput
 
 	// Setup query handler.
 	queryErr := workflow.SetQueryHandler(ctx, "report_state",
-		func(input interface{}) (*kitchensink.WorkflowState, error) {
+		func(input any) (*kitchensink.WorkflowState, error) {
 			return state.workflowState, nil
 		})
 	if queryErr != nil {
@@ -71,7 +72,7 @@ func KitchenSinkWorkflow(ctx workflow.Context, params *kitchensink.WorkflowInput
 
 	// Setup update handler.
 	updateErr := workflow.SetUpdateHandlerWithOptions(ctx, "do_actions_update",
-		func(ctx workflow.Context, actions *kitchensink.DoActionsUpdate) (rval interface{}, err error) {
+		func(ctx workflow.Context, actions *kitchensink.DoActionsUpdate) (rval any, err error) {
 			payload, err := state.handleActionSet(ctx, actions.GetDoActions())
 			if payload != nil {
 				return payload, err
@@ -204,7 +205,6 @@ func (ws *KSWorkflowState) handleActionSet(
 	// return values if we should return, then awaiting on that or completion
 	var actionsCompleted int
 	for _, action := range set.Actions {
-		action := action
 		workflow.Go(ctx, func(ctx workflow.Context) {
 			if maybeReturnValue, maybeErr := ws.handleAction(ctx, action); maybeReturnValue != nil || maybeErr != nil {
 				returnValue, err = maybeReturnValue, maybeErr
@@ -236,12 +236,7 @@ func isSignalAlreadyReceived(params *kitchensink.WorkflowInput, signalID int32) 
 		return true
 	}
 	// If the signal ID is not in the expected list, it means we already processed it
-	for _, id := range params.ExpectedSignalIds {
-		if id == signalID {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(params.ExpectedSignalIds, signalID)
 }
 
 // handleSignalDeduplication removes a received signal ID from the expected list.
@@ -287,9 +282,9 @@ func (ws *KSWorkflowState) handleAction(
 		if child.WorkflowType != "" {
 			childType = child.WorkflowType
 		}
-		var searchAttributes map[string]interface{}
+		var searchAttributes map[string]any
 		if child.SearchAttributes != nil {
-			searchAttributes = make(map[string]interface{})
+			searchAttributes = make(map[string]any)
 			for k, v := range child.SearchAttributes {
 				searchAttributes[k] = v
 			}
@@ -324,14 +319,14 @@ func (ws *KSWorkflowState) handleAction(
 		})
 		return nil, err
 	} else if upsertMemo := action.GetUpsertMemo(); upsertMemo != nil {
-		convertedMap := make(map[string]interface{}, len(upsertMemo.GetUpsertedMemo().Fields))
+		convertedMap := make(map[string]any, len(upsertMemo.GetUpsertedMemo().Fields))
 		for k, v := range upsertMemo.GetUpsertedMemo().Fields {
 			convertedMap[k] = v
 		}
 		err := workflow.UpsertMemo(ctx, convertedMap)
 		return nil, err
 	} else if upsertSA := action.GetUpsertSearchAttributes(); upsertSA != nil {
-		convertedMap := make(map[string]interface{}, len(upsertSA.GetSearchAttributes()))
+		convertedMap := make(map[string]any, len(upsertSA.GetSearchAttributes()))
 		for k, v := range upsertSA.GetSearchAttributes() {
 			convertedMap[k] = v
 		}

--- a/workers/go/workerlib/workflowutils/workflow_utils.go
+++ b/workers/go/workerlib/workflowutils/workflow_utils.go
@@ -12,7 +12,6 @@ func RunConcurrently(ctx workflow.Context, funcs ...func(workflow.Context) error
 	completed := 0
 	var innerErr error
 	for _, f := range funcs {
-		f := f
 		workflow.Go(ctx, func(ctx workflow.Context) {
 			if err := f(ctx); err != nil {
 				innerErr = err


### PR DESCRIPTION
## What was changed

I've bumped both go modules to 1.26.5 and run `go fix ./...` across them.

## Why?

Cleanliness while I was here doing other things