### PR TITLE
loadgen: add configurable weighted payload-size distribution to throughput_stress

### DIFF
--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -158,8 +159,9 @@ func (d *fixedDistribution[T]) UnmarshalJSON(data []byte) error {
 }
 
 type discreteDistribution[T distValueType] struct {
-	weights map[T]int
-	cache   *discreteCache[T]
+	weights   map[T]int
+	cacheOnce sync.Once
+	cache     *discreteCache[T]
 }
 
 // discreteCache holds pre-computed values for discreteDistribution sampling
@@ -203,7 +205,9 @@ func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 		}
 	}
 
-	if d.cache == nil {
+	// Build the sampling cache exactly once; Sample is called concurrently from
+	// multiple iteration goroutines that share a distribution instance.
+	d.cacheOnce.Do(func() {
 		keys := make([]T, 0, len(d.weights))
 		for k := range d.weights {
 			keys = append(keys, k)
@@ -235,7 +239,7 @@ func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 			weights:     weights,
 			totalWeight: totalWeight,
 		}
-	}
+	})
 
 	// Perform weighted sampling
 	r := rng.Intn(d.cache.totalWeight)

--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -12,7 +12,7 @@ import (
 
 // distValueType constrains the types that can be used as distribution values.
 type distValueType interface {
-	int64 | time.Duration | float32
+	int64 | time.Duration | float32 | int32
 }
 
 type distribution[T distValueType] interface {
@@ -212,20 +212,9 @@ func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 		for k := range d.weights {
 			keys = append(keys, k)
 		}
-		switch any(keys[0]).(type) {
-		case int64:
-			sort.Slice(keys, func(i, j int) bool {
-				return any(keys[i]).(int64) < any(keys[j]).(int64)
-			})
-		case float32:
-			sort.Slice(keys, func(i, j int) bool {
-				return any(keys[i]).(float32) < any(keys[j]).(float32)
-			})
-		case time.Duration:
-			sort.Slice(keys, func(i, j int) bool {
-				return any(keys[i]).(time.Duration) < any(keys[j]).(time.Duration)
-			})
-		}
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i] < keys[j]
+		})
 
 		totalWeight := 0
 		weights := make([]int, len(keys))
@@ -298,19 +287,8 @@ func (d *uniformDistribution[T]) GetType() string {
 }
 
 func (d *uniformDistribution[T]) Validate() error {
-	switch any(d.min).(type) {
-	case int64:
-		if any(d.max).(int64) < any(d.min).(int64) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
-	case float32:
-		if any(d.max).(float32) < any(d.min).(float32) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
-	case time.Duration:
-		if any(d.max).(time.Duration) < any(d.min).(time.Duration) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
+	if d.max < d.min {
+		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
 	}
 	return nil
 }
@@ -324,13 +302,20 @@ func (d *uniformDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 		}
 		result := minVal + rng.Int63n(maxVal-minVal+1)
 		return T(result), true
+	case int32:
+		minVal, maxVal := any(d.min).(int32), any(d.max).(int32)
+		if maxVal <= minVal {
+			return d.min, true
+		}
+		result := minVal + rng.Int31n(maxVal-minVal+1)
+		return T(result), true
 	case float32:
 		minVal, maxVal := any(d.min).(float32), any(d.max).(float32)
 		if maxVal <= minVal {
 			return d.min, true
 		}
 		result := minVal + rng.Float32()*(maxVal-minVal)
-		return any(result).(T), true
+		return T(result), true
 	case time.Duration:
 		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
 		if maxVal <= minVal {
@@ -450,67 +435,18 @@ func (d *normalDistribution[T]) GetType() string {
 }
 
 func (d *normalDistribution[T]) Validate() error {
-	switch any(d.stdDev).(type) {
-	case int64:
-		if any(d.stdDev).(int64) <= 0 {
-			return fmt.Errorf("standard deviation must be positive, got %v", d.stdDev)
-		}
-		if any(d.max).(int64) < any(d.min).(int64) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
-	case float32:
-		if any(d.stdDev).(float32) <= 0 {
-			return fmt.Errorf("standard deviation must be positive, got %v", d.stdDev)
-		}
-		if any(d.max).(float32) < any(d.min).(float32) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
-	case time.Duration:
-		if any(d.stdDev).(time.Duration) <= 0 {
-			return fmt.Errorf("standard deviation must be positive, got %v", d.stdDev)
-		}
-		if any(d.max).(time.Duration) < any(d.min).(time.Duration) {
-			return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
-		}
+	if d.stdDev <= 0 {
+		return fmt.Errorf("standard deviation must be positive, got %v", d.stdDev)
+	}
+	if d.max < d.min {
+		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
 	}
 	return nil
 }
 
 func (d *normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
-	switch any(d.mean).(type) {
-	case int64:
-		mean, stdDev := any(d.mean).(int64), any(d.stdDev).(int64)
-		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
-
-		result := max(mean+int64(float64(stdDev)*rng.NormFloat64()), minVal)
-		if result > maxVal {
-			result = maxVal
-		}
-		return T(result), true
-	case float32:
-		mean, stdDev := any(d.mean).(float32), any(d.stdDev).(float32)
-		minVal, maxVal := any(d.min).(float32), any(d.max).(float32)
-
-		result := mean + float32(float64(stdDev)*rng.NormFloat64())
-		if result < minVal {
-			result = minVal
-		}
-		if result > maxVal {
-			result = maxVal
-		}
-		return any(result).(T), true
-	case time.Duration:
-		mean, stdDev := any(d.mean).(time.Duration), any(d.stdDev).(time.Duration)
-		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
-
-		result := max(time.Duration(int64(mean)+int64(float64(stdDev)*rng.NormFloat64())), minVal)
-		if result > maxVal {
-			result = maxVal
-		}
-		return T(result), true
-	default:
-		return d.mean, false
-	}
+	result := min(d.max, max(d.min, d.mean+T(float64(d.stdDev)*rng.NormFloat64())))
+	return result, true
 }
 
 func (d *normalDistribution[T]) MarshalJSON() ([]byte, error) {
@@ -584,6 +520,22 @@ func parseFromJSON[T any](rawMap map[string]json.RawMessage, fieldName string) (
 			return zero, fmt.Errorf("failed to parse int64 value '%s': %w", strValue, err)
 		}
 		return any(intVal).(T), nil
+	case int32:
+		var numValue int32
+		if err := json.Unmarshal(rawMsg, &numValue); err == nil {
+			return any(numValue).(T), nil
+		}
+
+		var strValue string
+		if err := json.Unmarshal(rawMsg, &strValue); err != nil {
+			return zero, fmt.Errorf("failed to parse '%s' as int32 or string: %w", fieldName, err)
+		}
+
+		intVal, err := strconv.ParseInt(strValue, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("failed to parse int32 value '%s': %w", strValue, err)
+		}
+		return any(int32(intVal)).(T), nil
 
 	case float32:
 		var numValue float32
@@ -650,7 +602,13 @@ func stringToValue[T distValueType](valueStr string) (T, error) {
 		if err != nil {
 			return zero, fmt.Errorf("failed to parse int64 value '%s': %w", valueStr, err)
 		}
-		return T(intVal), nil
+		return any(intVal).(T), nil
+	case int32:
+		intVal, err := strconv.ParseInt(valueStr, 10, 32)
+		if err != nil {
+			return zero, fmt.Errorf("failed to parse int32 value '%s': %w", valueStr, err)
+		}
+		return any(int32(intVal)).(T), nil
 	case float32:
 		floatVal, err := strconv.ParseFloat(valueStr, 32)
 		if err != nil {

--- a/loadgen/helper_payload.go
+++ b/loadgen/helper_payload.go
@@ -1,0 +1,51 @@
+package loadgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+)
+
+// PayloadConfig configures activity payload sizes using the shared distribution
+// framework. Parsed from a JSON string passed via --option (with @file.json support).
+type PayloadConfig struct {
+	// Size is the distribution (in bytes) of activity payload sizes. See DistributionField
+	// for the supported distribution types and their JSON format.
+	Size *DistributionField[int64] `json:"size"`
+}
+
+// ParseAndValidatePayloadConfig parses a PayloadConfig from JSON. An empty input indicates
+// that no payload config was supplied, and (nil, nil) is returned.
+func ParseAndValidatePayloadConfig(jsonStr string) (*PayloadConfig, error) {
+	if jsonStr == "" {
+		return nil, nil
+	}
+	config := &PayloadConfig{}
+	if err := json.Unmarshal([]byte(jsonStr), config); err != nil {
+		return nil, fmt.Errorf("failed to parse PayloadConfig JSON: %w", err)
+	}
+	return config, nil
+}
+
+// SamplePayloadSize samples an activity payload size (in bytes) from the configured Size
+// distribution. If c is nil or Size is unset, fallback is returned. The result is clamped to
+// [0, math.MaxInt32] because payload sizes are stored in int32 proto fields; without the
+// upper clamp a large sampled value would wrap to a negative int32 and panic the worker's
+// make([]byte, size).
+func (c *PayloadConfig) SamplePayloadSize(rng *rand.Rand, fallback int) int {
+	if c == nil || c.Size == nil {
+		return fallback
+	}
+	value, ok := c.Size.Sample(rng)
+	if !ok {
+		return fallback
+	}
+	if value < 0 {
+		value = 0
+	}
+	if value > math.MaxInt32 {
+		value = math.MaxInt32
+	}
+	return int(value)
+}

--- a/loadgen/helper_payload.go
+++ b/loadgen/helper_payload.go
@@ -30,9 +30,7 @@ func ParseAndValidatePayloadConfig(jsonStr string) (*PayloadConfig, error) {
 
 // SamplePayloadSize samples an activity payload size (in bytes) from the configured Size
 // distribution. If c is nil or Size is unset, fallback is returned. The result is clamped to
-// [0, math.MaxInt32] because payload sizes are stored in int32 proto fields; without the
-// upper clamp a large sampled value would wrap to a negative int32 and panic the worker's
-// make([]byte, size).
+// [0, math.MaxInt32] to match the protobuf field.
 func (c *PayloadConfig) SamplePayloadSize(rng *rand.Rand, fallback int) int {
 	if c == nil || c.Size == nil {
 		return fallback

--- a/loadgen/helper_payload.go
+++ b/loadgen/helper_payload.go
@@ -3,7 +3,6 @@ package loadgen
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"math/rand"
 )
 
@@ -12,7 +11,7 @@ import (
 type PayloadConfig struct {
 	// Size is the distribution (in bytes) of activity payload sizes. See DistributionField
 	// for the supported distribution types and their JSON format.
-	Size *DistributionField[int64] `json:"size"`
+	Size *DistributionField[int32] `json:"size"`
 }
 
 // ParseAndValidatePayloadConfig parses a PayloadConfig from JSON. An empty input indicates
@@ -30,8 +29,8 @@ func ParseAndValidatePayloadConfig(jsonStr string) (*PayloadConfig, error) {
 
 // SamplePayloadSize samples an activity payload size (in bytes) from the configured Size
 // distribution. If c is nil or Size is unset, fallback is returned. The result is clamped to
-// [0, math.MaxInt32] to match the protobuf field.
-func (c *PayloadConfig) SamplePayloadSize(rng *rand.Rand, fallback int) int {
+// [0, math.MaxInt32] to match bytes_to_receive etc in the kitchensink proto.
+func (c *PayloadConfig) SamplePayloadSize(rng *rand.Rand, fallback int32) int32 {
 	if c == nil || c.Size == nil {
 		return fallback
 	}
@@ -42,8 +41,5 @@ func (c *PayloadConfig) SamplePayloadSize(rng *rand.Rand, fallback int) int {
 	if value < 0 {
 		value = 0
 	}
-	if value > math.MaxInt32 {
-		value = math.MaxInt32
-	}
-	return int(value)
+	return value
 }

--- a/loadgen/helper_payload_test.go
+++ b/loadgen/helper_payload_test.go
@@ -1,7 +1,6 @@
 package loadgen
 
 import (
-	"math"
 	"math/rand"
 	"testing"
 
@@ -36,32 +35,26 @@ func TestPayloadConfigSamplePayloadSize(t *testing.T) {
 
 	t.Run("nil config returns fallback", func(t *testing.T) {
 		var config *PayloadConfig
-		assert.Equal(t, 256, config.SamplePayloadSize(rng, 256))
+		assert.Equal(t, int32(256), config.SamplePayloadSize(rng, 256))
 	})
 
 	t.Run("config with nil Size returns fallback", func(t *testing.T) {
 		config := &PayloadConfig{}
-		assert.Equal(t, 256, config.SamplePayloadSize(rng, 256))
+		assert.Equal(t, int32(256), config.SamplePayloadSize(rng, 256))
 	})
 
 	t.Run("fixed distribution returns the fixed value", func(t *testing.T) {
-		dist := NewFixedDistribution[int64](1024)
+		dist := NewFixedDistribution[int32](1024)
 		config := &PayloadConfig{Size: &dist}
-		assert.Equal(t, 1024, config.SamplePayloadSize(rng, 256))
-	})
-
-	t.Run("values above int32 max are clamped (no negative-length panic)", func(t *testing.T) {
-		dist := NewFixedDistribution[int64](int64(math.MaxInt32) + 5000)
-		config := &PayloadConfig{Size: &dist}
-		assert.Equal(t, math.MaxInt32, config.SamplePayloadSize(rng, 256))
+		assert.Equal(t, int32(1024), config.SamplePayloadSize(rng, 256))
 	})
 
 	t.Run("discrete distribution respects weights over many samples", func(t *testing.T) {
-		dist := NewDiscreteDistribution(map[int64]int{100: 70, 200: 25, 300: 5})
+		dist := NewDiscreteDistribution(map[int32]int{100: 70, 200: 25, 300: 5})
 		config := &PayloadConfig{Size: &dist}
 
 		const iterations = 10000
-		counts := map[int]int{}
+		counts := map[int32]int{}
 		rng := rand.New(rand.NewSource(42))
 		for i := 0; i < iterations; i++ {
 			counts[config.SamplePayloadSize(rng, 0)]++
@@ -69,7 +62,7 @@ func TestPayloadConfigSamplePayloadSize(t *testing.T) {
 
 		// Only the configured keys should ever appear.
 		for k := range counts {
-			assert.Contains(t, []int{100, 200, 300}, k)
+			assert.Contains(t, []int32{100, 200, 300}, k)
 		}
 
 		// Loose bounds on the proportions to guard against gross weighting bugs.

--- a/loadgen/helper_payload_test.go
+++ b/loadgen/helper_payload_test.go
@@ -1,0 +1,80 @@
+package loadgen
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAndValidatePayloadConfig(t *testing.T) {
+	t.Run("empty string returns nil config and nil error", func(t *testing.T) {
+		config, err := ParseAndValidatePayloadConfig("")
+		require.NoError(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("valid config with discrete size", func(t *testing.T) {
+		config, err := ParseAndValidatePayloadConfig(
+			`{"size":{"type":"discrete","weights":{"100":1,"200":3}}}`)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Size)
+	})
+
+	t.Run("invalid JSON returns an error", func(t *testing.T) {
+		config, err := ParseAndValidatePayloadConfig("{not valid json")
+		require.Error(t, err)
+		assert.Nil(t, config)
+	})
+}
+
+func TestPayloadConfigSamplePayloadSize(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	t.Run("nil config returns fallback", func(t *testing.T) {
+		var config *PayloadConfig
+		assert.Equal(t, 256, config.SamplePayloadSize(rng, 256))
+	})
+
+	t.Run("config with nil Size returns fallback", func(t *testing.T) {
+		config := &PayloadConfig{}
+		assert.Equal(t, 256, config.SamplePayloadSize(rng, 256))
+	})
+
+	t.Run("fixed distribution returns the fixed value", func(t *testing.T) {
+		dist := NewFixedDistribution[int64](1024)
+		config := &PayloadConfig{Size: &dist}
+		assert.Equal(t, 1024, config.SamplePayloadSize(rng, 256))
+	})
+
+	t.Run("values above int32 max are clamped (no negative-length panic)", func(t *testing.T) {
+		dist := NewFixedDistribution[int64](int64(math.MaxInt32) + 5000)
+		config := &PayloadConfig{Size: &dist}
+		assert.Equal(t, math.MaxInt32, config.SamplePayloadSize(rng, 256))
+	})
+
+	t.Run("discrete distribution respects weights over many samples", func(t *testing.T) {
+		dist := NewDiscreteDistribution(map[int64]int{100: 70, 200: 25, 300: 5})
+		config := &PayloadConfig{Size: &dist}
+
+		const iterations = 10000
+		counts := map[int]int{}
+		rng := rand.New(rand.NewSource(42))
+		for i := 0; i < iterations; i++ {
+			counts[config.SamplePayloadSize(rng, 0)]++
+		}
+
+		// Only the configured keys should ever appear.
+		for k := range counts {
+			assert.Contains(t, []int{100, 200, 300}, k)
+		}
+
+		// Loose bounds on the proportions to guard against gross weighting bugs.
+		assert.InDelta(t, 0.70, float64(counts[100])/iterations, 0.1)
+		assert.InDelta(t, 0.25, float64(counts[200])/iterations, 0.1)
+		assert.InDelta(t, 0.05, float64(counts[300])/iterations, 0.05)
+	})
+}

--- a/loadgen/kitchensink/helpers.go
+++ b/loadgen/kitchensink/helpers.go
@@ -2,6 +2,7 @@ package kitchensink
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"go.temporal.io/api/common/v1"
@@ -23,10 +24,14 @@ func ActivityNameAndArgs(act *ExecuteActivityAction) (string, []any) {
 	if delay := act.GetDelay(); delay != nil {
 		return "delay", []any{delay.AsDuration()}
 	} else if payload := act.GetPayload(); payload != nil {
+		// Fill with pseudo-random, incompressible bytes so the payload occupies its full
+		// configured size in history/persistence instead of compressing away. The rng is
+		// seeded by size (not the global source) to stay deterministic: this runs in workflow
+		// context (worker launchActivity), where the activity input is recorded in history and
+		// must match on replay.
 		inputData := make([]byte, payload.BytesToReceive)
-		for i := range inputData {
-			inputData[i] = byte(i % 256)
-		}
+		r := rand.New(rand.NewSource(int64(payload.BytesToReceive)))
+		_, _ = r.Read(inputData)
 		return "payload", []any{inputData, payload.BytesToReturn}
 	} else if client := act.GetClient(); client != nil {
 		return "client", []any{client}

--- a/loadgen/kitchensink/helpers.go
+++ b/loadgen/kitchensink/helpers.go
@@ -26,9 +26,7 @@ func ActivityNameAndArgs(act *ExecuteActivityAction) (string, []any) {
 	} else if payload := act.GetPayload(); payload != nil {
 		// Fill with pseudo-random, incompressible bytes so the payload occupies its full
 		// configured size in history/persistence instead of compressing away. The rng is
-		// seeded by size (not the global source) to stay deterministic: this runs in workflow
-		// context (worker launchActivity), where the activity input is recorded in history and
-		// must match on replay.
+		// seeded by size so its deterministic on replay
 		inputData := make([]byte, payload.BytesToReceive)
 		r := rand.New(rand.NewSource(int64(payload.BytesToReceive)))
 		_, _ = r.Read(inputData)

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -369,7 +369,7 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 // samplePayloadSize samples an activity payload size (in bytes) from the configured
 // Payload distribution, falling back to 256 bytes when none is configured.
 func (t *tpsExecutor) samplePayloadSize(rng *rand.Rand) int {
-	return t.config.Payload.SamplePayloadSize(rng, 256)
+	return int(t.config.Payload.SamplePayloadSize(rng, 256))
 }
 
 func (t *tpsExecutor) updateStateOnIterationCompletion() {

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -54,6 +54,9 @@ const (
 	// Requires server support for standalone activities (dynamic config `activity.enableStandalone`).
 	// Default is false.
 	IncludeStandaloneActivityFlag = "include-standalone-activity"
+	// PayloadDistributionJsonFlag is a JSON string (or @file) configuring a weighted
+	// activity payload-size distribution. See loadgen.PayloadConfig for details.
+	PayloadDistributionJsonFlag = "payload-distribution-json"
 )
 
 type tpsState struct {
@@ -82,6 +85,7 @@ type tpsConfig struct {
 	IncludeDescribe               bool
 	IncludeStandaloneNexus        bool
 	IncludeStandaloneActivity     bool
+	Payload                       *loadgen.PayloadConfig
 }
 
 type tpsExecutor struct {
@@ -99,8 +103,8 @@ var _ loadgen.Configurable = (*tpsExecutor)(nil)
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: fmt.Sprintf(
-			"Throughput stress scenario. Use --option with '%s', '%s', '%s', '%s', '%s', '%s' to control internal parameters",
-			IterFlag, ContinueAsNewAfterIterFlag, IncludeRetryScenariosFlag, IncludeDescribeFlag, IncludeStandaloneNexusFlag, IncludeStandaloneActivityFlag),
+			"Throughput stress scenario. Use --option with '%s', '%s', '%s', '%s', '%s', '%s', '%s' to control internal parameters",
+			IterFlag, ContinueAsNewAfterIterFlag, IncludeRetryScenariosFlag, IncludeDescribeFlag, IncludeStandaloneNexusFlag, IncludeStandaloneActivityFlag, PayloadDistributionJsonFlag),
 		ExecutorFn: func() loadgen.Executor { return newThroughputStressExecutor() },
 	})
 }
@@ -187,6 +191,13 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 		return fmt.Errorf("%s requires %s to be set", IncludeStandaloneNexusFlag, NexusEndpointFlag)
 	}
 	config.IncludeStandaloneActivity = info.ScenarioOptionBool(IncludeStandaloneActivityFlag, false)
+
+	if payloadStr, ok := info.ScenarioOptions[PayloadDistributionJsonFlag]; ok {
+		config.Payload, err = loadgen.ParseAndValidatePayloadConfig(payloadStr)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", PayloadDistributionJsonFlag, err)
+		}
+	}
 
 	t.config = config
 	t.rng = rand.New(rand.NewSource(config.RngSeed))
@@ -355,6 +366,12 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 	return errors.Join(tpsErrors...)
 }
 
+// samplePayloadSize samples an activity payload size (in bytes) from the configured
+// Payload distribution, falling back to 256 bytes when none is configured.
+func (t *tpsExecutor) samplePayloadSize(rng *rand.Rand) int {
+	return t.config.Payload.SamplePayloadSize(rng, 256)
+}
+
 func (t *tpsExecutor) updateStateOnIterationCompletion() {
 	t.lock.Lock()
 	defer t.lock.Unlock()
@@ -363,9 +380,12 @@ func (t *tpsExecutor) updateStateOnIterationCompletion() {
 }
 
 func (t *tpsExecutor) createActions(run *loadgen.Run) []*ActionSet {
+	// One rng per iteration, threaded through the recursion so the sampled sequence
+	// continues across continue-as-new boundaries instead of restarting per chunk.
+	rng := rand.New(rand.NewSource(t.config.RngSeed + int64(run.Iteration)))
 	return []*ActionSet{
 		{
-			Actions:    t.createActionsChunk(run, 0, 0, t.config.InternalIterations),
+			Actions:    t.createActionsChunk(run, rng, 0, 0, t.config.InternalIterations),
 			Concurrent: false,
 		},
 	}
@@ -373,6 +393,7 @@ func (t *tpsExecutor) createActions(run *loadgen.Run) []*ActionSet {
 
 func (t *tpsExecutor) createActionsChunk(
 	run *loadgen.Run,
+	rng *rand.Rand,
 	childCount int,
 	continueAsNewCounter int,
 	remainingInternalIters int,
@@ -386,14 +407,12 @@ func (t *tpsExecutor) createActionsChunk(
 	isLastChunk := remainingInternalIters <= itersPerChunk
 	itersPerChunk = min(itersPerChunk, remainingInternalIters) // cap chunk size to remaining iterations
 
-	rng := rand.New(rand.NewSource(t.config.RngSeed + int64(run.Iteration)))
-
 	// Create actions for the current chunk
 	for i := 0; i < itersPerChunk; i++ {
 		syncActions := []*Action{
-			PayloadActivity(256, 256, DefaultLocalActivity),
-			PayloadActivity(0, 256, DefaultLocalActivity),
-			PayloadActivity(0, 256, DefaultLocalActivity),
+			PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultLocalActivity),
+			PayloadActivity(0, t.samplePayloadSize(rng), DefaultLocalActivity),
+			PayloadActivity(0, t.samplePayloadSize(rng), DefaultLocalActivity),
 			// TODO: use local activity: server error log "failed to set query completion state to succeeded
 			ClientActivity(ClientActions(t.createSelfQuery()), DefaultRemoteActivity),
 		}
@@ -406,11 +425,11 @@ func (t *tpsExecutor) createActionsChunk(
 
 		childCount++
 		asyncActions := []*Action{
-			t.createChildWorkflowAction(run, childCount),
-			PayloadActivity(256, 256, DefaultRemoteActivity),
-			PayloadActivity(256, 256, DefaultRemoteActivity),
-			PayloadActivity(0, 256, DefaultLocalActivity),
-			PayloadActivity(0, 256, DefaultLocalActivity),
+			t.createChildWorkflowAction(run, childCount, rng),
+			PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultRemoteActivity),
+			PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultRemoteActivity),
+			PayloadActivity(0, t.samplePayloadSize(rng), DefaultLocalActivity),
+			PayloadActivity(0, t.samplePayloadSize(rng), DefaultLocalActivity),
 			GenericActivity("noop", DefaultLocalActivity),
 			ClientActivity(ClientActions(t.createSelfQuery()), DefaultRemoteActivity),
 			ClientActivity(ClientActions(t.createSelfSignal()), DefaultLocalActivity),
@@ -464,7 +483,7 @@ func (t *tpsExecutor) createActionsChunk(
 
 		// Add standalone activities, if configured.
 		if t.config.IncludeStandaloneActivity {
-			asyncActions = append(asyncActions, t.createStandaloneActivityAction(loadgen.TaskQueueForRun(run.RunID)))
+			asyncActions = append(asyncActions, t.createStandaloneActivityAction(loadgen.TaskQueueForRun(run.RunID), rng))
 		}
 
 		chunkActions = append(chunkActions, syncActions...)
@@ -498,6 +517,7 @@ func (t *tpsExecutor) createActionsChunk(
 								{
 									Actions: t.createActionsChunk(
 										run,
+										rng,
 										childCount,
 										continueAsNewCounter+1,
 										remainingInternalIters-itersPerChunk),
@@ -514,7 +534,7 @@ func (t *tpsExecutor) createActionsChunk(
 	return chunkActions
 }
 
-func (t *tpsExecutor) createChildWorkflowAction(run *loadgen.Run, childID int) *Action {
+func (t *tpsExecutor) createChildWorkflowAction(run *loadgen.Run, childID int, rng *rand.Rand) *Action {
 	return &Action{
 		Variant: &Action_ExecChildWorkflow{
 			ExecChildWorkflow: &ExecuteChildWorkflowAction{
@@ -523,9 +543,9 @@ func (t *tpsExecutor) createChildWorkflowAction(run *loadgen.Run, childID int) *
 						InitialActions: []*ActionSet{
 							{
 								Actions: []*Action{
-									PayloadActivity(256, 256, DefaultRemoteActivity),
-									PayloadActivity(256, 256, DefaultRemoteActivity),
-									PayloadActivity(256, 256, DefaultRemoteActivity),
+									PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultRemoteActivity),
+									PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultRemoteActivity),
+									PayloadActivity(t.samplePayloadSize(rng), t.samplePayloadSize(rng), DefaultRemoteActivity),
 									NewEmptyReturnResultAction(),
 								},
 								Concurrent: false,
@@ -749,15 +769,16 @@ func (t *tpsExecutor) createStandaloneNexusOperationAction(operation string) *Ac
 	}), DefaultRemoteActivity)
 }
 
-func (t *tpsExecutor) createStandaloneActivityAction(taskQueue string) *Action {
+func (t *tpsExecutor) createStandaloneActivityAction(taskQueue string, rng *rand.Rand) *Action {
+	size := int32(t.samplePayloadSize(rng))
 	return ClientActivity(ClientActions(&ClientAction{
 		Variant: &ClientAction_DoStandaloneActivity{
 			DoStandaloneActivity: &DoStandaloneActivity{
 				Activity: &ExecuteActivityAction{
 					ActivityType: &ExecuteActivityAction_Payload{
 						Payload: &ExecuteActivityAction_PayloadActivity{
-							BytesToReceive: 256,
-							BytesToReturn:  256,
+							BytesToReceive: size,
+							BytesToReturn:  size,
 						},
 					},
 					TaskQueue:           taskQueue,

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -380,8 +380,8 @@ func (t *tpsExecutor) updateStateOnIterationCompletion() {
 }
 
 func (t *tpsExecutor) createActions(run *loadgen.Run) []*ActionSet {
-	// One rng per iteration, threaded through the recursion so the sampled sequence
-	// continues across continue-as-new boundaries instead of restarting per chunk.
+	// We thread one rng throughout so the sampled sequence continues across
+	// continue-as-new boundaries instead of restarting per chunk.
 	rng := rand.New(rand.NewSource(t.config.RngSeed + int64(run.Iteration)))
 	return []*ActionSet{
 		{

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/temporalio/omes/clioptions"
 	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
+	ks "github.com/temporalio/omes/loadgen/kitchensink"
+	"go.temporal.io/sdk/converter"
+	"go.uber.org/zap"
 )
 
 func TestThroughputStress(t *testing.T) {
@@ -71,4 +75,116 @@ func TestThroughputStress(t *testing.T) {
 		_, err = env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully when resuming from end")
 	})
+}
+
+func TestThroughputStressConfigurePayload(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID: "tps-payload",
+		ScenarioOptions: map[string]string{
+			PayloadDistributionJsonFlag: `{"size":{"type":"discrete","weights":{"1024":1}}}`,
+		},
+	}
+	require.NoError(t, executor.Configure(info))
+	require.NotNil(t, executor.config.Payload)
+
+	// Single-value distribution always samples the configured value.
+	require.Equal(t, 1024, executor.samplePayloadSize(rand.New(rand.NewSource(1))))
+}
+
+func TestThroughputStressConfigureNoPayload(t *testing.T) {
+	t.Parallel()
+
+	// Without the option, payload sizing falls back to the previous hardcoded 256.
+	executor := newThroughputStressExecutor()
+	require.NoError(t, executor.Configure(loadgen.ScenarioInfo{RunID: "tps-no-payload"}))
+	require.Nil(t, executor.config.Payload)
+	require.Equal(t, 256, executor.samplePayloadSize(rand.New(rand.NewSource(1))))
+}
+
+func TestThroughputStressConfigureInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID: "tps-payload-invalid",
+		ScenarioOptions: map[string]string{
+			PayloadDistributionJsonFlag: `{"size":{"type":"bogus"}}`,
+		},
+	}
+	require.Error(t, executor.Configure(info))
+}
+
+// TestThroughputStressPayloadSequenceAcrossContinueAsNew guards against the payload-size
+// rng restarting at each continue-as-new boundary: the whole nested action tree is built
+// client-side from a single per-iteration rng, so a later chunk must continue the sequence
+// rather than repeat the first chunk verbatim.
+func TestThroughputStressPayloadSequenceAcrossContinueAsNew(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID:       "tps-can-seq",
+		ExecutionID: "exec",
+		Logger:      zap.NewNop().Sugar(),
+		ScenarioOptions: map[string]string{
+			IterFlag:                    "4", // > ContinueAsNewAfterIter, so chunks are nested via CAN
+			ContinueAsNewAfterIterFlag:  "1",
+			PayloadDistributionJsonFlag: `{"size":{"type":"uniform","min":"1","max":"1000000"}}`,
+		},
+	}
+	require.NoError(t, executor.Configure(info))
+
+	sets := executor.createActions(info.NewRun(1))
+	require.Len(t, sets, 1)
+
+	chunk1 := sets[0].GetActions()
+	chunk1Sizes := directPayloadSizes(chunk1)
+	require.NotEmpty(t, chunk1Sizes)
+
+	chunk2Sizes := directPayloadSizes(decodeContinueAsNewChunk(t, chunk1))
+	require.NotEmpty(t, chunk2Sizes)
+
+	require.NotEqual(t, chunk1Sizes, chunk2Sizes,
+		"payload-size sequence must advance across continue-as-new, not restart identically")
+}
+
+// directPayloadSizes collects the receive/return byte sizes of payload activities directly
+// in the given actions (descending into nested action sets but not into child workflows or
+// continue-as-new arguments).
+func directPayloadSizes(actions []*ks.Action) []int32 {
+	var out []int32
+	for _, a := range actions {
+		switch v := a.GetVariant().(type) {
+		case *ks.Action_ExecActivity:
+			if p := v.ExecActivity.GetPayload(); p != nil {
+				out = append(out, p.GetBytesToReceive(), p.GetBytesToReturn())
+			}
+		case *ks.Action_NestedActionSet:
+			out = append(out, directPayloadSizes(v.NestedActionSet.GetActions())...)
+		}
+	}
+	return out
+}
+
+// decodeContinueAsNewChunk finds the ContinueAsNew action in a chunk and decodes its
+// argument back into the next chunk's actions.
+func decodeContinueAsNewChunk(t *testing.T, actions []*ks.Action) []*ks.Action {
+	t.Helper()
+	for _, a := range actions {
+		can, ok := a.GetVariant().(*ks.Action_ContinueAsNew)
+		if !ok {
+			continue
+		}
+		require.NotEmpty(t, can.ContinueAsNew.GetArguments())
+		var input ks.WorkflowInput
+		conv := converter.NewProtoJSONPayloadConverter()
+		require.NoError(t, conv.FromPayload(can.ContinueAsNew.GetArguments()[0], &input))
+		require.NotEmpty(t, input.GetInitialActions())
+		return input.GetInitialActions()[0].GetActions()
+	}
+	t.Fatal("no ContinueAsNew action found in chunk")
+	return nil
 }

--- a/workers/typescript/package-lock.json
+++ b/workers/typescript/package-lock.json
@@ -1007,7 +1007,6 @@
       "integrity": "sha512-0l1gl/72PErwUZuavcRpRAQN9uSst+Nk++niC5IX6lmMWpXoScYx3oq/narT64/sKv/eRiPTaAjBFGDEQiWJIw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -1499,7 +1498,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1517,7 +1515,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1563,7 +1560,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1937,7 +1933,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2181,7 +2176,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2665,7 +2659,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3598,7 +3591,6 @@
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -4059,7 +4051,6 @@
       "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4294,7 +4285,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4678,7 +4668,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4805,8 +4794,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4827,7 +4815,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4992,7 +4979,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
## What was changed

Adds a `--option payload-distribution-json` knob to the `throughput_stress` scenario to pull payload sizes from a `DistributionField`. This replaces the existing hard-coded 256B payload size which I've kept as the default.

NOTE: Activity input bytes are now pseudo-random data pulled from the rng so we can actually test CDS/Walker behavior with large payloads as we compress everything we can.

## Why?

We need to test temporal with more realistic workloads. This will let us configure those