### PR TITLE
Fix CLI image build after Debian protobuf revision update

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.21.12-11 libprotoc-dev=3.21.12-11 \
+      protobuf-compiler=3.21.12-* libprotoc-dev=3.21.12-* \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Rust for kitchen-sink-gen


### PR DESCRIPTION
## What was changed
The CLI Dockerfile pinned the protobuf Debian packages to `3.21.12-11`, but Debian’s repos no longer provide that version:
```
E: Version '3.21.12-11' for 'protobuf-compiler' was not found
```

instead, Debians' repos now provide the updated revision, `3.21.12-11+deb13u1`. Both packages contain protobuf `3.21.12`, but `apt` can no longer install the pinned debian proto package as it's no longer available.

This change loosens the Debian packaging revision constraint to `3.21.12-*`, keeping protobuf on the intended 3.21.12 release. Opted for wildcard instead of specific revision version to prevent future CI failures of this nature.

## Why?
Fix for docker build/push CI failure.

2. How was this tested:
Verified by building and running the CLI image for both linux/amd64 and linux/arm64.
