### PR TITLE
loadgen: add mixture distribution

### DIFF
--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -1,17 +1,19 @@
 # Build in a full featured container
-ARG TARGETARCH
-FROM --platform=linux/$TARGETARCH eclipse-temurin:21-jammy AS build
+# Use BUILDPLATFORM so the build stage runs natively (avoids QEMU networking issues
+# with apt-get when cross-building for arm64 on an amd64 host).
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jammy AS build
 
-# Install protobuf compiler and dependencies
+# Install protobuf compiler and dependencies (runs on native build platform, no QEMU)
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
       protobuf-compiler=3.12.4* git=1:2.34.1-1ubuntu1
 
-# Get go compiler
+# Get go compiler for the build platform
+ARG BUILDARCH
 ARG TARGETARCH
-RUN wget -q https://go.dev/dl/go1.21.12.linux-${TARGETARCH}.tar.gz \
-    && tar -C /usr/local -xzf go1.21.12.linux-${TARGETARCH}.tar.gz
+RUN wget -q https://go.dev/dl/go1.21.12.linux-${BUILDARCH}.tar.gz \
+    && tar -C /usr/local -xzf go1.21.12.linux-${BUILDARCH}.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 WORKDIR /app
@@ -30,7 +32,10 @@ COPY loadgen ./loadgen
 COPY metrics ./metrics
 COPY scenarios ./scenarios
 COPY internal ./internal
-RUN CGO_ENABLED=0 go build -o temporal-omes ./cmd/omes
+# Build a native binary to use during Docker build (for the prepare-worker step below)
+RUN CGO_ENABLED=0 go build -o temporal-omes-build ./cmd/omes
+# Cross-compile the binary for the target platform (included in the final image)
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o temporal-omes ./cmd/omes
 
 ARG SDK_VERSION
 
@@ -46,14 +51,14 @@ COPY workers/java ./workers/java
 ENV GRADLE_USER_HOME="/gradle"
 RUN /app/workers/java/gradlew --version
 
-# Build the worker
+# Build the worker using the native binary (avoids running a TARGETARCH binary under QEMU)
 WORKDIR /app
-RUN CGO_ENABLED=0 ./temporal-omes prepare-worker --language java --dir-name prepared --version "$SDK_VERSION"
+RUN CGO_ENABLED=0 ./temporal-omes-build prepare-worker --language java --dir-name prepared --version "$SDK_VERSION"
 
-# Copy the CLI and prepared feature to a "run" container. Distroless isn't used here since we run
-# through Gradle and it's more annoying than it's worth to get its deps to line up
-FROM --platform=linux/$TARGETARCH eclipse-temurin:21
-RUN apt-get update && apt-get install --no-install-recommends --assume-yes git && rm -rf /var/lib/apt/lists/*
+# Copy the CLI and prepared feature to a "run" container. Use Alpine to avoid apt-get
+# networking issues with ports.ubuntu.com in QEMU-emulated arm64 containers.
+FROM --platform=linux/$TARGETARCH eclipse-temurin:21-alpine
+RUN apk add --no-cache git
 ENV GRADLE_USER_HOME="/gradle"
 
 COPY --from=build /app/temporal-omes /app/temporal-omes

--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -42,6 +42,9 @@ type distribution[T distValueType] interface {
 //
 //   - "normal" - Normal distribution.
 //     Example: {"type": "normal", "mean": "500", "stdDev": "100", "min": "0", "max": "1000"}
+//
+//   - "mixture" - Mixture of weighted nested distributions.
+//     Example: {"type": "mixture", "components": [{"weight": 3, "distribution": {"type": "normal", "mean": "500", "stdDev": "100", "min": "0", "max": "1000"}}, {"weight": 7, "distribution": {"type": "uniform", "min": "100", "max": "1000"}}]}
 type DistributionField[T distValueType] struct {
 	distribution[T]
 	distType string
@@ -95,6 +98,10 @@ func (df *DistributionField[T]) UnmarshalJSON(data []byte) error {
 		df.distribution = &dist
 	case "normal":
 		var dist normalDistribution[T]
+		err = json.Unmarshal(data, &dist)
+		df.distribution = &dist
+	case "mixture":
+		var dist mixtureDistribution[T]
 		err = json.Unmarshal(data, &dist)
 		df.distribution = &dist
 	default:
@@ -489,6 +496,107 @@ func (d *normalDistribution[T]) UnmarshalJSON(data []byte) error {
 	d.stdDev = stdDev
 	d.min = minVal
 	d.max = maxVal
+
+	return nil
+}
+
+type mixtureComponent[T distValueType] struct {
+	weight       int
+	distribution DistributionField[T]
+}
+
+type mixtureDistribution[T distValueType] struct {
+	components []mixtureComponent[T]
+
+	// totalWeight is the sum of component weights, cached on first Sample.
+	// Sample is called concurrently from multiple iteration goroutines that
+	// share a distribution instance, so it is computed exactly once.
+	totalWeightOnce sync.Once
+	totalWeight     int
+}
+
+func (d *mixtureDistribution[T]) GetType() string {
+	return "mixture"
+}
+
+func (d *mixtureDistribution[T]) Validate() error {
+	if len(d.components) == 0 {
+		return fmt.Errorf("components cannot be empty")
+	}
+	for i, component := range d.components {
+		if component.weight <= 0 {
+			return fmt.Errorf("component %d weight must be positive, got %d", i, component.weight)
+		}
+		if component.distribution.distribution == nil {
+			return fmt.Errorf("component %d is missing a distribution", i)
+		}
+		if err := component.distribution.Validate(); err != nil {
+			return fmt.Errorf("invalid component %d distribution: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (d *mixtureDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+	var zero T
+	if len(d.components) == 0 {
+		return zero, false
+	}
+
+	d.totalWeightOnce.Do(func() {
+		for _, component := range d.components {
+			d.totalWeight += component.weight
+		}
+	})
+	if d.totalWeight <= 0 {
+		return zero, false
+	}
+
+	// Perform weighted sampling to pick a component, then sample from it.
+	r := rng.Intn(d.totalWeight)
+	cumulativeWeight := 0
+	for _, component := range d.components {
+		cumulativeWeight += component.weight
+		if r < cumulativeWeight {
+			return component.distribution.Sample(rng)
+		}
+	}
+	return zero, false
+}
+
+func (d *mixtureDistribution[T]) MarshalJSON() ([]byte, error) {
+	components := make([]map[string]any, len(d.components))
+	for i, component := range d.components {
+		components[i] = map[string]any{
+			"weight":       component.weight,
+			"distribution": component.distribution,
+		}
+	}
+
+	return json.Marshal(map[string]any{
+		"type":       d.GetType(),
+		"components": components,
+	})
+}
+
+func (d *mixtureDistribution[T]) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Components []struct {
+			Weight       int                  `json:"weight"`
+			Distribution DistributionField[T] `json:"distribution"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	d.components = make([]mixtureComponent[T], len(raw.Components))
+	for i, component := range raw.Components {
+		d.components[i] = mixtureComponent[T]{
+			weight:       component.Weight,
+			distribution: component.Distribution,
+		}
+	}
 
 	return nil
 }

--- a/loadgen/helper_dist_test.go
+++ b/loadgen/helper_dist_test.go
@@ -479,6 +479,120 @@ func TestDistributionField(t *testing.T) {
 		// no need to test other dist types ...
 	})
 
+	t.Run("Mixture Distribution", func(t *testing.T) {
+		t.Run("Int64", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":3,"distribution":{"type":"uniform","min":"0","max":"100"}},{"weight":7,"distribution":{"type":"uniform","min":"1000","max":"2000"}}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			require.NoError(t, err)
+
+			// Test exact values with specific seeds
+			rng := rand.New(rand.NewSource(testSeed))
+			value, ok := df.Sample(rng)
+			assert.True(t, ok)
+			assert.Equal(t, int64(1234), value)
+
+			// Verify deterministic behavior
+			rng2 := rand.New(rand.NewSource(testSeed))
+			value2, ok2 := df.Sample(rng2)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			// Test with other specific seeds for different values, including a
+			// draw that picks the low-weight component.
+			rng3 := rand.New(rand.NewSource(1))
+			value3, ok3 := df.Sample(rng3)
+			assert.True(t, ok3)
+			assert.Equal(t, int64(35), value3)
+
+			checkJsonRoundtrip(t, err, df)
+		})
+
+		t.Run("Nested mixture", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":1,"distribution":{"type":"mixture","components":[{"weight":1,"distribution":{"type":"uniform","min":"0","max":"100"}},{"weight":1,"distribution":{"type":"uniform","min":"1000","max":"2000"}}]}},{"weight":1,"distribution":{"type":"fixed","value":"9999"}}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			require.NoError(t, err)
+
+			rng := rand.New(rand.NewSource(0))
+			value, ok := df.Sample(rng)
+			assert.True(t, ok)
+			assert.Equal(t, int64(63), value)
+
+			// Verify deterministic behavior
+			rng2 := rand.New(rand.NewSource(0))
+			value2, ok2 := df.Sample(rng2)
+			assert.True(t, ok2)
+			assert.Equal(t, value, value2)
+
+			checkJsonRoundtrip(t, err, df)
+		})
+
+		t.Run("Single component is valid and always samples that component", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":5,"distribution":{"type":"fixed","value":"777"}}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			require.NoError(t, err)
+
+			for i := range 10 {
+				rng := rand.New(rand.NewSource(testSeed + int64(i)))
+				v, ok := df.Sample(rng)
+				assert.True(t, ok)
+				assert.Equal(t, int64(777), v)
+			}
+
+			checkJsonRoundtrip(t, err, df)
+		})
+
+		t.Run("Empty components is invalid", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "components cannot be empty")
+		})
+
+		t.Run("Non-positive weight is invalid", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":0,"distribution":{"type":"fixed","value":"1"}}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "component 0 weight must be positive")
+		})
+
+		t.Run("Null component distribution is invalid", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":1,"distribution":null}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "component 0 is missing a distribution")
+		})
+
+		t.Run("Missing component distribution is invalid", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":1}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "component 0 is missing a distribution")
+		})
+
+		t.Run("Invalid nested distribution is invalid", func(t *testing.T) {
+			jsonData := `{"type":"mixture","components":[{"weight":1,"distribution":{"type":"normal","mean":"5","stdDev":"0","min":"0","max":"10"}}]}`
+			var df DistributionField[int64]
+
+			err := json.Unmarshal([]byte(jsonData), &df)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "standard deviation must be positive")
+		})
+	})
+
 	t.Run("Error Cases", func(t *testing.T) {
 		t.Run("Unknown distribution type", func(t *testing.T) {
 			jsonData := `{"type":"unknown"}`
@@ -516,11 +630,16 @@ func checkJsonRoundtrip[T distValueType](t *testing.T, err error, df Distributio
 	t.Helper()
 
 	marshaled, err := json.Marshal(df)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var unmarshalled DistributionField[T]
 	err = json.Unmarshal(marshaled, &unmarshalled)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.EqualExportedValues(t, df, unmarshalled)
+	// The distribution structs expose no exported fields (and some hold
+	// sampling caches), so EqualExportedValues would pass vacuously. Compare
+	// the re-marshaled JSON instead: a faithful roundtrip must reproduce it.
+	remarshaled, err := json.Marshal(unmarshalled)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(marshaled), string(remarshaled))
 }

--- a/loadgen/helper_dist_test.go
+++ b/loadgen/helper_dist_test.go
@@ -88,7 +88,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, float32(1.5), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
@@ -121,7 +121,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 	})
 
@@ -194,7 +194,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, float32(38.205994), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 	})
 
@@ -264,7 +264,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, int64(1), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Float32", func(t *testing.T) {
@@ -302,7 +302,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, float32(1), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, time.Duration(1), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 	})
 
@@ -415,7 +415,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, float32(66.34703), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Duration", func(t *testing.T) {
@@ -447,7 +447,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 	})
 
@@ -506,7 +506,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok3)
 			assert.Equal(t, int64(35), value3)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Nested mixture", func(t *testing.T) {
@@ -527,7 +527,7 @@ func TestDistributionField(t *testing.T) {
 			assert.True(t, ok2)
 			assert.Equal(t, value, value2)
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Single component is valid and always samples that component", func(t *testing.T) {
@@ -544,7 +544,7 @@ func TestDistributionField(t *testing.T) {
 				assert.Equal(t, int64(777), v)
 			}
 
-			checkJsonRoundtrip(t, err, df)
+			checkJsonRoundtrip(t, df)
 		})
 
 		t.Run("Empty components is invalid", func(t *testing.T) {
@@ -626,7 +626,7 @@ func TestDistributionField(t *testing.T) {
 	})
 }
 
-func checkJsonRoundtrip[T distValueType](t *testing.T, err error, df DistributionField[T]) {
+func checkJsonRoundtrip[T distValueType](t *testing.T, df DistributionField[T]) {
 	t.Helper()
 
 	marshaled, err := json.Marshal(df)


### PR DESCRIPTION
## What

Adds a `mixture` distribution to loadgen. A mixture is a JSON-configured list of weighted components, each an arbitrary nested distribution. Every `Sample` picks a component by its integer relative weight, then samples from that component's underlying distribution.

This expresses mixed workloads that no single distribution can, for example a uniform bulk with a weighted normal tail.

## Config

```json
{
  "type": "mixture",
  "components": [
    {"weight": 3, "distribution": {"type": "normal", "mean": "500", "stdDev": "100", "min": "0", "max": "1000"}},
    {"weight": 7, "distribution": {"type": "uniform", "min": "100", "max": "1000"}}
  ]
}
```