### PR TITLE
loadgen: export distribution types and add JSON tags

### DIFF
--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -4,18 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 )
 
-// distValueType constrains the types that can be used as distribution values.
-type distValueType interface {
+// DistValueType constrains the types that can be used as distribution values.
+type DistValueType interface {
 	int64 | time.Duration | float32 | int32
 }
 
-type distribution[T distValueType] interface {
+type Distribution[T DistValueType] interface {
 	// Sample returns a random value from the distribution using the provided random number generator.
 	Sample(rng *rand.Rand) (T, bool)
 	// GetType returns the distribution type identifier.
@@ -45,23 +45,25 @@ type distribution[T distValueType] interface {
 //
 //   - "mixture" - Mixture of weighted nested distributions.
 //     Example: {"type": "mixture", "components": [{"weight": 3, "distribution": {"type": "normal", "mean": "500", "stdDev": "100", "min": "0", "max": "1000"}}, {"weight": 7, "distribution": {"type": "uniform", "min": "100", "max": "1000"}}]}
-type DistributionField[T distValueType] struct {
-	distribution[T]
-	distType string
+type DistributionField[T DistValueType] struct {
+	Distribution[T]
+	// DistType is NOT marshaled as the custom MarshalJSON implementation flattens the type
+	// alongside the internal distribution's type
+	DistType string `json:"-"`
 }
 
 // NOTE: each distribution's marshaller is responsible for setting the "type" field.
 func (df DistributionField[T]) MarshalJSON() ([]byte, error) {
-	if df.distribution == nil {
+	if df.Distribution == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(df.distribution)
+	return json.Marshal(df.Distribution)
 }
 
 func (df *DistributionField[T]) UnmarshalJSON(data []byte) error {
 	if len(data) == 0 || string(data) == "null" {
-		df.distribution = nil
-		df.distType = ""
+		df.Distribution = nil
+		df.DistType = ""
 		return nil
 	}
 
@@ -75,35 +77,35 @@ func (df *DistributionField[T]) UnmarshalJSON(data []byte) error {
 	if typeInfo.Type == "" {
 		return fmt.Errorf("missing distribution type")
 	}
-	df.distType = typeInfo.Type
+	df.DistType = typeInfo.Type
 
 	// unmarshal the distribution data based on the type
 	var err error
 	switch typeInfo.Type {
 	case "fixed":
-		var dist fixedDistribution[T]
+		var dist FixedDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	case "discrete":
-		var dist discreteDistribution[T]
+		var dist DiscreteDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	case "uniform":
-		var dist uniformDistribution[T]
+		var dist UniformDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	case "zipf":
-		var dist zipfDistribution[T]
+		var dist ZipfDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	case "normal":
-		var dist normalDistribution[T]
+		var dist NormalDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	case "mixture":
-		var dist mixtureDistribution[T]
+		var dist MixtureDistribution[T]
 		err = json.Unmarshal(data, &dist)
-		df.distribution = &dist
+		df.Distribution = &dist
 	default:
 		return fmt.Errorf("unknown distribution type: %s", typeInfo.Type)
 	}
@@ -112,45 +114,45 @@ func (df *DistributionField[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to unmarshal %s distribution: %w", typeInfo.Type, err)
 	}
 
-	if err := df.distribution.Validate(); err != nil {
+	if err := df.Distribution.Validate(); err != nil {
 		return fmt.Errorf("invalid %s distribution: %w", typeInfo.Type, err)
 	}
 
 	return nil
 }
 
-type fixedDistribution[T distValueType] struct {
-	value T
+type FixedDistribution[T DistValueType] struct {
+	Value T `json:"value"`
 }
 
-func NewFixedDistribution[T distValueType](value T) DistributionField[T] {
+func NewFixedDistribution[T DistValueType](value T) DistributionField[T] {
 	return DistributionField[T]{
-		distribution: &fixedDistribution[T]{value: value},
-		distType:     "fixed",
+		Distribution: &FixedDistribution[T]{Value: value},
+		DistType:     "fixed",
 	}
 }
 
-func (d *fixedDistribution[T]) GetType() string {
+func (d *FixedDistribution[T]) GetType() string {
 	return "fixed"
 }
 
-func (d *fixedDistribution[T]) Validate() error {
+func (d *FixedDistribution[T]) Validate() error {
 	// Fixed distributions are always valid
 	return nil
 }
 
-func (d *fixedDistribution[T]) Sample(_ *rand.Rand) (T, bool) {
-	return d.value, true
+func (d *FixedDistribution[T]) Sample(_ *rand.Rand) (T, bool) {
+	return d.Value, true
 }
 
-func (d *fixedDistribution[T]) MarshalJSON() ([]byte, error) {
+func (d *FixedDistribution[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{
 		"type":  d.GetType(),
-		"value": renderToJSON(d.value),
+		"value": renderToJSON(d.Value),
 	})
 }
 
-func (d *fixedDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *FixedDistribution[T]) UnmarshalJSON(data []byte) error {
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
@@ -161,39 +163,39 @@ func (d *fixedDistribution[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	d.value = value
+	d.Value = value
 	return nil
 }
 
-type discreteDistribution[T distValueType] struct {
-	weights   map[T]int
-	cacheOnce sync.Once
-	cache     *discreteCache[T]
+type DiscreteDistribution[T DistValueType] struct {
+	Weights   map[T]int         `json:"weights"`
+	cacheOnce sync.Once         `json:"-"`
+	cache     *discreteCache[T] `json:"-"`
 }
 
-// discreteCache holds pre-computed values for discreteDistribution sampling
-type discreteCache[T distValueType] struct {
+// discreteCache holds pre-computed values for DiscreteDistribution sampling
+type discreteCache[T DistValueType] struct {
 	keys        []T
 	weights     []int
 	totalWeight int
 }
 
-func NewDiscreteDistribution[T distValueType](weights map[T]int) DistributionField[T] {
+func NewDiscreteDistribution[T DistValueType](weights map[T]int) DistributionField[T] {
 	return DistributionField[T]{
-		distribution: &discreteDistribution[T]{weights: weights},
-		distType:     "discrete",
+		Distribution: &DiscreteDistribution[T]{Weights: weights},
+		DistType:     "discrete",
 	}
 }
 
-func (d *discreteDistribution[T]) GetType() string {
+func (d *DiscreteDistribution[T]) GetType() string {
 	return "discrete"
 }
 
-func (d *discreteDistribution[T]) Validate() error {
-	if len(d.weights) == 0 {
+func (d *DiscreteDistribution[T]) Validate() error {
+	if len(d.Weights) == 0 {
 		return fmt.Errorf("weights map cannot be empty")
 	}
-	for value, weight := range d.weights {
+	for value, weight := range d.Weights {
 		if weight <= 0 {
 			return fmt.Errorf("weight value must be positive, got %d for value %v", weight, value)
 		}
@@ -201,13 +203,13 @@ func (d *discreteDistribution[T]) Validate() error {
 	return nil
 }
 
-func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+func (d *DiscreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	var zero T
-	if len(d.weights) == 0 {
+	if len(d.Weights) == 0 {
 		return zero, false
 	}
-	if len(d.weights) == 1 {
-		for v := range d.weights {
+	if len(d.Weights) == 1 {
+		for v := range d.Weights {
 			return v, true
 		}
 	}
@@ -215,18 +217,16 @@ func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	// Build the sampling cache exactly once; Sample is called concurrently from
 	// multiple iteration goroutines that share a distribution instance.
 	d.cacheOnce.Do(func() {
-		keys := make([]T, 0, len(d.weights))
-		for k := range d.weights {
+		keys := make([]T, 0, len(d.Weights))
+		for k := range d.Weights {
 			keys = append(keys, k)
 		}
-		sort.Slice(keys, func(i, j int) bool {
-			return keys[i] < keys[j]
-		})
+		slices.Sort(keys)
 
 		totalWeight := 0
 		weights := make([]int, len(keys))
 		for i, k := range keys {
-			weights[i] = d.weights[k]
+			weights[i] = d.Weights[k]
 			totalWeight += weights[i]
 		}
 
@@ -249,9 +249,9 @@ func (d *discreteDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	return zero, false
 }
 
-func (d *discreteDistribution[T]) MarshalJSON() ([]byte, error) {
-	weights := make(map[string]int, len(d.weights))
-	for value, weight := range d.weights {
+func (d *DiscreteDistribution[T]) MarshalJSON() ([]byte, error) {
+	weights := make(map[string]int, len(d.Weights))
+	for value, weight := range d.Weights {
 		weights[renderToJSON(value)] = weight
 	}
 
@@ -261,7 +261,7 @@ func (d *discreteDistribution[T]) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (d *discreteDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *DiscreteDistribution[T]) UnmarshalJSON(data []byte) error {
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
@@ -272,78 +272,78 @@ func (d *discreteDistribution[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to parse 'weights' as map[string]int: %w", err)
 	}
 
-	d.weights = make(map[T]int, len(weightsMap))
+	d.Weights = make(map[T]int, len(weightsMap))
 	for valueStr, weight := range weightsMap {
 		value, err := stringToValue[T](valueStr)
 		if err != nil {
 			return err
 		}
-		d.weights[value] = weight
+		d.Weights[value] = weight
 	}
 
 	return nil
 }
 
-type uniformDistribution[T distValueType] struct {
-	min T
-	max T
+type UniformDistribution[T DistValueType] struct {
+	Min T `json:"min"`
+	Max T `json:"max"`
 }
 
-func (d *uniformDistribution[T]) GetType() string {
+func (d *UniformDistribution[T]) GetType() string {
 	return "uniform"
 }
 
-func (d *uniformDistribution[T]) Validate() error {
-	if d.max < d.min {
-		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
+func (d *UniformDistribution[T]) Validate() error {
+	if d.Max < d.Min {
+		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.Max, d.Min)
 	}
 	return nil
 }
 
-func (d *uniformDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
-	switch any(d.min).(type) {
+func (d *UniformDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+	switch any(d.Min).(type) {
 	case int64:
-		minVal, maxVal := any(d.min).(int64), any(d.max).(int64)
+		minVal, maxVal := any(d.Min).(int64), any(d.Max).(int64)
 		if maxVal <= minVal {
-			return d.min, true
+			return d.Min, true
 		}
 		result := minVal + rng.Int63n(maxVal-minVal+1)
 		return T(result), true
 	case int32:
-		minVal, maxVal := any(d.min).(int32), any(d.max).(int32)
+		minVal, maxVal := any(d.Min).(int32), any(d.Max).(int32)
 		if maxVal <= minVal {
-			return d.min, true
+			return d.Min, true
 		}
 		result := minVal + rng.Int31n(maxVal-minVal+1)
 		return T(result), true
 	case float32:
-		minVal, maxVal := any(d.min).(float32), any(d.max).(float32)
+		minVal, maxVal := any(d.Min).(float32), any(d.Max).(float32)
 		if maxVal <= minVal {
-			return d.min, true
+			return d.Min, true
 		}
 		result := minVal + rng.Float32()*(maxVal-minVal)
 		return T(result), true
 	case time.Duration:
-		minVal, maxVal := any(d.min).(time.Duration), any(d.max).(time.Duration)
+		minVal, maxVal := any(d.Min).(time.Duration), any(d.Max).(time.Duration)
 		if maxVal <= minVal {
-			return d.min, true
+			return d.Min, true
 		}
 		result := time.Duration(int64(minVal) + rng.Int63n(int64(maxVal)-int64(minVal)+1))
 		return T(result), true
 	default:
-		return d.min, true
+		return d.Min, true
 	}
 }
 
-func (d *uniformDistribution[T]) MarshalJSON() ([]byte, error) {
+func (d *UniformDistribution[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{
 		"type": d.GetType(),
-		"min":  renderToJSON(d.min),
-		"max":  renderToJSON(d.max),
+		"min":  renderToJSON(d.Min),
+		"max":  renderToJSON(d.Max),
 	})
 }
 
-func (d *uniformDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *UniformDistribution[T]) UnmarshalJSON(data []byte) error {
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
@@ -359,50 +359,50 @@ func (d *uniformDistribution[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	d.min = min
-	d.max = max
+	d.Min = min
+	d.Max = max
 
 	return nil
 }
 
-type zipfDistribution[T distValueType] struct {
-	s float64
-	v float64
-	n uint64
+type ZipfDistribution[T DistValueType] struct {
+	S float64 `json:"s"`
+	V float64 `json:"v"`
+	N uint64  `json:"n"`
 }
 
-func (d *zipfDistribution[T]) GetType() string {
+func (d *ZipfDistribution[T]) GetType() string {
 	return "zipf"
 }
 
-func (d *zipfDistribution[T]) Validate() error {
-	if d.s <= 1.0 {
-		return fmt.Errorf("zipf distribution requires s > 1.0, got %f", d.s)
+func (d *ZipfDistribution[T]) Validate() error {
+	if d.S <= 1.0 {
+		return fmt.Errorf("zipf distribution requires s > 1.0, got %f", d.S)
 	}
-	if d.v < 1.0 {
-		return fmt.Errorf("zipf distribution requires v ≥ 1.0, got %f", d.v)
+	if d.V < 1.0 {
+		return fmt.Errorf("zipf distribution requires v ≥ 1.0, got %f", d.V)
 	}
-	if d.n < 1 {
-		return fmt.Errorf("zipf distribution requires n ≥ 1, got %d", d.n)
+	if d.N < 1 {
+		return fmt.Errorf("zipf distribution requires n ≥ 1, got %d", d.N)
 	}
 	return nil
 }
 
-func (d *zipfDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
-	zipf := rand.NewZipf(rng, d.s, d.v, d.n)
+func (d *ZipfDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+	zipf := rand.NewZipf(rng, d.S, d.V, d.N)
 	return T(zipf.Uint64()), true
 }
 
-func (d *zipfDistribution[T]) MarshalJSON() ([]byte, error) {
+func (d *ZipfDistribution[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{
 		"type": d.GetType(),
-		"s":    d.s,
-		"v":    d.v,
-		"n":    d.n,
+		"s":    d.S,
+		"v":    d.V,
+		"n":    d.N,
 	})
 }
 
-func (d *zipfDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *ZipfDistribution[T]) UnmarshalJSON(data []byte) error {
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
@@ -423,50 +423,50 @@ func (d *zipfDistribution[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	d.s = s
-	d.v = v
-	d.n = n
+	d.S = s
+	d.V = v
+	d.N = n
 
 	return nil
 }
 
-type normalDistribution[T distValueType] struct {
-	mean   T
-	stdDev T
-	min    T
-	max    T
+type NormalDistribution[T DistValueType] struct {
+	Mean   T `json:"mean"`
+	StdDev T `json:"stdDev"`
+	Min    T `json:"min"`
+	Max    T `json:"max"`
 }
 
-func (d *normalDistribution[T]) GetType() string {
+func (d *NormalDistribution[T]) GetType() string {
 	return "normal"
 }
 
-func (d *normalDistribution[T]) Validate() error {
-	if d.stdDev <= 0 {
-		return fmt.Errorf("standard deviation must be positive, got %v", d.stdDev)
+func (d *NormalDistribution[T]) Validate() error {
+	if d.StdDev <= 0 {
+		return fmt.Errorf("standard deviation must be positive, got %v", d.StdDev)
 	}
-	if d.max < d.min {
-		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.max, d.min)
+	if d.Max < d.Min {
+		return fmt.Errorf("max value (%v) cannot be less than min value (%v)", d.Max, d.Min)
 	}
 	return nil
 }
 
-func (d *normalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
-	result := min(d.max, max(d.min, d.mean+T(float64(d.stdDev)*rng.NormFloat64())))
+func (d *NormalDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+	result := min(d.Max, max(d.Min, d.Mean+T(float64(d.StdDev)*rng.NormFloat64())))
 	return result, true
 }
 
-func (d *normalDistribution[T]) MarshalJSON() ([]byte, error) {
+func (d *NormalDistribution[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{
 		"type":   d.GetType(),
-		"mean":   renderToJSON(d.mean),
-		"stdDev": renderToJSON(d.stdDev),
-		"min":    renderToJSON(d.min),
-		"max":    renderToJSON(d.max),
+		"mean":   renderToJSON(d.Mean),
+		"stdDev": renderToJSON(d.StdDev),
+		"min":    renderToJSON(d.Min),
+		"max":    renderToJSON(d.Max),
 	})
 }
 
-func (d *normalDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *NormalDistribution[T]) UnmarshalJSON(data []byte) error {
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMap); err != nil {
 		return err
@@ -492,60 +492,60 @@ func (d *normalDistribution[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	d.mean = mean
-	d.stdDev = stdDev
-	d.min = minVal
-	d.max = maxVal
+	d.Mean = mean
+	d.StdDev = stdDev
+	d.Min = minVal
+	d.Max = maxVal
 
 	return nil
 }
 
-type mixtureComponent[T distValueType] struct {
-	weight       int
-	distribution DistributionField[T]
+type MixtureComponent[T DistValueType] struct {
+	Weight       int                  `json:"weight"`
+	Distribution DistributionField[T] `json:"distribution"`
 }
 
-type mixtureDistribution[T distValueType] struct {
-	components []mixtureComponent[T]
+type MixtureDistribution[T DistValueType] struct {
+	Components []MixtureComponent[T] `json:"components"`
 
 	// totalWeight is the sum of component weights, cached on first Sample.
 	// Sample is called concurrently from multiple iteration goroutines that
 	// share a distribution instance, so it is computed exactly once.
-	totalWeightOnce sync.Once
-	totalWeight     int
+	totalWeightOnce sync.Once `json:"-"`
+	totalWeight     int       `json:"-"`
 }
 
-func (d *mixtureDistribution[T]) GetType() string {
+func (d *MixtureDistribution[T]) GetType() string {
 	return "mixture"
 }
 
-func (d *mixtureDistribution[T]) Validate() error {
-	if len(d.components) == 0 {
+func (d *MixtureDistribution[T]) Validate() error {
+	if len(d.Components) == 0 {
 		return fmt.Errorf("components cannot be empty")
 	}
-	for i, component := range d.components {
-		if component.weight <= 0 {
-			return fmt.Errorf("component %d weight must be positive, got %d", i, component.weight)
+	for i, component := range d.Components {
+		if component.Weight <= 0 {
+			return fmt.Errorf("component %d weight must be positive, got %d", i, component.Weight)
 		}
-		if component.distribution.distribution == nil {
+		if component.Distribution.Distribution == nil {
 			return fmt.Errorf("component %d is missing a distribution", i)
 		}
-		if err := component.distribution.Validate(); err != nil {
+		if err := component.Distribution.Validate(); err != nil {
 			return fmt.Errorf("invalid component %d distribution: %w", i, err)
 		}
 	}
 	return nil
 }
 
-func (d *mixtureDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
+func (d *MixtureDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	var zero T
-	if len(d.components) == 0 {
+	if len(d.Components) == 0 {
 		return zero, false
 	}
 
 	d.totalWeightOnce.Do(func() {
-		for _, component := range d.components {
-			d.totalWeight += component.weight
+		for _, component := range d.Components {
+			d.totalWeight += component.Weight
 		}
 	})
 	if d.totalWeight <= 0 {
@@ -555,21 +555,21 @@ func (d *mixtureDistribution[T]) Sample(rng *rand.Rand) (T, bool) {
 	// Perform weighted sampling to pick a component, then sample from it.
 	r := rng.Intn(d.totalWeight)
 	cumulativeWeight := 0
-	for _, component := range d.components {
-		cumulativeWeight += component.weight
+	for _, component := range d.Components {
+		cumulativeWeight += component.Weight
 		if r < cumulativeWeight {
-			return component.distribution.Sample(rng)
+			return component.Distribution.Sample(rng)
 		}
 	}
 	return zero, false
 }
 
-func (d *mixtureDistribution[T]) MarshalJSON() ([]byte, error) {
-	components := make([]map[string]any, len(d.components))
-	for i, component := range d.components {
+func (d *MixtureDistribution[T]) MarshalJSON() ([]byte, error) {
+	components := make([]map[string]any, len(d.Components))
+	for i, component := range d.Components {
 		components[i] = map[string]any{
-			"weight":       component.weight,
-			"distribution": component.distribution,
+			"weight":       component.Weight,
+			"distribution": component.Distribution,
 		}
 	}
 
@@ -579,7 +579,7 @@ func (d *mixtureDistribution[T]) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (d *mixtureDistribution[T]) UnmarshalJSON(data []byte) error {
+func (d *MixtureDistribution[T]) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Components []struct {
 			Weight       int                  `json:"weight"`
@@ -590,11 +590,11 @@ func (d *mixtureDistribution[T]) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	d.components = make([]mixtureComponent[T], len(raw.Components))
+	d.Components = make([]MixtureComponent[T], len(raw.Components))
 	for i, component := range raw.Components {
-		d.components[i] = mixtureComponent[T]{
-			weight:       component.Weight,
-			distribution: component.Distribution,
+		d.Components[i] = MixtureComponent[T]{
+			Weight:       component.Weight,
+			Distribution: component.Distribution,
 		}
 	}
 
@@ -693,7 +693,7 @@ func parseFromJSON[T any](rawMap map[string]json.RawMessage, fieldName string) (
 	}
 }
 
-func renderToJSON[T distValueType](value T) string {
+func renderToJSON[T DistValueType](value T) string {
 	switch v := any(value).(type) {
 	case time.Duration:
 		return v.String()
@@ -702,7 +702,7 @@ func renderToJSON[T distValueType](value T) string {
 	}
 }
 
-func stringToValue[T distValueType](valueStr string) (T, error) {
+func stringToValue[T DistValueType](valueStr string) (T, error) {
 	var zero T
 	switch any(zero).(type) {
 	case int64:

--- a/loadgen/helper_dist.go
+++ b/loadgen/helper_dist.go
@@ -20,7 +20,7 @@ type Distribution[T DistValueType] interface {
 	Sample(rng *rand.Rand) (T, bool)
 	// GetType returns the distribution type identifier.
 	GetType() string
-	// Validate checks if the distribution is valid.
+	// Validate returns an error if the distribution is invalid.
 	Validate() error
 }
 

--- a/loadgen/helper_dist_test.go
+++ b/loadgen/helper_dist_test.go
@@ -22,14 +22,14 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[int64]{
-				distribution: &discreteDistribution[int64]{
-					weights: map[int64]int{
+				Distribution: &DiscreteDistribution[int64]{
+					Weights: map[int64]int{
 						1:  10,
 						5:  20,
 						10: 70,
 					},
 				},
-				distType: "discrete",
+				DistType: "discrete",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -60,14 +60,14 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[float32]{
-				distribution: &discreteDistribution[float32]{
-					weights: map[float32]int{
+				Distribution: &DiscreteDistribution[float32]{
+					Weights: map[float32]int{
 						1.5:   10,
 						5.25:  20,
 						10.75: 70,
 					},
 				},
-				distType: "discrete",
+				DistType: "discrete",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -99,14 +99,14 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[time.Duration]{
-				distribution: &discreteDistribution[time.Duration]{
-					weights: map[time.Duration]int{
+				Distribution: &DiscreteDistribution[time.Duration]{
+					Weights: map[time.Duration]int{
 						1 * time.Second:  10,
 						5 * time.Second:  20,
 						10 * time.Second: 70,
 					},
 				},
-				distType: "discrete",
+				DistType: "discrete",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -134,11 +134,11 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[int64]{
-				distribution: &uniformDistribution[int64]{
-					min: 1,
-					max: 100,
+				Distribution: &UniformDistribution[int64]{
+					Min: 1,
+					Max: 100,
 				},
-				distType: "uniform",
+				DistType: "uniform",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -169,11 +169,11 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[float32]{
-				distribution: &uniformDistribution[float32]{
-					min: 1.5,
-					max: 99.9,
+				Distribution: &UniformDistribution[float32]{
+					Min: 1.5,
+					Max: 99.9,
 				},
-				distType: "uniform",
+				DistType: "uniform",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -205,11 +205,11 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[time.Duration]{
-				distribution: &uniformDistribution[time.Duration]{
-					min: 1 * time.Second,
-					max: 1 * time.Minute,
+				Distribution: &UniformDistribution[time.Duration]{
+					Min: 1 * time.Second,
+					Max: 1 * time.Minute,
 				},
-				distType: "uniform",
+				DistType: "uniform",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -238,12 +238,12 @@ func TestDistributionField(t *testing.T) {
 			require.NotNil(t, df)
 
 			expected := DistributionField[int64]{
-				distribution: &zipfDistribution[int64]{
-					s: 2.0,
-					v: 1.0,
-					n: 100,
+				Distribution: &ZipfDistribution[int64]{
+					S: 2.0,
+					V: 1.0,
+					N: 100,
 				},
-				distType: "zipf",
+				DistType: "zipf",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -276,12 +276,12 @@ func TestDistributionField(t *testing.T) {
 			require.NotNil(t, df)
 
 			expected := DistributionField[float32]{
-				distribution: &zipfDistribution[float32]{
-					s: 2.0,
-					v: 1.0,
-					n: 100,
+				Distribution: &ZipfDistribution[float32]{
+					S: 2.0,
+					V: 1.0,
+					N: 100,
 				},
-				distType: "zipf",
+				DistType: "zipf",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -313,12 +313,12 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[time.Duration]{
-				distribution: &zipfDistribution[time.Duration]{
-					s: 2.0,
-					v: 1.0,
-					n: 100,
+				Distribution: &ZipfDistribution[time.Duration]{
+					S: 2.0,
+					V: 1.0,
+					N: 100,
 				},
-				distType: "zipf",
+				DistType: "zipf",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -352,13 +352,13 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[int64]{
-				distribution: &normalDistribution[int64]{
-					mean:   50,
-					stdDev: 10,
-					min:    30,
-					max:    70,
+				Distribution: &NormalDistribution[int64]{
+					Mean:   50,
+					StdDev: 10,
+					Min:    30,
+					Max:    70,
 				},
-				distType: "normal",
+				DistType: "normal",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -388,13 +388,13 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[float32]{
-				distribution: &normalDistribution[float32]{
-					mean:   50.5,
-					stdDev: 10.2,
-					min:    30.1,
-					max:    70.9,
+				Distribution: &NormalDistribution[float32]{
+					Mean:   50.5,
+					StdDev: 10.2,
+					Min:    30.1,
+					Max:    70.9,
 				},
-				distType: "normal",
+				DistType: "normal",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -426,13 +426,13 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[time.Duration]{
-				distribution: &normalDistribution[time.Duration]{
-					mean:   20 * time.Second,
-					stdDev: 5 * time.Second,
-					min:    1 * time.Second,
-					max:    60 * time.Second,
+				Distribution: &NormalDistribution[time.Duration]{
+					Mean:   20 * time.Second,
+					StdDev: 5 * time.Second,
+					Min:    1 * time.Second,
+					Max:    60 * time.Second,
 				},
-				distType: "normal",
+				DistType: "normal",
 			}
 			assert.EqualExportedValues(t, expected, df)
 
@@ -460,12 +460,12 @@ func TestDistributionField(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := DistributionField[int64]{
-				distribution: &fixedDistribution[int64]{
-					value: 42,
+				Distribution: &FixedDistribution[int64]{
+					Value: 42,
 				},
-				distType: "fixed",
+				DistType: "fixed",
 			}
-			assert.Equal(t, expected.distType, df.distType)
+			assert.Equal(t, expected.DistType, df.DistType)
 
 			// Test all samples return the same value regardless of seed.
 			for i := range 10 {
@@ -621,12 +621,12 @@ func TestDistributionField(t *testing.T) {
 			var parsedDF DistributionField[int64]
 			err = json.Unmarshal(marshaled, &parsedDF)
 			assert.NoError(t, err)
-			assert.Nil(t, parsedDF.distribution)
+			assert.Nil(t, parsedDF.Distribution)
 		})
 	})
 }
 
-func checkJsonRoundtrip[T distValueType](t *testing.T, df DistributionField[T]) {
+func checkJsonRoundtrip[T DistValueType](t *testing.T, df DistributionField[T]) {
 	t.Helper()
 
 	marshaled, err := json.Marshal(df)


### PR DESCRIPTION
## What was changed
All distribution-related types and interfaces in `loadgen` are now exported publicly, with JSON struct tags matching their existing wire format.

## Why?
Lets upstream components configure omes distributions through a type-safe Go API instead of only hand-written JSON.