### PR TITLE
Add reusable devserver ports

### DIFF
--- a/devserver/config.go
+++ b/devserver/config.go
@@ -3,6 +3,7 @@ package devserver
 import (
 	"bytes"
 	"cmp"
+	"errors"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -39,6 +40,51 @@ const (
 )
 
 const maxPortAllocationAttempts = 50
+
+func resolvePorts(supplied *Ports) (Ports, error) {
+	if supplied == nil {
+		ports, err := allocatePorts("127.0.0.1")
+		if err != nil {
+			return Ports{}, err
+		}
+		return newPorts("127.0.0.1", ports), nil
+	}
+	if err := supplied.validate(); err != nil {
+		return Ports{}, err
+	}
+	return *supplied, nil
+}
+
+func (p Ports) validate() error {
+	if p.Host == "" {
+		return errors.New("host is required")
+	}
+	seen := make(map[int]struct{}, portCount)
+	for _, port := range p.portArray() {
+		if port <= 0 || port > 65535 {
+			return fmt.Errorf("invalid port %d", port)
+		}
+		if _, ok := seen[port]; ok {
+			return fmt.Errorf("duplicate port %d", port)
+		}
+		seen[port] = struct{}{}
+	}
+	return nil
+}
+
+func (p Ports) portArray() [portCount]int {
+	return [portCount]int{
+		p.FrontendGRPC,
+		p.FrontendMembership,
+		p.FrontendHTTP,
+		p.HistoryGRPC,
+		p.HistoryMembership,
+		p.MatchingGRPC,
+		p.MatchingMembership,
+		p.WorkerGRPC,
+		p.WorkerMembership,
+	}
+}
 
 // allocatePorts returns portCount free ports in the postgres-safe
 // range (<32768). It binds each port to prove it's free, then releases the

--- a/devserver/config_test.go
+++ b/devserver/config_test.go
@@ -1,6 +1,7 @@
 package devserver
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -25,6 +26,33 @@ func TestAllocatePorts(t *testing.T) {
 	}
 }
 
+func TestResolvePortsAllocatesByDefault(t *testing.T) {
+	ports, err := resolvePorts(nil)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", ports.Host)
+	require.NoError(t, ports.validate())
+}
+
+func TestResolvePortsReusesSuppliedPorts(t *testing.T) {
+	want := newPorts("127.0.0.1", [portCount]int{7233, 7234, 7243, 7235, 7236, 7237, 7238, 7239, 7240})
+	got, err := resolvePorts(&want)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestResolvePortsRejectsIncompleteOrInvalidSuppliedPorts(t *testing.T) {
+	valid := newPorts("127.0.0.1", [portCount]int{7233, 7234, 7243, 7235, 7236, 7237, 7238, 7239, 7240})
+
+	for _, ports := range []Ports{
+		{},
+		{Host: "127.0.0.1"},
+		func() Ports { ports := valid; ports.WorkerMembership = ports.FrontendGRPC; return ports }(),
+	} {
+		_, err := resolvePorts(&ports)
+		require.Error(t, err)
+	}
+}
+
 func TestServerPorts(t *testing.T) {
 	ports := newPorts("127.0.0.1", [portCount]int{7233, 7234, 7243, 7235, 7236, 7237, 7238, 7239, 7240})
 	server := &Server{
@@ -34,6 +62,18 @@ func TestServerPorts(t *testing.T) {
 
 	require.Equal(t, "127.0.0.1:7233", server.FrontendHostPort())
 	require.Equal(t, ports, server.Ports())
+}
+
+func TestServerStopIgnoresCanceledCommandContext(t *testing.T) {
+	workDir := t.TempDir()
+	server := &Server{
+		cancel:  func() {},
+		done:    make(chan error, 1),
+		workDir: workDir,
+	}
+	server.done <- context.Canceled
+
+	require.NoError(t, server.Stop())
 }
 
 func TestDefaultOutputDirUsesRepoRoot(t *testing.T) {

--- a/devserver/devserver.go
+++ b/devserver/devserver.go
@@ -50,6 +50,9 @@ type Options struct {
 	// server's own frontend. Set this to another server's frontend to join a
 	// multi-process cluster (e.g. for mixed-version testing).
 	ClusterEndpoint ClusterEndpoint
+	// Ports, when set, supplies the complete port allocation for this server.
+	// All ports must be set. When nil, Start allocates a fresh set of ports.
+	Ports *Ports
 }
 
 // ClusterEndpoint identifies an active-cluster pointer for the server's
@@ -143,19 +146,17 @@ func Start(ctx context.Context, opts Options) (*Server, error) {
 
 	// Allocate service ports and create configs before the clone+build
 	// so misconfiguration surfaces immediately.
-	const host = "127.0.0.1"
-	ports, err := allocatePorts(host)
+	serverPorts, err := resolvePorts(opts.Ports)
 	if err != nil {
-		return nil, fmt.Errorf("devserver: allocate ports: %w", err)
+		return nil, fmt.Errorf("devserver: resolve ports: %w", err)
 	}
-	serverPorts := newPorts(host, ports)
 	frontendAddr := net.JoinHostPort(serverPorts.Host, strconv.Itoa(serverPorts.FrontendGRPC))
-	frontendHTTPAddr := net.JoinHostPort(host, strconv.Itoa(ports[portFrontendHTTP]))
+	frontendHTTPAddr := net.JoinHostPort(serverPorts.Host, strconv.Itoa(serverPorts.FrontendHTTP))
 	dynConfigPath, err := writeDynamicConfig(workDir, frontendHTTPAddr, opts.DynamicConfigValues)
 	if err != nil {
 		return nil, fmt.Errorf("devserver: write dynamic config: %w", err)
 	}
-	serverEnv, err := buildServerEnv(opts.Persistence, opts.ClusterEndpoint, dynConfigPath, host, ports)
+	serverEnv, err := buildServerEnv(opts.Persistence, opts.ClusterEndpoint, dynConfigPath, serverPorts.Host, serverPorts.portArray())
 	if err != nil {
 		return nil, fmt.Errorf("devserver: build env: %w", err)
 	}
@@ -232,9 +233,16 @@ func (s *Server) Stop() error {
 		s.cancel()
 		err := <-s.done
 		_ = os.RemoveAll(s.workDir)
-		s.stopErr = classifyExitErr(err)
+		s.stopErr = classifyStopErr(err)
 	})
 	return s.stopErr
+}
+
+func classifyStopErr(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return classifyExitErr(err)
 }
 
 // classifyExitErr treats a clean exit or termination by our own SIGTERM


### PR DESCRIPTION
## Summary
- allow devserver callers to reuse a complete validated port allocation
- treat shutdown cancellation as a successful stop

## Validation
- go test -tags test_dep ./devserver