### PR TITLE
go.mod: pin harness/api to a real pseudo-version so downstream can resolve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,12 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/features v0.0.0-20260427223549-86e4c0deedd7
-	github.com/temporalio/omes/workers/go/harness/api v0.0.0-00010101000000-000000000000
+	// harness/api is a module nested in this repo. This MUST stay a real pseudo-version
+	// (a pushed commit whose workers/go/harness/api tree matches the local one), never the
+	// v0.0.0-00010101... placeholder: downstream consumers inherit this require but NOT the
+	// local replace below, so a placeholder breaks their `go list -m all`/module graph.
+	// Bump this whenever workers/go/harness/api changes.
+	github.com/temporalio/omes/workers/go/harness/api v0.0.0-20260601200529-2419bd37e739
 	go.temporal.io/api v1.62.12
 	go.temporal.io/sdk v1.45.0
 	go.uber.org/zap v1.27.0
@@ -72,5 +77,7 @@ require (
 replace (
 	github.com/temporalio/features/features => github.com/temporalio/features/features v0.0.0-20260324215619-e5868d9ba03f
 	github.com/temporalio/features/harness/go => github.com/temporalio/features/harness/go v0.0.0-20260324215619-e5868d9ba03f
+	// Local dev of the nested harness/api module; downstream consumers ignore this and use
+	// the real pseudo-version required above instead.
 	github.com/temporalio/omes/workers/go/harness/api => ./workers/go/harness/api
 )

--- a/workers/go/go.mod
+++ b/workers/go/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/temporalio/omes v1.0.0
-	github.com/temporalio/omes/workers/go/harness/api v0.0.0-00010101000000-000000000000
+	github.com/temporalio/omes/workers/go/harness/api v0.0.0-20260601200529-2419bd37e739
 )
 
 require (


### PR DESCRIPTION
## What was changed

The root module's `require` on the nested `workers/go/harness/api` module was pinned to the `v0.0.0-00010101000000-000000000000` local-replace placeholder. Change it to a real, VCS-resolvable pseudo-version (`v0.0.0-20260601200529-2419bd37e739`, at `2419bd3` — the last commit to touch `harness/api`) and keep the local `replace` for in-repo development.

## Why?

Go **ignores `replace` directives from dependency modules** — only the main module's replaces apply. So any downstream consumer of `github.com/temporalio/omes` inherits our placeholder `require` **without** the local `replace => ./workers/go/harness/api` that makes it resolve. Result: their module graph can't be built — `go list -m all` fails with:

```
github.com/temporalio/omes/workers/go/harness/api@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

This was dormant because nothing consumed the root module downstream until the benchgo→omes migration made **saas-cicd** import it. saas-cicd is currently carrying a local-replace workaround ([saas-cicd#3337](https://github.com/temporalio/saas-cicd/pull/3337)); this is the upstream root-cause fix, after which that workaround can be dropped.

With a **real** required version + the local replace kept:
- **Downstream** ignores the replace and resolves the real pseudo-version via git. ✅
- **In-repo** builds still use the local `harness/api` tree via the replace. ✅

## How was this tested

- `go build ./...` → passes (local dev still uses the local tree via replace)
- `go list -m github.com/temporalio/omes/workers/go/harness/api@2419bd3` → resolves the pseudo-version (downstream-resolvable)
- `go mod tidy` → holds the real version (does **not** revert to the placeholder) and produces no go.sum churn

## Follow-up (not in this PR)

The pinned version is maintained by hand, and the local replace hides staleness in-repo — if `harness/api` changes and the pin isn't bumped, in-repo CI stays green while downstream gets stale api code. Worth a small CI check that fails when the pinned pseudo-version doesn't match the current `workers/go/harness/api` tree. Happy to follow up.