### PR TITLE
docs: split running/configuring omes into docs/running.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This project is for testing load generation scenarios against Temporal. This is primarily used by the Temporal team to
 benchmark features and situations. Backwards compatibility may not be maintained.
 
+## Documentation
+
+- **[Running & configuring omes](./docs/running.md)** — run commands, load configuration, worker
+  profiles, and running against a specific SDK version.
+
 ## Why the weird name?
 
 Omes (pronounced oh-mess) is the Hebrew word for "load" (עומס).
@@ -118,80 +123,11 @@ func init() {
 1. When using `GenericExecutor`, use methods of `*loadgen.Run` in your `Execute` as much as possible.
 1. Liberally add helpers to the `loadgen` package that will be useful to other scenario authors.
 
-### Run scenario with worker - Start a worker, an optional dev server, and run a scenario
+### Running and configuring omes
 
-During local development it's typically easiest to run both the worker and the scenario together.
-You can do that like follows. If you want an embedded server rather than one you've already started,
-pass `--embedded-server`.
-
-```sh
-go run ./cmd/omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go
-```
-
-Notes:
-
-- Cleanup is **not** automatically performed here
-- Accepts combined flags for `run-worker` and `run-scenario` commands
-
-### Run a worker for a specific language SDK
-
-```sh
-go run ./cmd/omes run-worker --run-id local-test-run --language go
-```
-
-Notes:
-
-- `--embedded-server` can be passed here to start an embedded localhost server
-- `--task-queue-suffix-index-start` and `--task-queue-suffix-index-end` represent an inclusive range for running the
-  worker on multiple task queues. The process will create a worker for every task queue from `<task-queue>-<start>`
-  through `<task-queue>-end`. This only applies to multi-task-queue scenarios.
-- `--worker-profile` selects a code-defined worker configuration profile in the language harness. Omes forwards the
-  selected profile to the worker process via `OMES_WORKER_PROFILE`; the profile is not a worker CLI flag.
-
-Worker profiles provide a named worker configuration selected with `--worker-profile`. When a profile is selected, it
-takes precedence over worker configuration flags such as poller counts, autoscale poller settings, activity rate limits,
-slot counts, and worker versioning options. Non-worker-configuration flags, such as task queue selection, client
-connection settings, logging, metrics, and `--worker-err-on-unimplemented`, continue to apply normally.
-
-The shared `resource-based-default` profile uses the SDK resource-based worker tuner. The worker harnesses also provide
-`throughput-stress-baseline`, a fixed worker configuration for `throughput_stress` runs. It sets a workflow cache size
-of 50, 8 workflow task slots, 32 activity and local activity slots, 2 workflow task pollers, and 4 activity task pollers
-in each SDK.
-
-```sh
-go run ./cmd run-scenario-with-worker --scenario throughput_stress --language go \
-    --run-id local-profile-test --worker-profile resource-based-default
-```
-
-### Run a test scenario
-
-```sh
-go run ./cmd/omes run-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
-```
-
-Notes:
-
-- Run ID is used to derive ID prefixes and the task queue name, it should be used to start a worker on the correct task queue
-  and by the cleanup script.
-- By default the number of iterations or duration is specified in the scenario config. They can be overridden with CLI
-  flags.
-- See help output for available flags.
-
-### Cleanup after scenario run
-
-```sh
-go run ./cmd/omes cleanup-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
-```
-
-### Running a specific version of the SDK
-
-The `--version` flag can be used to specify a version of the SDK to use, it accepts either
-a version number like `v1.24.0` or you can also pass a local path to use a local SDK version.
-This is useful while testing unreleased or in-development versions of the SDK.
-
-```sh
-go run ./cmd/omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go --version /path/to/go-sdk
-```
+See **[docs/running.md](./docs/running.md)** for how to run omes (`run-scenario-with-worker`,
+`run-worker`, `run-scenario`, `cleanup-scenario`), configure the offered load, select a worker profile,
+and run against a specific SDK version.
 
 ### Building and publishing docker images
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,123 @@
+# Running omes
+
+How to run omes and configure the load it generates. This is the reference for local runs (laptop or a
+dev server) and applies equally whether you're self-hosting Temporal or running against a Temporal Cloud
+namespace.
+
+For authoring new scenarios, see the [README](../README.md#usage). For running against Temporal Cloud
+cells inside Temporal's own infra (scaffold / VCR), see the internal runbooks.
+
+## The commands
+
+omes has three ways to run, plus cleanup. Each takes a **scenario** and a **run-id**; the run-id derives
+the task queue, so a worker and the scenario that drives it must share it.
+
+### Run a scenario with a worker (local all-in-one)
+
+Easiest during development — starts the worker and the scenario together. Add `--embedded-server` to
+also start an embedded Temporal server instead of connecting to one you're already running.
+
+```sh
+go run ./cmd/omes run-scenario-with-worker --scenario workflow_with_single_noop_activity --language go
+```
+
+### Run a worker on its own
+
+```sh
+go run ./cmd/omes run-worker --run-id local-test-run --language go
+```
+
+### Run a scenario against an already-running worker
+
+```sh
+go run ./cmd/omes run-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
+```
+
+### Clean up after a run
+
+```sh
+go run ./cmd/omes cleanup-scenario --scenario workflow_with_single_noop_activity --run-id local-test-run
+```
+
+Run any command with `--help` for the full, authoritative flag list.
+
+## Configuring the load
+
+Run configuration comes in **two separate channels**:
+
+### 1. Built-in run flags (typed)
+
+These apply to every scenario and override its defaults:
+
+| Flag | Meaning |
+| --- | --- |
+| `--iterations` | Total iterations to run (mutually exclusive with `--duration`). |
+| `--duration` | How long to keep starting new iterations (mutually exclusive with `--iterations`). |
+| `--max-concurrent` | Max iterations running at once. |
+| `--max-iterations-per-second` | Rate limit on starting iterations (0 = unlimited). |
+| `--max-iteration-attempts` | Attempts per iteration (default 1). |
+| `--timeout` | Hard stop; cancels in-flight iterations and exits non-zero. |
+
+If you set neither `--iterations` nor `--duration`, the scenario's own default applies.
+
+### 2. Per-scenario options (`--option key=value`)
+
+Scenario-specific knobs are passed as repeated `--option key=value` pairs. The valid keys are defined by
+each scenario (read the scenario source or its `list-scenarios` description). A value may be loaded from
+a file with `@`: `--option sleep-activity-json=@sleep.json`.
+
+```sh
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+  --option nexus-endpoint=my-endpoint --run-id my-run
+```
+
+### One scenario per run
+
+A single omes run executes exactly **one** scenario. To run two load shapes at the same time, start two
+runs, each with its own `--run-id` (hence its own task queue). Composing load happens **within** a
+scenario (its action tree / executor), not by combining scenarios on the command line.
+
+## Worker configuration
+
+`run-worker` (and `run-scenario-with-worker`) accept worker-tuning options:
+
+- `--worker-profile <name>` selects a code-defined worker configuration profile in the language harness.
+  It is forwarded to the worker via the `OMES_WORKER_PROFILE` env var (it is not a worker CLI flag), and
+  when set it **takes precedence over** the individual tuning flags (poller counts, autoscale, slot
+  counts, activity rate limits, versioning). Non-tuning flags (task queue, client connection, logging,
+  metrics, `--worker-err-on-unimplemented`) still apply. Built-in profiles:
+  - `resource-based-default` — the SDK resource-based worker tuner.
+  - `throughput-stress-baseline` — a fixed config for `throughput_stress` runs (workflow cache 50, 8
+    workflow-task slots, 32 activity/local-activity slots, 2 workflow-task pollers, 4 activity pollers).
+- `--task-queue-suffix-index-start` / `--task-queue-suffix-index-end` run the worker across an inclusive
+  range of task queues (`<task-queue>-<start>` … `<task-queue>-<end>`), for multi-task-queue scenarios.
+- `--embedded-server` starts an embedded localhost server (cannot be combined with TLS or a non-default
+  `--server-address`).
+
+```sh
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+    --run-id local-profile-test --worker-profile resource-based-default
+```
+
+## Running a specific SDK version
+
+`--version` accepts a released version (`v1.24.0`) or a local path to an SDK checkout — useful for
+testing unreleased SDKs:
+
+```sh
+go run ./cmd/omes run-scenario-with-worker \
+  --scenario workflow_with_single_noop_activity --language go --version /path/to/go-sdk
+```
+
+## Gotchas
+
+- **A default run is quiet.** Per-iteration progress logs at debug level, so at the default `info` level
+  you'll see a connect line, a long silence, then a completion line. Pass `--log-level debug` to watch
+  iterations, and always sanity-check that work actually ran rather than trusting the absence of errors.
+- **Language names and aliases.** `--language` accepts `go`, `python` (`py`), `java`, `typescript`
+  (`ts`), `dotnet` (`cs`), `ruby` (`rb`). If you pass an unknown value the error message lists the
+  accepted set.
+- **`--option` is stringly-typed.** A malformed value (e.g. an int option set to `abc`) currently fails
+  hard rather than with a friendly message, and an **unknown/misspelled key is silently ignored** (the
+  default is used). Double-check option spelling.
+- **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected at run time.


### PR DESCRIPTION
## What

Split the running/configuring material out of `README.md` into a dedicated `docs/running.md`, and slim the README to point at it.

- **`docs/running.md`** (new) — run commands (`run-scenario-with-worker`, `run-worker`, `run-scenario`, `cleanup-scenario`), load configuration (typed run flags vs per-scenario `--option`), one-scenario-per-run, worker profiles / multi-task-queue, running a specific SDK version, and current gotchas (near-silent default output, `--option` parsing, language aliases).
- **`README.md`** — slimmed to point at `docs/running.md`; drops the duplicated run subsections (also removes the stale `go run ./cmd` typo).

Part of the omes UX documentation pass; content describes current behavior, no code changes.