### PR TITLE
fix - add disable host verification flag support for go worker

### DIFF
--- a/workers/go/harness/client.go
+++ b/workers/go/harness/client.go
@@ -83,7 +83,7 @@ func buildClientConfig(opts clientConfigOptions) (ClientConfig, error) {
 		nop := zap.NewNop()
 		logger = nop.Sugar()
 	}
-	tlsConfig, err := buildTLSConfig(logger, opts)
+	tlsConfig, err := buildTLSConfig(opts)
 	if err != nil {
 		return ClientConfig{}, err
 	}
@@ -101,12 +101,10 @@ func buildClientConfig(opts clientConfigOptions) (ClientConfig, error) {
 	}, nil
 }
 
-func buildTLSConfig(logger *zap.SugaredLogger, opts clientConfigOptions) (*tls.Config, error) {
-	if opts.DisableHostVerification {
-		logger.Warn("disable_host_verification is not supported by the Go harness; ignoring")
-	}
+func buildTLSConfig(opts clientConfigOptions) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
-		ServerName: opts.TLSServerName,
+		InsecureSkipVerify: opts.DisableHostVerification,
+		ServerName:         opts.TLSServerName,
 	}
 	if opts.TLSCertPath != "" {
 		if opts.TLSKeyPath == "" {

--- a/workers/go/harness/project_test.go
+++ b/workers/go/harness/project_test.go
@@ -228,6 +228,7 @@ func TestProjectInitPassesRunMetadataToHandler(t *testing.T) {
 		capturedConfig.Namespace != "default" ||
 		capturedConfig.APIKey != "token" ||
 		capturedConfig.TLS == nil ||
+		!capturedConfig.TLS.InsecureSkipVerify ||
 		capturedConfig.TLS.ServerName != "server.local" ||
 		len(capturedConfig.TLS.Certificates) != 0 {
 		t.Fatalf("unexpected client config: %+v", capturedConfig)


### PR DESCRIPTION
## What was changed
DWISOTT

## Why?
Used in release pipelines

2. How was this tested:
modified existing test

3. Any docs updates needed?
No
