### PR TITLE
docs: clarify that --run-id is not a Temporal workflow Run ID

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -9,8 +9,13 @@ cells inside Temporal's own infra (scaffold / VCR), see the internal runbooks.
 
 ## The commands
 
-omes has three ways to run, plus cleanup. Each takes a **scenario** and a **run-id**; the run-id derives
-the task queue, so a worker and the scenario that drives it must share it.
+omes has three ways to run, plus cleanup. Each takes a **scenario** and a **run-id**.
+
+> **`--run-id` is not a Temporal workflow Run ID.** A Temporal Run ID identifies a single workflow
+> execution; omes's run-id is a label for the entire load run. omes uses it to name the task queue
+> (`omes-<run-id>`) and to prefix the workflow IDs it starts
+> (`w-<run-id>-<execution-id>-<iteration>`). Because the task queue is derived from it, a worker and the
+> scenario driving it **must be given the same run-id**.
 
 ### Run a scenario with a worker (local all-in-one)
 


### PR DESCRIPTION
## Why

`--run-id` collides with a core Temporal term. A Temporal **Run ID** identifies a single workflow execution; omes's run-id is a label for an entire load run, so setting it as global process config reads as non-intuitive to anyone who knows the Temporal concept.

The distinction is already stated — but only in a Go comment:

> `loadgen/scenario.go:113-115` — "Run ID of the current scenario run, used to generate a unique task queue and workflow ID prefix. This is a single value for the whole scenario, and not a Workflow RunId."

No user-facing doc said it. `docs/running.md` and the README described only the mechanics ("derives the task queue"), leaving a reader who never opens the source with no way to learn it. omes also reports a *genuine* Temporal run ID in a failure message (`scenario.go:463`), so both meanings can show up in one tool's output.

## What

Adds a short callout to `docs/running.md` stating that `--run-id` is not a workflow Run ID, and what omes actually derives from it:

- the task queue name — `omes-<run-id>` (`TaskQueueForRun`, `loadgen/scenario.go:330-332`)
- the workflow ID prefix — `w-<run-id>-<execution-id>-<iteration>` (`loadgen/scenario.go:375`)

Docs only; no code changes. Follow-up to #429.