### PR TITLE
loadgen: make option declarations the source of truth

### DIFF
--- a/cmd/omes/list_scenarios.go
+++ b/cmd/omes/list_scenarios.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/temporalio/omes/loadgen"
@@ -13,30 +14,9 @@ func listScenariosCmd() *cobra.Command {
 		Use:   "list-scenarios",
 		Short: "List Scenarios",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Collect scenario descriptions, sort, display
 			var descs []string
 			for name, scen := range loadgen.GetScenarios() {
-				var defaultConfigDesc string
-				executor := scen.ExecutorFn()
-				if iface, _ := executor.(loadgen.HasDefaultConfiguration); iface != nil {
-					config := iface.GetDefaultConfiguration()
-					config.ApplyDefaults()
-					defaultConfigDesc = "\n    Default configuration:"
-					if config.Iterations != 0 {
-						defaultConfigDesc += fmt.Sprintf("\n        Iterations: %v", config.Iterations)
-					}
-					if config.Duration != 0 {
-						defaultConfigDesc += fmt.Sprintf("\n        Duration: %v", config.Duration)
-					}
-					if config.MaxConcurrent != 0 {
-						defaultConfigDesc += fmt.Sprintf("\n        Max concurrent: %v", config.MaxConcurrent)
-					}
-					if config.Timeout != 0 {
-						defaultConfigDesc += fmt.Sprintf("\n        Timeout: %v", config.Timeout)
-					}
-				}
-				descs = append(descs, fmt.Sprintf("Scenario: %v\n    Description: %v%v\n",
-					name, scen.Description, defaultConfigDesc))
+				descs = append(descs, describeScenario(name, scen))
 			}
 			sort.Strings(descs)
 			for _, desc := range descs {
@@ -44,4 +24,45 @@ func listScenariosCmd() *cobra.Command {
 			}
 		},
 	}
+}
+
+func describeScenario(name string, scen *loadgen.Scenario) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Scenario: %v\n    Description: %v\n", name, scen.Description)
+
+	if config, ok := scen.GetDefaultConfiguration(); ok {
+		config.ApplyDefaults()
+		b.WriteString("    Default configuration:\n")
+		if config.Iterations != 0 {
+			fmt.Fprintf(&b, "        Iterations: %v\n", config.Iterations)
+		}
+		if config.Duration != 0 {
+			fmt.Fprintf(&b, "        Duration: %v\n", config.Duration)
+		}
+		if config.MaxConcurrent != 0 {
+			fmt.Fprintf(&b, "        Max concurrent: %v\n", config.MaxConcurrent)
+		}
+		if config.Timeout != 0 {
+			fmt.Fprintf(&b, "        Timeout: %v\n", config.Timeout)
+		}
+	}
+
+	if opts := scen.DeclaredOptions(); len(opts) > 0 {
+		b.WriteString("    Options (set with --option <name>=<value>):\n")
+		for _, o := range opts {
+			fmt.Fprintf(&b, "        %s (%s)", o.Name, o.Type)
+			switch {
+			case o.Required:
+				b.WriteString(" [required]")
+			case o.Default != "":
+				fmt.Fprintf(&b, " [default: %s]", o.Default)
+			}
+			if o.Usage != "" {
+				fmt.Fprintf(&b, "\n            %s", o.Usage)
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
 }

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -139,7 +139,6 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	if resolveErr != nil {
 		return &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: resolveErr}
 	}
-	scenarioOptions = resolvedOptions
 
 	metrics := r.metricsOptions.MustCreateMetrics(ctx, r.logger)
 	defer metrics.Shutdown(ctx, r.logger, r.scenario.Scenario, r.scenario.RunID, r.scenario.RunFamily)
@@ -189,9 +188,9 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 			DoNotRegisterSearchAttributes: r.doNotRegisterSearchAttributes,
 			IgnoreAlreadyStarted:          r.ignoreAlreadyStarted,
 		},
-		ScenarioOptions: scenarioOptions,
-		Namespace:       r.clientOptions.Namespace,
-		RootPath:        repoDir,
+		Options:   resolvedOptions,
+		Namespace: r.clientOptions.Namespace,
+		RootPath:  repoDir,
 		ExportOptions: loadgen.ExportOptions{
 			ExportHistoriesDir:    r.exportHistoriesDir,
 			ExportHistoriesFilter: r.exportHistoriesFilter,

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -27,6 +28,13 @@ func runScenarioCmd() *cobra.Command {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
 			if err := r.run(ctx); err != nil {
+				// A rejected --option is a usage error. Print it plainly instead
+				// of as a fatal-level stack trace, which reads as a crash.
+				var invalidOptions *loadgen.InvalidOptionsError
+				if errors.As(err, &invalidOptions) {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
 				r.logger.Fatal(err)
 			}
 		},
@@ -124,6 +132,14 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 		}
 		scenarioOptions[key] = value
 	}
+
+	// Validate before dialing, so a bad option fails immediately rather than
+	// after a connection attempt.
+	resolvedOptions, resolveErr := scenario.ResolveOptions(scenarioOptions)
+	if resolveErr != nil {
+		return &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: resolveErr}
+	}
+	scenarioOptions = resolvedOptions
 
 	metrics := r.metricsOptions.MustCreateMetrics(ctx, r.logger)
 	defer metrics.Shutdown(ctx, r.logger, r.scenario.Scenario, r.scenario.RunID, r.scenario.RunFamily)

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -136,8 +136,8 @@ and attempts) and use the `*loadgen.Run` helpers — `DefaultStartWorkflowOption
 `ExecuteKitchenSinkWorkflow` — rather than re-deriving IDs and task queues yourself.
 
 Optional interfaces an executor may implement: `Configurable` (a `Configure` hook for validating options
-up front), `Resumable` (`Snapshot`/`LoadState`), and `HasDefaultConfiguration` (declare the scenario's
-default iterations/concurrency).
+up front) and `Resumable` (`Snapshot`/`LoadState`). To declare default iterations/concurrency, prefer the
+scenario's `DefaultConfiguration` field over the older `HasDefaultConfiguration` executor interface.
 
 ## Exposing options
 
@@ -146,28 +146,72 @@ Scenario configuration arrives through **two separate channels**, and knowing wh
 1. **Built-in run flags** — iterations, duration, concurrency, rate, attempts, timeout. These are
    framework-level and apply to every scenario, so you neither declare nor read them; see
    [running.md](./running.md#configuring-the-load) for the list.
-2. **Your own options** — arbitrary `--option key=value` pairs, read from `ScenarioInfo`:
+2. **Your own options** — `--option key=value` pairs that you **declare** on the scenario.
+
+### Declare them
+
+Declare options with the same typed registrars used for omes's own CLI flags — an `OptionSet` embeds a
+`pflag.FlagSet`, so `Int`, `Duration`, `Bool`, `Float64`, `String` and the rest are all available, and
+pflag does the parsing and type checking:
+
+```go
+loadgen.MustRegisterScenario(loadgen.Scenario{
+	Description: "Each iteration executes a single workflow with child workflows and/or activities.",
+	Options: func(o *loadgen.OptionSet) {
+		o.Int("children-per-workflow", 30, "Number of child workflows started per iteration.")
+		o.Duration("sleep-time", time.Second, "How long each sleep activity sleeps.")
+
+		o.Int("task-queue-count", 0, "Number of task queues to spread iterations across.")
+		o.MarkRequired("task-queue-count")
+	},
+	ExecutorFn: /* ... */,
+})
+```
+
+Declaring buys you three things:
+
+- **Unknown names are rejected.** A user who types `--option activites-per-workflow=50` gets an error
+  listing what the scenario actually accepts, instead of a silently-ignored option and a run at the default.
+- **Malformed values are rejected before the run starts**, with a message naming the option and the
+  expected type — and every problem is reported at once, not one per attempt.
+- **`list-scenarios` shows your options**, their types, defaults, and descriptions, so users can discover
+  them without reading your source.
+
+If your scenario uses a shared executor that reads options of its own, call that executor's declaration
+helper from yours — for example `loadgen.DeclareFuzzExecutorOptions(o)`.
+
+### Read them
 
 ```go
 children := info.ScenarioOptionInt("children-per-workflow", 30)
 sleep := info.ScenarioOptionDuration("sleep-duration", 5*time.Second)
 ```
 
-Accessors exist for int, float, bool, duration, and string, each taking the default inline.
+Accessors exist for int, float, bool, duration, and string. Note that **declared defaults are used for
+validation and display, not injected into the run** — a scenario reads its own default through the
+accessor. That is deliberate: some scenarios treat an option's *absence* as meaningful, and injecting
+defaults would silently change what they do. Keep the accessor's inline default and the declared default
+the same, since the declared one is what `list-scenarios` advertises.
+
+### Declaring a default run configuration
+
+If your scenario only makes sense at a particular scale, declare it and `list-scenarios` will show that
+too:
+
+```go
+DefaultConfiguration: &loadgen.RunConfiguration{Iterations: 100, MaxConcurrent: 5},
+```
 
 ### Conventions for options
 
-- **Document every option in the scenario's `Description`, with its default.** That string is the only
-  thing `list-scenarios` shows a user, so an undocumented option is an invisible one.
-- **Validate required options explicitly** and return a clear error naming the option. If your executor
-  implements `Configurable`, validate in `Configure` so the run fails immediately rather than mid-load.
+- **Declare every option.** A scenario that declares none keeps the legacy behavior — any option name is
+  accepted and nothing is validated — so an undeclared option is both unvalidated and undiscoverable.
+- **Give each option a usage string.** It's what a user sees in `list-scenarios`.
+- **Use `MarkRequired` instead of hand-rolling a check** in `PrepareTestInput` or `Configure`; the
+  framework fails the run before any load starts.
+- **Don't restate options in the `Description`.** `list-scenarios` renders the declarations, so listing
+  names and defaults in prose only creates something to drift.
 - **Prefer the typed accessors** over reading the raw map, so values parse consistently.
-
-> **Current sharp edges to be aware of** (they affect how carefully you document):
-> the typed accessors **panic** on a malformed value rather than returning a friendly error, and an
-> **unknown or misspelled option key is silently ignored** — the default is used and nothing warns. A
-> user who typos your option name gets a quiet, wrong-shaped run, so exact option names in the
-> description matter.
 
 ## Testing your scenario
 
@@ -187,6 +231,6 @@ against a real cluster they generally have to be pre-registered.
 1. snake_case filenames — the filename _is_ the scenario name.
 2. Prefer `KitchenSinkExecutor`; go custom only when you must, and reuse `GenericExecutor` and
    `*loadgen.Run` when you do.
-3. Document every option and its default in the `Description`.
-4. Validate required options up front, with errors that name the option.
+3. Declare every option, with a type, a default or `Required`, and a description.
+4. Declare a `DefaultConfiguration` if the scenario assumes a particular scale.
 5. Put helpers other scenario authors would want in the `loadgen` package, not in your scenario file.

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -183,15 +183,25 @@ helper from yours — for example `loadgen.DeclareFuzzExecutorOptions(o)`.
 ### Read them
 
 ```go
-children := info.ScenarioOptionInt("children-per-workflow", 30)
-sleep := info.ScenarioOptionDuration("sleep-duration", 5*time.Second)
+children := info.OptionInt("children-per-workflow")
+sleep := info.OptionDuration("sleep-time")
 ```
 
-Accessors exist for int, float, bool, duration, and string. Note that **declared defaults are used for
-validation and display, not injected into the run** — a scenario reads its own default through the
-accessor. That is deliberate: some scenarios treat an option's *absence* as meaningful, and injecting
-defaults would silently change what they do. Keep the accessor's inline default and the declared default
-the same, since the declared one is what `list-scenarios` advertises.
+Accessors exist for int, float64, bool, duration, and string. They take **no default** — the declaration
+is the only place a default lives, so an option the user didn't supply reads back as whatever you
+declared. Values are already validated, so these can't fail on user input; reading an option you didn't
+declare is a bug in the scenario and reads as the zero value.
+
+If an option's real default can't be written as a constant — say it derives from the run's `--duration` —
+declare a sentinel, say so in the usage string, and resolve it in code:
+
+```go
+o.Duration(IterTimeoutFlag, 0, "Timeout for internal iterations. 0 means auto: the run duration plus a minute.")
+...
+if config.InternalIterTimeout == 0 {
+    config.InternalIterTimeout = cmp.Or(info.Configuration.Duration+time.Minute, time.Minute)
+}
+```
 
 ### Declaring a default run configuration
 
@@ -204,14 +214,13 @@ DefaultConfiguration: &loadgen.RunConfiguration{Iterations: 100, MaxConcurrent: 
 
 ### Conventions for options
 
-- **Declare every option.** A scenario that declares none keeps the legacy behavior — any option name is
-  accepted and nothing is validated — so an undeclared option is both unvalidated and undiscoverable.
+- **Declare every option you read.** A scenario accepts exactly what it declares, and the accessors read
+  from the declarations — so an undeclared option can't be passed and can't be read.
 - **Give each option a usage string.** It's what a user sees in `list-scenarios`.
 - **Use `MarkRequired` instead of hand-rolling a check** in `PrepareTestInput` or `Configure`; the
   framework fails the run before any load starts.
 - **Don't restate options in the `Description`.** `list-scenarios` renders the declarations, so listing
   names and defaults in prose only creates something to drift.
-- **Prefer the typed accessors** over reading the raw map, so values parse consistently.
 
 ## Testing your scenario
 
@@ -231,6 +240,6 @@ against a real cluster they generally have to be pre-registered.
 1. snake_case filenames — the filename _is_ the scenario name.
 2. Prefer `KitchenSinkExecutor`; go custom only when you must, and reuse `GenericExecutor` and
    `*loadgen.Run` when you do.
-3. Declare every option, with a type, a default or `Required`, and a description.
+3. Declare every option you read, with a type, a default or `MarkRequired`, and a usage string.
 4. Declare a `DefaultConfiguration` if the scenario assumes a particular scale.
 5. Put helpers other scenario authors would want in the `loadgen` package, not in your scenario file.

--- a/docs/running.md
+++ b/docs/running.md
@@ -122,7 +122,8 @@ go run ./cmd/omes run-scenario-with-worker \
 - **Language names and aliases.** `--language` accepts `go`, `python` (`py`), `java`, `typescript`
   (`ts`), `dotnet` (`cs`), `ruby` (`rb`). If you pass an unknown value the error message lists the
   accepted set.
-- **`--option` is stringly-typed.** A malformed value (e.g. an int option set to `abc`) currently fails
-  hard rather than with a friendly message, and an **unknown/misspelled key is silently ignored** (the
-  default is used). Double-check option spelling.
+- **Option validation depends on the scenario declaring its options.** When a scenario declares them
+  (most do), an unknown name or a malformed value is rejected before the run starts, and
+  `list-scenarios` shows you what it accepts. A scenario that declares none accepts any option name and
+  parses values on first read, so a typo there is silently ignored and the default is used.
 - **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected at run time.

--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -33,7 +33,7 @@ type FuzzExecutor struct {
 // Scenarios using it should call this from their own Options declaration so the
 // options validate and appear in `list-scenarios`.
 func DeclareFuzzExecutorOptions(o *OptionSet) {
-	o.String("nexus-endpoint", "", "Existing Nexus endpoint to use instead of creating one for the run.")
+	o.String("nexus-endpoint", "", "Nexus endpoint to use. Empty creates one for this run.")
 	o.String("kitchen-sink-gen", "", "Name of, or absolute path to, the kitchen-sink-gen executable.")
 }
 

--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -29,6 +29,14 @@ type FuzzExecutor struct {
 	DefaultConfiguration RunConfiguration
 }
 
+// DeclareFuzzExecutorOptions declares the options [FuzzExecutor] itself reads.
+// Scenarios using it should call this from their own Options declaration so the
+// options validate and appear in `list-scenarios`.
+func DeclareFuzzExecutorOptions(o *OptionSet) {
+	o.String("nexus-endpoint", "", "Existing Nexus endpoint to use instead of creating one for the run.")
+	o.String("kitchen-sink-gen", "", "Name of, or absolute path to, the kitchen-sink-gen executable.")
+}
+
 func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 	if k.InitInputs == nil {
 		return fmt.Errorf("InitInputs must be specified")

--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -43,7 +43,7 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 	}
 
 	// Use a user-provided nexus endpoint, or auto-create one for this run
-	endpointName := info.ScenarioOptions["nexus-endpoint"]
+	endpointName := info.OptionString("nexus-endpoint")
 	if endpointName == "" {
 		var err error
 		endpointName, err = ensureNexusEndpoint(ctx, info.Client, info.Namespace, info.RunID)
@@ -68,8 +68,7 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 		var cmd *exec.Cmd
 		// The value of the 'kitchen-sink-gen' option is the name of or absolute
 		// path to the executable.
-		executable, ok := info.ScenarioOptions["kitchen-sink-gen"]
-		if ok && executable != "" {
+		if executable := info.OptionString("kitchen-sink-gen"); executable != "" {
 			cmd = exec.CommandContext(ctx, executable, fileOrArgs.Args...)
 		} else {
 			projDir := filepath.Join(info.RootPath, "loadgen", "kitchen-sink-gen", "Cargo.toml")

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -99,31 +99,32 @@ func (e *InvalidOptionsError) Error() string {
 func (e *InvalidOptionsError) Unwrap() error { return e.Err }
 
 // ResolveOptions validates user-supplied options against the scenario's
-// declarations and returns the values the run should use.
+// declarations and returns the set the run should read from.
 //
 // Every problem is reported at once rather than one per run attempt: unknown
 // option names, values that do not parse as their declared type, and missing
-// required options.
+// required options. A scenario that declares no options accepts none.
 //
-// Declared defaults describe and validate; they are deliberately not written
-// into the returned map. Scenarios read their own defaults through the
-// ScenarioOption* accessors, and some treat an option's *absence* as meaningful
-// — injecting defaults here would silently change what those scenarios do.
-//
-// A scenario that declares no options is passed through untouched, which keeps
-// scenarios outside this repository working unchanged.
-func (s *Scenario) ResolveOptions(provided map[string]string) (map[string]string, error) {
+// The returned set holds each option's declared default, overwritten by whatever
+// the user supplied — so the declaration is the single source of truth for both
+// the value and the default.
+func (s *Scenario) ResolveOptions(provided map[string]string) (*OptionSet, error) {
 	set := s.optionSet()
 	if set == nil {
-		return provided, nil
+		set = newOptionSet("")
 	}
 
 	var errs []error
 	for _, name := range sortedKeys(provided) {
 		flag := set.Lookup(name)
 		if flag == nil {
-			errs = append(errs, fmt.Errorf("unknown option %q; this scenario accepts: %s",
-				name, strings.Join(set.names(), ", ")))
+			accepted := set.names()
+			if len(accepted) == 0 {
+				errs = append(errs, fmt.Errorf("unknown option %q; this scenario accepts no options", name))
+			} else {
+				errs = append(errs, fmt.Errorf("unknown option %q; this scenario accepts: %s",
+					name, strings.Join(accepted, ", ")))
+			}
 			continue
 		}
 		// pflag does the type checking, but phrases its error for a `--flag`;
@@ -148,14 +149,29 @@ func (s *Scenario) ResolveOptions(provided map[string]string) (map[string]string
 	if len(errs) > 0 {
 		return nil, errors.Join(errs...)
 	}
+	return set, nil
+}
 
-	resolved := make(map[string]string, len(provided))
-	set.VisitAll(func(f *pflag.Flag) {
-		if f.Changed {
-			resolved[f.Name] = f.Value.String()
-		}
-	})
-	return resolved, nil
+// MustResolveOptions is [Scenario.ResolveOptions] for tests and other callers that
+// treat a bad option as a programming error. It panics instead of returning one.
+func (s *Scenario) MustResolveOptions(provided map[string]string) *OptionSet {
+	set, err := s.ResolveOptions(provided)
+	if err != nil {
+		panic(err)
+	}
+	return set
+}
+
+// MustResolveScenarioOptions resolves options for a registered scenario by name,
+// for building a [ScenarioInfo] in tests. Resolving through the real declarations
+// means a test that misspells an option fails rather than silently testing a
+// default.
+func MustResolveScenarioOptions(scenarioName string, provided map[string]string) *OptionSet {
+	s := GetScenario(scenarioName)
+	if s == nil {
+		panic(fmt.Errorf("no registered scenario named %q", scenarioName))
+	}
+	return s.MustResolveOptions(provided)
 }
 
 func sortedRequired(m map[string]struct{}) []string {

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -1,0 +1,177 @@
+package loadgen
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// OptionSet declares the options a scenario accepts via `--option <name>=<value>`.
+// It embeds a [pflag.FlagSet], so options are declared with the same typed
+// registrars as omes's own CLI flags and pflag does the parsing, type checking,
+// and default rendering.
+type OptionSet struct {
+	*pflag.FlagSet
+	required map[string]struct{}
+}
+
+// MarkRequired fails any run that does not explicitly supply the named options.
+func (o *OptionSet) MarkRequired(names ...string) {
+	for _, name := range names {
+		o.required[name] = struct{}{}
+	}
+}
+
+func newOptionSet(name string) *OptionSet {
+	fs := pflag.NewFlagSet(name+" options", pflag.ContinueOnError)
+	// Options are surfaced by `list-scenarios` and validation errors, never by
+	// pflag printing its own usage.
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	return &OptionSet{FlagSet: fs, required: make(map[string]struct{})}
+}
+
+func (o *OptionSet) names() []string {
+	var names []string
+	o.VisitAll(func(f *pflag.Flag) { names = append(names, f.Name) })
+	sort.Strings(names)
+	return names
+}
+
+// DeclaredOption describes one declared option for display.
+type DeclaredOption struct {
+	Name     string
+	Type     string
+	Default  string
+	Usage    string
+	Required bool
+}
+
+// DeclaredOptions returns the scenario's declared options, sorted by name. It is
+// empty for a scenario that declares none.
+func (s *Scenario) DeclaredOptions() []DeclaredOption {
+	set := s.optionSet()
+	if set == nil {
+		return nil
+	}
+	var out []DeclaredOption
+	set.VisitAll(func(f *pflag.Flag) {
+		_, required := set.required[f.Name]
+		out = append(out, DeclaredOption{
+			Name:     f.Name,
+			Type:     f.Value.Type(),
+			Default:  f.DefValue,
+			Usage:    f.Usage,
+			Required: required,
+		})
+	})
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// optionSet builds a fresh set from the scenario's declaration, or nil if it
+// declares no options.
+func (s *Scenario) optionSet() *OptionSet {
+	if s.Options == nil {
+		return nil
+	}
+	set := newOptionSet(s.Description)
+	s.Options(set)
+	return set
+}
+
+// InvalidOptionsError reports `--option` values a scenario rejects. It exists so
+// callers can present a bad option as the usage error it is, rather than as a
+// crash.
+type InvalidOptionsError struct {
+	ScenarioName string
+	Err          error
+}
+
+func (e *InvalidOptionsError) Error() string {
+	return fmt.Sprintf("invalid --option values for scenario %q:\n%v", e.ScenarioName, e.Err)
+}
+
+func (e *InvalidOptionsError) Unwrap() error { return e.Err }
+
+// ResolveOptions validates user-supplied options against the scenario's
+// declarations and returns the values the run should use.
+//
+// Every problem is reported at once rather than one per run attempt: unknown
+// option names, values that do not parse as their declared type, and missing
+// required options.
+//
+// Declared defaults describe and validate; they are deliberately not written
+// into the returned map. Scenarios read their own defaults through the
+// ScenarioOption* accessors, and some treat an option's *absence* as meaningful
+// — injecting defaults here would silently change what those scenarios do.
+//
+// A scenario that declares no options is passed through untouched, which keeps
+// scenarios outside this repository working unchanged.
+func (s *Scenario) ResolveOptions(provided map[string]string) (map[string]string, error) {
+	set := s.optionSet()
+	if set == nil {
+		return provided, nil
+	}
+
+	var errs []error
+	for _, name := range sortedKeys(provided) {
+		flag := set.Lookup(name)
+		if flag == nil {
+			errs = append(errs, fmt.Errorf("unknown option %q; this scenario accepts: %s",
+				name, strings.Join(set.names(), ", ")))
+			continue
+		}
+		// pflag does the type checking, but phrases its error for a `--flag`;
+		// users type `--option name=value`, so report it in those terms.
+		if err := set.Set(name, provided[name]); err != nil {
+			errs = append(errs, fmt.Errorf("option %q expects type %s, got %q",
+				name, flag.Value.Type(), provided[name]))
+		}
+	}
+
+	for _, name := range sortedRequired(set.required) {
+		flag := set.Lookup(name)
+		if flag == nil {
+			errs = append(errs, fmt.Errorf("option %q is marked required but not declared", name))
+			continue
+		}
+		if !flag.Changed {
+			errs = append(errs, fmt.Errorf("option %q is required", name))
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	resolved := make(map[string]string, len(provided))
+	set.VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			resolved[f.Name] = f.Value.String()
+		}
+	})
+	return resolved, nil
+}
+
+func sortedRequired(m map[string]struct{}) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/loadgen/options_test.go
+++ b/loadgen/options_test.go
@@ -1,0 +1,234 @@
+package loadgen
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveOptionsUndeclaredPassesThrough(t *testing.T) {
+	// Scenarios that declare nothing keep the legacy behavior: anything goes.
+	// This is what keeps scenarios outside this repo working.
+	s := &Scenario{}
+	got, err := s.ResolveOptions(map[string]string{"anything": "goes", "even": "nonsense"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 2 || got["anything"] != "goes" {
+		t.Fatalf("expected provided options untouched, got %v", got)
+	}
+}
+
+func TestResolveOptionsKeepsProvidedValues(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("count", 30, "")
+		o.Duration("wait", time.Second, "")
+	}}
+	got, err := s.ResolveOptions(map[string]string{"count": "7", "wait": "2m"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got["count"] != "7" {
+		t.Errorf("count: want 7, got %q", got["count"])
+	}
+	if got["wait"] != "2m0s" {
+		t.Errorf("wait: want 2m0s, got %q", got["wait"])
+	}
+}
+
+func TestResolveOptionsDoesNotInjectDefaults(t *testing.T) {
+	// Declared defaults describe and validate; they must not be written into the
+	// map. Some scenarios treat an option's absence as meaningful (a deprecated
+	// alias feeding another option's default, or a presence-only flag), and
+	// injecting defaults would silently change what those scenarios do.
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("count", 30, "")
+		o.Bool("enabled", false, "")
+		o.String("label", "", "")
+	}}
+	got, err := s.ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no values for unsupplied options, got %v", got)
+	}
+}
+
+func TestResolveOptionsRejectsUnknownName(t *testing.T) {
+	// The typo case that previously ran happily with a silently-ignored option.
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("activities-per-workflow", 30, "")
+		o.Int("children-per-workflow", 30, "")
+	}}
+	_, err := s.ResolveOptions(map[string]string{"activites-per-workflow": "50"})
+	if err == nil {
+		t.Fatal("expected an error for a misspelled option")
+	}
+	if !strings.Contains(err.Error(), "activites-per-workflow") {
+		t.Errorf("error should name the offending key, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "activities-per-workflow") {
+		t.Errorf("error should list accepted options, got: %v", err)
+	}
+}
+
+func TestResolveOptionsRejectsMalformedValues(t *testing.T) {
+	for _, tc := range []struct {
+		typ     string
+		declare func(*OptionSet)
+		value   string
+	}{
+		{"int", func(o *OptionSet) { o.Int("n", 0, "") }, "abc"},
+		{"float64", func(o *OptionSet) { o.Float64("n", 0, "") }, "abc"},
+		{"bool", func(o *OptionSet) { o.Bool("n", false, "") }, "maybe"},
+		{"duration", func(o *OptionSet) { o.Duration("n", 0, "") }, "5 fortnights"},
+	} {
+		t.Run(tc.typ, func(t *testing.T) {
+			s := &Scenario{Options: tc.declare}
+			_, err := s.ResolveOptions(map[string]string{"n": tc.value})
+			if err == nil {
+				t.Fatalf("expected an error for %s value %q", tc.typ, tc.value)
+			}
+			if !strings.Contains(err.Error(), tc.value) {
+				t.Errorf("error should quote the bad value, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.typ) {
+				t.Errorf("error should name the expected type, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveOptionsAcceptsBoolForms(t *testing.T) {
+	// pflag accepts all the strconv.ParseBool forms, not just the literal "true".
+	s := &Scenario{Options: func(o *OptionSet) { o.Bool("on", false, "") }}
+	for _, v := range []string{"true", "false", "1", "0", "TRUE", "False"} {
+		if _, err := s.ResolveOptions(map[string]string{"on": v}); err != nil {
+			t.Errorf("expected %q to be accepted, got %v", v, err)
+		}
+	}
+}
+
+func TestResolveOptionsRequired(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("task-queue-count", 0, "")
+		o.MarkRequired("task-queue-count")
+	}}
+
+	_, err := s.ResolveOptions(nil)
+	if err == nil {
+		t.Fatal("expected an error when a required option is missing")
+	}
+	if !strings.Contains(err.Error(), "task-queue-count") || !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should say which option is required, got: %v", err)
+	}
+
+	if _, err := s.ResolveOptions(map[string]string{"task-queue-count": "4"}); err != nil {
+		t.Errorf("expected supplying the required option to succeed, got %v", err)
+	}
+}
+
+func TestResolveOptionsReportsEveryProblemAtOnce(t *testing.T) {
+	// The point of validating up front: one run tells you everything that's wrong.
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("count", 0, "")
+		o.Int("needed", 0, "")
+		o.MarkRequired("needed")
+	}}
+	_, err := s.ResolveOptions(map[string]string{"count": "abc", "bogus": "1"})
+	if err == nil {
+		t.Fatal("expected errors")
+	}
+	msg := err.Error()
+	for _, want := range []string{"count", "bogus", "needed"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected all problems reported together, %q missing from: %v", want, msg)
+		}
+	}
+}
+
+func TestDeclaredOptionsDescribesForDisplay(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Duration("wait", 5*time.Second, "How long to wait.")
+		o.Int("needed", 0, "Must be supplied.")
+		o.MarkRequired("needed")
+	}}
+	opts := s.DeclaredOptions()
+	if len(opts) != 2 {
+		t.Fatalf("want 2 declared options, got %d", len(opts))
+	}
+	// Sorted by name: needed, wait.
+	if opts[0].Name != "needed" || !opts[0].Required {
+		t.Errorf("want required option first, got %+v", opts[0])
+	}
+	if opts[1].Name != "wait" || opts[1].Type != "duration" || opts[1].Default != "5s" {
+		t.Errorf("want wait/duration/5s, got %+v", opts[1])
+	}
+	if opts[1].Usage != "How long to wait." {
+		t.Errorf("usage not carried through, got %q", opts[1].Usage)
+	}
+}
+
+func TestDeclaredOptionsEmptyWhenUndeclared(t *testing.T) {
+	if got := (&Scenario{}).DeclaredOptions(); len(got) != 0 {
+		t.Errorf("expected no declared options, got %v", got)
+	}
+}
+
+func TestScenarioOptionAccessorsDoNotPanic(t *testing.T) {
+	// Undeclared options are still parsed lazily; a bad value must fall back
+	// rather than take the process down.
+	info := &ScenarioInfo{ScenarioOptions: map[string]string{
+		"i": "abc", "f": "abc", "b": "maybe", "d": "abc",
+	}}
+	if got := info.ScenarioOptionInt("i", 7); got != 7 {
+		t.Errorf("int: want fallback 7, got %v", got)
+	}
+	if got := info.ScenarioOptionFloat("f", 1.5); got != 1.5 {
+		t.Errorf("float: want fallback 1.5, got %v", got)
+	}
+	if got := info.ScenarioOptionBool("b", true); !got {
+		t.Errorf("bool: want fallback true, got %v", got)
+	}
+	if got := info.ScenarioOptionDuration("d", time.Second); got != time.Second {
+		t.Errorf("duration: want fallback 1s, got %v", got)
+	}
+}
+
+func TestScenarioOptionBoolAcceptsParseBoolForms(t *testing.T) {
+	info := &ScenarioInfo{ScenarioOptions: map[string]string{"on": "1", "off": "0"}}
+	if !info.ScenarioOptionBool("on", false) {
+		t.Error(`expected "1" to read as true`)
+	}
+	if info.ScenarioOptionBool("off", true) {
+		t.Error(`expected "0" to read as false`)
+	}
+}
+
+func TestGetDefaultConfigurationPrefersScenarioDeclaration(t *testing.T) {
+	want := RunConfiguration{Iterations: 42}
+	s := &Scenario{DefaultConfiguration: &want, ExecutorFn: func() Executor { return nil }}
+	got, ok := s.GetDefaultConfiguration()
+	if !ok || got.Iterations != 42 {
+		t.Fatalf("want declared configuration, got %+v (ok=%v)", got, ok)
+	}
+
+	// No declaration, and an executor that doesn't implement the interface.
+	s = &Scenario{ExecutorFn: func() Executor { return ExecutorFunc(nil) }}
+	if _, ok := s.GetDefaultConfiguration(); ok {
+		t.Error("expected no default configuration to be reported")
+	}
+}
+
+func TestInvalidOptionsErrorNamesScenarioAndUnwraps(t *testing.T) {
+	inner := errors.New("boom")
+	err := &InvalidOptionsError{ScenarioName: "my_scenario", Err: inner}
+	if !strings.Contains(err.Error(), "my_scenario") || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("want scenario name and cause in message, got %q", err.Error())
+	}
+	if !errors.Is(err, inner) {
+		t.Error("want the wrapped error to be unwrappable")
+	}
+}

--- a/loadgen/options_test.go
+++ b/loadgen/options_test.go
@@ -7,16 +7,14 @@ import (
 	"time"
 )
 
-func TestResolveOptionsUndeclaredPassesThrough(t *testing.T) {
-	// Scenarios that declare nothing keep the legacy behavior: anything goes.
-	// This is what keeps scenarios outside this repo working.
+func TestResolveOptionsRejectsWhenNoneDeclared(t *testing.T) {
 	s := &Scenario{}
-	got, err := s.ResolveOptions(map[string]string{"anything": "goes", "even": "nonsense"})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	_, err := s.ResolveOptions(map[string]string{"anything": "goes"})
+	if err == nil {
+		t.Fatal("expected an error: a scenario declaring no options accepts none")
 	}
-	if len(got) != 2 || got["anything"] != "goes" {
-		t.Fatalf("expected provided options untouched, got %v", got)
+	if !strings.Contains(err.Error(), "accepts no options") {
+		t.Errorf("error should say the scenario accepts no options, got: %v", err)
 	}
 }
 
@@ -25,34 +23,48 @@ func TestResolveOptionsKeepsProvidedValues(t *testing.T) {
 		o.Int("count", 30, "")
 		o.Duration("wait", time.Second, "")
 	}}
-	got, err := s.ResolveOptions(map[string]string{"count": "7", "wait": "2m"})
+	set, err := s.ResolveOptions(map[string]string{"count": "7", "wait": "2m"})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got["count"] != "7" {
-		t.Errorf("count: want 7, got %q", got["count"])
+	info := &ScenarioInfo{Options: set}
+	if got := info.OptionInt("count"); got != 7 {
+		t.Errorf("count: want 7, got %v", got)
 	}
-	if got["wait"] != "2m0s" {
-		t.Errorf("wait: want 2m0s, got %q", got["wait"])
+	if got := info.OptionDuration("wait"); got != 2*time.Minute {
+		t.Errorf("wait: want 2m, got %v", got)
 	}
 }
 
-func TestResolveOptionsDoesNotInjectDefaults(t *testing.T) {
-	// Declared defaults describe and validate; they must not be written into the
-	// map. Some scenarios treat an option's absence as meaningful (a deprecated
-	// alias feeding another option's default, or a presence-only flag), and
-	// injecting defaults would silently change what those scenarios do.
+func TestOptionAccessorsReturnDeclaredDefaults(t *testing.T) {
+	// The declaration is the only place a default lives, so an unsupplied option
+	// reads back as whatever was declared.
 	s := &Scenario{Options: func(o *OptionSet) {
 		o.Int("count", 30, "")
-		o.Bool("enabled", false, "")
-		o.String("label", "", "")
+		o.Duration("wait", 5*time.Second, "")
+		o.Bool("enabled", true, "")
+		o.Float64("ratio", 1.5, "")
+		o.String("label", "hello", "")
 	}}
-	got, err := s.ResolveOptions(nil)
+	set, err := s.ResolveOptions(nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(got) != 0 {
-		t.Errorf("expected no values for unsupplied options, got %v", got)
+	info := &ScenarioInfo{Options: set}
+	if got := info.OptionInt("count"); got != 30 {
+		t.Errorf("count: want 30, got %v", got)
+	}
+	if got := info.OptionDuration("wait"); got != 5*time.Second {
+		t.Errorf("wait: want 5s, got %v", got)
+	}
+	if got := info.OptionBool("enabled"); !got {
+		t.Errorf("enabled: want true, got %v", got)
+	}
+	if got := info.OptionFloat64("ratio"); got != 1.5 {
+		t.Errorf("ratio: want 1.5, got %v", got)
+	}
+	if got := info.OptionString("label"); got != "hello" {
+		t.Errorf("label: want hello, got %q", got)
 	}
 }
 
@@ -177,33 +189,18 @@ func TestDeclaredOptionsEmptyWhenUndeclared(t *testing.T) {
 	}
 }
 
-func TestScenarioOptionAccessorsDoNotPanic(t *testing.T) {
-	// Undeclared options are still parsed lazily; a bad value must fall back
-	// rather than take the process down.
-	info := &ScenarioInfo{ScenarioOptions: map[string]string{
-		"i": "abc", "f": "abc", "b": "maybe", "d": "abc",
-	}}
-	if got := info.ScenarioOptionInt("i", 7); got != 7 {
-		t.Errorf("int: want fallback 7, got %v", got)
+func TestOptionAccessorsTolerateUndeclaredReads(t *testing.T) {
+	// Reading an option the scenario never declared is a bug in the scenario. It
+	// must report rather than take the process down mid-run.
+	info := &ScenarioInfo{ScenarioName: "buggy"}
+	if got := info.OptionInt("nope"); got != 0 {
+		t.Errorf("int: want zero value, got %v", got)
 	}
-	if got := info.ScenarioOptionFloat("f", 1.5); got != 1.5 {
-		t.Errorf("float: want fallback 1.5, got %v", got)
+	if got := info.OptionString("nope"); got != "" {
+		t.Errorf("string: want empty, got %q", got)
 	}
-	if got := info.ScenarioOptionBool("b", true); !got {
-		t.Errorf("bool: want fallback true, got %v", got)
-	}
-	if got := info.ScenarioOptionDuration("d", time.Second); got != time.Second {
-		t.Errorf("duration: want fallback 1s, got %v", got)
-	}
-}
-
-func TestScenarioOptionBoolAcceptsParseBoolForms(t *testing.T) {
-	info := &ScenarioInfo{ScenarioOptions: map[string]string{"on": "1", "off": "0"}}
-	if !info.ScenarioOptionBool("on", false) {
-		t.Error(`expected "1" to read as true`)
-	}
-	if info.ScenarioOptionBool("off", true) {
-		t.Error(`expected "0" to read as false`)
+	if got := info.OptionDuration("nope"); got != 0 {
+		t.Errorf("duration: want zero, got %v", got)
 	}
 }
 

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -40,9 +39,11 @@ type Scenario struct {
 	//		o.MarkRequired("task-queue-count")
 	//	}
 	//
-	// Declaring lets omes reject unknown names and malformed values before the
-	// run starts, and lets `list-scenarios` show what the scenario accepts.
-	// Leaving it nil keeps the legacy behavior of accepting any option.
+	// Declarations are the single source of truth for an option's type and
+	// default: omes rejects unknown names and malformed values before the run
+	// starts, `list-scenarios` shows what the scenario accepts, and the Option*
+	// accessors read from them. A scenario that declares nothing accepts no
+	// options.
 	Options func(*OptionSet)
 	// DefaultConfiguration is the scenario's own default run configuration,
 	// shown by `list-scenarios` and used for any field the user does not
@@ -158,8 +159,10 @@ type ScenarioInfo struct {
 	ClientOptions clioptions.ClientOptions
 	// Configuration info passed by user if any.
 	Configuration RunConfiguration
-	// ScenarioOptions are info passed from the command line. Do not mutate these.
-	ScenarioOptions map[string]string
+	// Options holds the scenario's options: each declared default, overwritten by
+	// whatever the user passed with `--option`. Read them with the Option*
+	// accessors. Do not mutate.
+	Options *OptionSet
 	// The namespace that was used when connecting the client.
 	Namespace string
 	// Path to the root of the omes dir
@@ -176,81 +179,70 @@ type ExportOptions struct {
 	ExportHistoriesFilter string
 }
 
-// The ScenarioOption* accessors return the value the user supplied, or
-// defaultValue. Keep defaultValue consistent with the scenario's declared
-// default (see [Scenario.Options]); the declaration is what `list-scenarios`
-// advertises, and it is not injected here.
+// The Option* accessors return the option's value: what the user passed, or the
+// default the scenario declared. Values are validated before the run starts, so
+// these cannot fail on user input.
 //
-// For a declared option a malformed value is rejected before the run starts. For
-// an undeclared one there is nothing to validate against, so a value that does
-// not parse falls back to defaultValue and logs a warning rather than panicking.
+// Reading an option the scenario did not declare is a bug in the scenario, not
+// something a user can cause. It logs and returns the zero value.
 
-func (s *ScenarioInfo) ScenarioOptionInt(name string, defaultValue int) int {
-	v := s.ScenarioOptions[name]
-	if v == "" {
-		return defaultValue
-	}
-	i, err := strconv.Atoi(v)
+func (s *ScenarioInfo) OptionInt(name string) int {
+	v, err := s.options().GetInt(name)
 	if err != nil {
-		s.warnUnparseableOption(name, v, "int", defaultValue)
-		return defaultValue
-	}
-	return i
-}
-
-func (s *ScenarioInfo) ScenarioOptionFloat(name string, defaultValue float64) float64 {
-	v := s.ScenarioOptions[name]
-	if v == "" {
-		return defaultValue
-	}
-	f, err := strconv.ParseFloat(v, 64)
-	if err != nil {
-		s.warnUnparseableOption(name, v, "float", defaultValue)
-		return defaultValue
-	}
-	return f
-}
-
-func (s *ScenarioInfo) ScenarioOptionBool(name string, defaultValue bool) bool {
-	v := s.ScenarioOptions[name]
-	if v == "" {
-		return defaultValue
-	}
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		s.warnUnparseableOption(name, v, "bool", defaultValue)
-		return defaultValue
-	}
-	return b
-}
-
-func (s *ScenarioInfo) ScenarioOptionDuration(name string, defaultValue time.Duration) time.Duration {
-	v := s.ScenarioOptions[name]
-	if v == "" {
-		return defaultValue
-	}
-	d, err := time.ParseDuration(v)
-	if err != nil {
-		s.warnUnparseableOption(name, v, "duration", defaultValue)
-		return defaultValue
-	}
-	return d
-}
-
-func (s *ScenarioInfo) ScenarioOptionString(name string, defaultValue string) string {
-	v := s.ScenarioOptions[name]
-	if v == "" {
-		return defaultValue
+		s.undeclaredOption(name, err)
 	}
 	return v
 }
 
-func (s *ScenarioInfo) warnUnparseableOption(name, value, want string, fallback any) {
-	if s.Logger == nil {
-		return
+func (s *ScenarioInfo) OptionFloat64(name string) float64 {
+	v, err := s.options().GetFloat64(name)
+	if err != nil {
+		s.undeclaredOption(name, err)
 	}
-	s.Logger.Warnf("option %q is not a valid %s (got %q); using %v. Declare the option on the scenario to have this rejected before the run starts.",
-		name, want, value, fallback)
+	return v
+}
+
+func (s *ScenarioInfo) OptionBool(name string) bool {
+	v, err := s.options().GetBool(name)
+	if err != nil {
+		s.undeclaredOption(name, err)
+	}
+	return v
+}
+
+func (s *ScenarioInfo) OptionDuration(name string) time.Duration {
+	v, err := s.options().GetDuration(name)
+	if err != nil {
+		s.undeclaredOption(name, err)
+	}
+	return v
+}
+
+func (s *ScenarioInfo) OptionString(name string) string {
+	v, err := s.options().GetString(name)
+	if err != nil {
+		s.undeclaredOption(name, err)
+	}
+	return v
+}
+
+// options returns the resolved set, or an empty one so a ScenarioInfo built
+// without options (in tests, say) reads zero values rather than panicking.
+func (s *ScenarioInfo) options() *OptionSet {
+	if s.Options == nil {
+		s.Options = newOptionSet("")
+	}
+	return s.Options
+}
+
+func (s *ScenarioInfo) undeclaredOption(name string, err error) {
+	msg := fmt.Sprintf("scenario %q read option %q, which it does not declare: %v",
+		s.ScenarioName, name, err)
+	if s.Logger != nil {
+		s.Logger.Error(msg)
+	} else {
+		clioptions.BackupLogger.Println(msg)
+	}
 }
 
 const DefaultIterations = 10

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -32,7 +32,38 @@ const OmesExecutionIDSearchAttribute = "OmesExecutionID"
 
 type Scenario struct {
 	Description string
-	ExecutorFn  func() Executor
+	// Options declares the options a user may set with `--option <name>=<value>`,
+	// using the same typed pflag registrars as omes's own CLI flags:
+	//
+	//	Options: func(o *loadgen.OptionSet) {
+	//		o.Int("children-per-workflow", 30, "Child workflows per iteration.")
+	//		o.MarkRequired("task-queue-count")
+	//	}
+	//
+	// Declaring lets omes reject unknown names and malformed values before the
+	// run starts, and lets `list-scenarios` show what the scenario accepts.
+	// Leaving it nil keeps the legacy behavior of accepting any option.
+	Options func(*OptionSet)
+	// DefaultConfiguration is the scenario's own default run configuration,
+	// shown by `list-scenarios` and used for any field the user does not
+	// override. It supersedes the [HasDefaultConfiguration] executor interface.
+	DefaultConfiguration *RunConfiguration
+	ExecutorFn           func() Executor
+}
+
+// GetDefaultConfiguration prefers the scenario's declared configuration and
+// falls back to the executor's [HasDefaultConfiguration] implementation,
+// reporting whether either was present.
+func (s *Scenario) GetDefaultConfiguration() (RunConfiguration, bool) {
+	if s.DefaultConfiguration != nil {
+		return *s.DefaultConfiguration, true
+	}
+	if s.ExecutorFn != nil {
+		if iface, _ := s.ExecutorFn().(HasDefaultConfiguration); iface != nil {
+			return iface.GetDefaultConfiguration(), true
+		}
+	}
+	return RunConfiguration{}, false
 }
 
 // Executor for a scenario.
@@ -145,6 +176,15 @@ type ExportOptions struct {
 	ExportHistoriesFilter string
 }
 
+// The ScenarioOption* accessors return the value the user supplied, or
+// defaultValue. Keep defaultValue consistent with the scenario's declared
+// default (see [Scenario.Options]); the declaration is what `list-scenarios`
+// advertises, and it is not injected here.
+//
+// For a declared option a malformed value is rejected before the run starts. For
+// an undeclared one there is nothing to validate against, so a value that does
+// not parse falls back to defaultValue and logs a warning rather than panicking.
+
 func (s *ScenarioInfo) ScenarioOptionInt(name string, defaultValue int) int {
 	v := s.ScenarioOptions[name]
 	if v == "" {
@@ -152,7 +192,8 @@ func (s *ScenarioInfo) ScenarioOptionInt(name string, defaultValue int) int {
 	}
 	i, err := strconv.Atoi(v)
 	if err != nil {
-		panic(err)
+		s.warnUnparseableOption(name, v, "int", defaultValue)
+		return defaultValue
 	}
 	return i
 }
@@ -164,7 +205,8 @@ func (s *ScenarioInfo) ScenarioOptionFloat(name string, defaultValue float64) fl
 	}
 	f, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		panic(err)
+		s.warnUnparseableOption(name, v, "float", defaultValue)
+		return defaultValue
 	}
 	return f
 }
@@ -174,7 +216,12 @@ func (s *ScenarioInfo) ScenarioOptionBool(name string, defaultValue bool) bool {
 	if v == "" {
 		return defaultValue
 	}
-	return v == "true"
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		s.warnUnparseableOption(name, v, "bool", defaultValue)
+		return defaultValue
+	}
+	return b
 }
 
 func (s *ScenarioInfo) ScenarioOptionDuration(name string, defaultValue time.Duration) time.Duration {
@@ -184,16 +231,26 @@ func (s *ScenarioInfo) ScenarioOptionDuration(name string, defaultValue time.Dur
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil {
-		panic(err)
+		s.warnUnparseableOption(name, v, "duration", defaultValue)
+		return defaultValue
 	}
 	return d
 }
+
 func (s *ScenarioInfo) ScenarioOptionString(name string, defaultValue string) string {
 	v := s.ScenarioOptions[name]
 	if v == "" {
 		return defaultValue
 	}
 	return v
+}
+
+func (s *ScenarioInfo) warnUnparseableOption(name, value, want string, fallback any) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Warnf("option %q is not a valid %s (got %q); using %v. Declare the option on the scenario to have this rejected before the run starts.",
+		name, want, value, fallback)
 }
 
 const DefaultIterations = 10

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -399,6 +399,12 @@ func TaskQueueForRun(runID string) string {
 	return "omes-" + runID
 }
 
+// EnsureNexusEndpoint returns the Nexus endpoint for this run, creating it if it
+// does not already exist. Call this when Nexus is enabled without a named endpoint.
+func (s *ScenarioInfo) EnsureNexusEndpoint(ctx context.Context) (string, error) {
+	return ensureNexusEndpoint(ctx, s.Client, s.Namespace, s.RunID)
+}
+
 // NexusEndpointForRun returns a sanitized Nexus endpoint name for the given run ID.
 func NexusEndpointForRun(runID string) string {
 	sanitized := sanitizeRunID.ReplaceAllString(strings.ReplaceAll(runID, "/", "-"), "")

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -76,11 +76,20 @@ var _ loadgen.Resumable = (*ebbAndFlowExecutor)(nil)
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: "Oscillates backlog between min and max.\n" +
-			"Options:\n" +
-			"  min-backlog, max-backlog, period, sleep-duration, max-rate,\n" +
-			"  control-interval, max-consecutive-errors, backlog-log-interval.\n" +
-			"Duration must be set.",
+		Description: "Oscillates backlog between min and max. Duration must be set.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(MinBacklogFlag, 0, "Minimum total backlog to target.")
+			o.Int(MaxBacklogFlag, 30, "Maximum total backlog to target.")
+			o.Duration(PeriodFlag, 60*time.Second, "Period of backlog-size oscillation.")
+			o.Duration("phase-time", 60*time.Second, "Deprecated alias for "+PeriodFlag+".")
+			o.Duration(SleepDurationFlag, time.Millisecond, "How long each activity sleeps.")
+			o.Int(MaxRateFlag, 1000, "Maximum workflows spawned per control interval.")
+			o.Duration(ControlIntervalFlag, 100*time.Millisecond, "How often the backlog is controlled.")
+			o.Int(MaxConsecutiveErrorsFlag, 10, "Consecutive errors tolerated before stopping.")
+			o.Duration(BacklogLogIntervalFlag, 30*time.Second, "How often backlog stats are logged.")
+			o.Duration(VisibilityVerificationTimeoutFlag, 30*time.Second, "Timeout for the visibility count check.")
+			o.String(SleepActivityJsonFlag, "", "JSON sleep-activity configuration; use @<file> to read from a file.")
+		},
 		ExecutorFn: func() loadgen.Executor { return newEbbAndFlowExecutor() },
 	})
 }

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -81,7 +81,6 @@ func init() {
 			o.Int(MinBacklogFlag, 0, "Minimum total backlog to target.")
 			o.Int(MaxBacklogFlag, 30, "Maximum total backlog to target.")
 			o.Duration(PeriodFlag, 60*time.Second, "Period of backlog-size oscillation.")
-			o.Duration("phase-time", 60*time.Second, "Deprecated alias for "+PeriodFlag+".")
 			o.Duration(SleepDurationFlag, time.Millisecond, "How long each activity sleeps.")
 			o.Int(MaxRateFlag, 1000, "Maximum workflows spawned per control interval.")
 			o.Duration(ControlIntervalFlag, 100*time.Millisecond, "How often the backlog is controlled.")
@@ -118,9 +117,7 @@ func (e *ebbAndFlowExecutor) Configure(info loadgen.ScenarioInfo) error {
 		return fmt.Errorf("max-backlog must be greater than min-backlog, got max=%d min=%d", config.MaxBacklog, config.MinBacklog)
 	}
 
-	// TODO: backwards-compatibility, remove later
-	pt := info.ScenarioOptionDuration("phase-time", 60*time.Second)
-	config.Period = info.ScenarioOptionDuration(PeriodFlag, pt)
+	config.Period = info.ScenarioOptionDuration(PeriodFlag, 60*time.Second)
 	if config.Period <= 0 {
 		return fmt.Errorf("period must be greater than 0, got %v", config.Period)
 	}

--- a/scenarios/ebb_and_flow.go
+++ b/scenarios/ebb_and_flow.go
@@ -99,30 +99,30 @@ func newEbbAndFlowExecutor() *ebbAndFlowExecutor {
 
 func (e *ebbAndFlowExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config := &ebbAndFlowConfig{
-		SleepDuration:                 info.ScenarioOptionDuration(SleepDurationFlag, 1*time.Millisecond),
-		MaxRate:                       int64(info.ScenarioOptionInt(MaxRateFlag, 1000)),
-		ControlInterval:               info.ScenarioOptionDuration(ControlIntervalFlag, 100*time.Millisecond),
-		MaxConsecutiveErrors:          info.ScenarioOptionInt(MaxConsecutiveErrorsFlag, 10),
-		BacklogLogInterval:            info.ScenarioOptionDuration(BacklogLogIntervalFlag, 30*time.Second),
-		VisibilityVerificationTimeout: info.ScenarioOptionDuration(VisibilityVerificationTimeoutFlag, 30*time.Second),
+		SleepDuration:                 info.OptionDuration(SleepDurationFlag),
+		MaxRate:                       int64(info.OptionInt(MaxRateFlag)),
+		ControlInterval:               info.OptionDuration(ControlIntervalFlag),
+		MaxConsecutiveErrors:          info.OptionInt(MaxConsecutiveErrorsFlag),
+		BacklogLogInterval:            info.OptionDuration(BacklogLogIntervalFlag),
+		VisibilityVerificationTimeout: info.OptionDuration(VisibilityVerificationTimeoutFlag),
 	}
 
-	config.MinBacklog = int64(info.ScenarioOptionInt(MinBacklogFlag, 0))
+	config.MinBacklog = int64(info.OptionInt(MinBacklogFlag))
 	if config.MinBacklog < 0 {
 		return fmt.Errorf("min-backlog must be non-negative, got %d", config.MinBacklog)
 	}
 
-	config.MaxBacklog = int64(info.ScenarioOptionInt(MaxBacklogFlag, 30))
+	config.MaxBacklog = int64(info.OptionInt(MaxBacklogFlag))
 	if config.MaxBacklog <= config.MinBacklog {
 		return fmt.Errorf("max-backlog must be greater than min-backlog, got max=%d min=%d", config.MaxBacklog, config.MinBacklog)
 	}
 
-	config.Period = info.ScenarioOptionDuration(PeriodFlag, 60*time.Second)
+	config.Period = info.OptionDuration(PeriodFlag)
 	if config.Period <= 0 {
 		return fmt.Errorf("period must be greater than 0, got %v", config.Period)
 	}
 
-	if sleepActivitiesStr, ok := info.ScenarioOptions[SleepActivityJsonFlag]; ok {
+	if sleepActivitiesStr := info.OptionString(SleepActivityJsonFlag); sleepActivitiesStr != "" {
 		var err error
 		// This scenario overrides "count" and "sleepDuration" so do not require them.
 		config.SleepActivityConfig, err = loadgen.ParseAndValidateSleepActivityConfig(sleepActivitiesStr, false, false)

--- a/scenarios/ebb_and_flow_test.go
+++ b/scenarios/ebb_and_flow_test.go
@@ -53,14 +53,14 @@ func TestEbbAndFlow(t *testing.T) {
 		Configuration: loadgen.RunConfiguration{
 			Duration: 10 * time.Second,
 		},
-		ScenarioOptions: map[string]string{
+		Options: loadgen.MustResolveScenarioOptions("ebb_and_flow", map[string]string{
 			MinBacklogFlag:                    "0",
 			MaxBacklogFlag:                    "1",
 			PeriodFlag:                        "5s",
 			BacklogLogIntervalFlag:            "5s",
 			VisibilityVerificationTimeoutFlag: "5s",
 			SleepActivityJsonFlag:             sleepActivityJson,
-		},
+		}),
 	}
 
 	var state ebbAndFlowState

--- a/scenarios/fuzzer.go
+++ b/scenarios/fuzzer.go
@@ -10,6 +10,13 @@ func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "This scenario uses the kitchen sink input generation tool to run fuzzy" +
 			" workflows",
+		Options: func(o *loadgen.OptionSet) {
+			loadgen.DeclareFuzzExecutorOptions(o)
+			o.String("input-file", "", "Pre-generated input file to replay instead of generating actions.")
+			o.String("seed", "", "Explicit seed for action generation.")
+			o.String("config", "", "Generator config override.")
+			o.Bool("no-output-file", false, "Skip writing last_fuzz_run.proto.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.FuzzExecutor{
 				InitInputs: func(ctx context.Context, info loadgen.ScenarioInfo) loadgen.FileOrArgs {
@@ -34,8 +41,7 @@ func init() {
 						nexusEndpoint = loadgen.NexusEndpointForRun(info.RunID)
 					}
 					args = append(args, "--nexus-endpoint", nexusEndpoint)
-					_, ok = info.ScenarioOptions["no-output-file"]
-					if !ok {
+					if !info.ScenarioOptionBool("no-output-file", false) {
 						args = append(args, "--output-path", "last_fuzz_run.proto")
 					}
 					return loadgen.FileOrArgs{

--- a/scenarios/fuzzer.go
+++ b/scenarios/fuzzer.go
@@ -6,6 +6,10 @@ import (
 	"github.com/temporalio/omes/loadgen"
 )
 
+// defaultFuzzOutputFile is where generated actions are written so a run can be
+// replayed with --option input-file.
+const defaultFuzzOutputFile = "last_fuzz_run.proto"
+
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "This scenario uses the kitchen sink input generation tool to run fuzzy" +
@@ -15,7 +19,8 @@ func init() {
 			o.String("input-file", "", "Pre-generated input file to replay instead of generating actions.")
 			o.String("seed", "", "Explicit seed for action generation.")
 			o.String("config", "", "Generator config override.")
-			o.Bool("no-output-file", false, "Skip writing last_fuzz_run.proto.")
+			o.String("output-file", defaultFuzzOutputFile,
+				"Path to write the generated actions to for replay. Empty writes nothing.")
 		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.FuzzExecutor{
@@ -41,8 +46,8 @@ func init() {
 						nexusEndpoint = loadgen.NexusEndpointForRun(info.RunID)
 					}
 					args = append(args, "--nexus-endpoint", nexusEndpoint)
-					if !info.ScenarioOptionBool("no-output-file", false) {
-						args = append(args, "--output-path", "last_fuzz_run.proto")
+					if outputFile := info.ScenarioOptionString("output-file", defaultFuzzOutputFile); outputFile != "" {
+						args = append(args, "--output-path", outputFile)
 					}
 					return loadgen.FileOrArgs{
 						Args: args,

--- a/scenarios/fuzzer.go
+++ b/scenarios/fuzzer.go
@@ -25,28 +25,25 @@ func init() {
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.FuzzExecutor{
 				InitInputs: func(ctx context.Context, info loadgen.ScenarioInfo) loadgen.FileOrArgs {
-					fPath, ok := info.ScenarioOptions["input-file"]
-					if ok && fPath != "" {
+					if fPath := info.OptionString("input-file"); fPath != "" {
 						return loadgen.FileOrArgs{
 							FilePath: fPath,
 						}
 					}
 
 					args := []string{"generate"}
-					seed, ok := info.ScenarioOptions["seed"]
-					if ok && seed != "" {
+					if seed := info.OptionString("seed"); seed != "" {
 						args = append(args, "--explicit-seed", seed)
 					}
-					config, ok := info.ScenarioOptions["config"]
-					if ok && config != "" {
+					if config := info.OptionString("config"); config != "" {
 						args = append(args, "--generator-config-override", config)
 					}
-					nexusEndpoint := info.ScenarioOptions["nexus-endpoint"]
+					nexusEndpoint := info.OptionString("nexus-endpoint")
 					if nexusEndpoint == "" {
 						nexusEndpoint = loadgen.NexusEndpointForRun(info.RunID)
 					}
 					args = append(args, "--nexus-endpoint", nexusEndpoint)
-					if outputFile := info.ScenarioOptionString("output-file", defaultFuzzOutputFile); outputFile != "" {
+					if outputFile := info.OptionString("output-file"); outputFile != "" {
 						args = append(args, "--output-path", outputFile)
 					}
 					return loadgen.FileOrArgs{

--- a/scenarios/fuzzer_example.go
+++ b/scenarios/fuzzer_example.go
@@ -10,6 +10,7 @@ func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "This scenario runs the kitchen sink input generation tool `example` " +
 			"command to help with basic verification of KS implementations.",
+		Options: loadgen.DeclareFuzzExecutorOptions,
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.FuzzExecutor{
 				InitInputs: func(ctx context.Context, info loadgen.ScenarioInfo) loadgen.FileOrArgs {

--- a/scenarios/long_idle_workflow.go
+++ b/scenarios/long_idle_workflow.go
@@ -70,11 +70,11 @@ type longIdleConfig struct {
 
 func parseLongIdleConfig(info *loadgen.ScenarioInfo) (*longIdleConfig, error) {
 	cfg := &longIdleConfig{
-		idleDuration:            info.ScenarioOptionDuration(longIdleIdleDurationFlag, time.Minute),
-		cyclesPerRun:            info.ScenarioOptionInt(longIdleCyclesPerRunFlag, 1),
-		activitiesPerCycle:      info.ScenarioOptionInt(longIdleActivitiesPerCycleFlag, 0),
-		activityDuration:        info.ScenarioOptionDuration(longIdleActivityDurationFlag, time.Second),
-		continueAsNewIterations: info.ScenarioOptionInt(longIdleContinueAsNewIterationsFlag, 0),
+		idleDuration:            info.OptionDuration(longIdleIdleDurationFlag),
+		cyclesPerRun:            info.OptionInt(longIdleCyclesPerRunFlag),
+		activitiesPerCycle:      info.OptionInt(longIdleActivitiesPerCycleFlag),
+		activityDuration:        info.OptionDuration(longIdleActivityDurationFlag),
+		continueAsNewIterations: info.OptionInt(longIdleContinueAsNewIterationsFlag),
 	}
 	if cfg.idleDuration <= 0 {
 		return nil, fmt.Errorf("%s must be > 0, got %v", longIdleIdleDurationFlag, cfg.idleDuration)

--- a/scenarios/long_idle_workflow.go
+++ b/scenarios/long_idle_workflow.go
@@ -32,15 +32,14 @@ const (
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: fmt.Sprintf(
-			"Run long-lived, mostly idle workflows that alternate idle periods with optional activity bursts. "+
-				"Options: '%s' (default 1m), '%s' (default 1), '%s' (default 0), '%s' (default 1s), '%s' (default 0).",
-			longIdleIdleDurationFlag,
-			longIdleCyclesPerRunFlag,
-			longIdleActivitiesPerCycleFlag,
-			longIdleActivityDurationFlag,
-			longIdleContinueAsNewIterationsFlag,
-		),
+		Description: "Run long-lived, mostly idle workflows that alternate idle periods with optional activity bursts.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Duration(longIdleIdleDurationFlag, time.Minute, "How long each idle period lasts.")
+			o.Int(longIdleCyclesPerRunFlag, 1, "Idle/activity cycles per workflow.")
+			o.Int(longIdleActivitiesPerCycleFlag, 0, "Activities run at the end of each idle period.")
+			o.Duration(longIdleActivityDurationFlag, time.Second, "How long each activity runs.")
+			o.Int(longIdleContinueAsNewIterationsFlag, 0, "Continue-as-new iterations per workflow (0 disables).")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &kitchensink.TestInput{

--- a/scenarios/long_idle_workflow_test.go
+++ b/scenarios/long_idle_workflow_test.go
@@ -15,7 +15,7 @@ func TestLongIdleWorkflow_ParseConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("defaults", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{}}
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("long_idle_workflow", nil)}
 		cfg, err := parseLongIdleConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, time.Minute, cfg.idleDuration)
@@ -26,13 +26,13 @@ func TestLongIdleWorkflow_ParseConfig(t *testing.T) {
 	})
 
 	t.Run("overrides", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("long_idle_workflow", map[string]string{
 			longIdleIdleDurationFlag:            "5ms",
 			longIdleCyclesPerRunFlag:            "3",
 			longIdleActivitiesPerCycleFlag:      "2",
 			longIdleActivityDurationFlag:        "250ms",
 			longIdleContinueAsNewIterationsFlag: "4",
-		}}
+		})}
 		cfg, err := parseLongIdleConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, 5*time.Millisecond, cfg.idleDuration)
@@ -52,7 +52,7 @@ func TestLongIdleWorkflow_ParseConfig(t *testing.T) {
 		}
 		for name, opts := range cases {
 			t.Run(name, func(t *testing.T) {
-				_, err := parseLongIdleConfig(&loadgen.ScenarioInfo{ScenarioOptions: opts})
+				_, err := parseLongIdleConfig(&loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("long_idle_workflow", opts)})
 				require.Error(t, err)
 			})
 		}
@@ -117,12 +117,12 @@ func TestLongIdleWorkflow(t *testing.T) {
 				Iterations:    3,
 				MaxConcurrent: 3,
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("long_idle_workflow", map[string]string{
 				longIdleIdleDurationFlag:       "1ms",
 				longIdleCyclesPerRunFlag:       "2",
 				longIdleActivitiesPerCycleFlag: "1",
 				longIdleActivityDurationFlag:   "1ms",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 	})
@@ -136,10 +136,10 @@ func TestLongIdleWorkflow(t *testing.T) {
 				Iterations:    2,
 				MaxConcurrent: 2,
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("long_idle_workflow", map[string]string{
 				longIdleIdleDurationFlag:            "1ms",
 				longIdleContinueAsNewIterationsFlag: "2",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 	})

--- a/scenarios/out_of_order_signals.go
+++ b/scenarios/out_of_order_signals.go
@@ -78,9 +78,9 @@ type outOfOrderSignalsConfig struct {
 
 func parseOutOfOrderSignalsConfig(info *loadgen.ScenarioInfo) (*outOfOrderSignalsConfig, error) {
 	cfg := &outOfOrderSignalsConfig{
-		signalsPerWorkflow: info.ScenarioOptionInt(oooSignalsCountFlag, 10),
-		shufflePercentage:  info.ScenarioOptionInt(oooSignalsShufflePercentageFlag, 100),
-		processingTime:     info.ScenarioOptionDuration(oooSignalsProcessingTimeFlag, 0),
+		signalsPerWorkflow: info.OptionInt(oooSignalsCountFlag),
+		shufflePercentage:  info.OptionInt(oooSignalsShufflePercentageFlag),
+		processingTime:     info.OptionDuration(oooSignalsProcessingTimeFlag),
 	}
 	if cfg.signalsPerWorkflow <= 0 {
 		return nil, fmt.Errorf("%s must be > 0, got %d", oooSignalsCountFlag, cfg.signalsPerWorkflow)

--- a/scenarios/out_of_order_signals.go
+++ b/scenarios/out_of_order_signals.go
@@ -42,13 +42,12 @@ const oooSignalReadyValue = "ready"
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: fmt.Sprintf(
-			"Send N signals per workflow in a deterministically shuffled order; the workflow processes them in event sequence. "+
-				"Options: '%s' (default 10), '%s' (default 100), '%s' (default 0).",
-			oooSignalsCountFlag,
-			oooSignalsShufflePercentageFlag,
-			oooSignalsProcessingTimeFlag,
-		),
+		Description: "Send N signals per workflow in a deterministically shuffled order; the workflow processes them in event sequence.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(oooSignalsCountFlag, 10, "Signals sent per workflow.")
+			o.Int(oooSignalsShufflePercentageFlag, 100, "Percentage of signals sent out of order.")
+			o.Duration(oooSignalsProcessingTimeFlag, 0, "Simulated processing time per signal.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &kitchensink.TestInput{

--- a/scenarios/out_of_order_signals_test.go
+++ b/scenarios/out_of_order_signals_test.go
@@ -145,7 +145,7 @@ func TestOutOfOrderSignals(t *testing.T) {
 				Iterations:    3,
 				MaxConcurrent: 3,
 			},
-			ScenarioOptions: opts,
+			Options: loadgen.MustResolveScenarioOptions("out_of_order_signals", opts),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 	}
@@ -170,7 +170,7 @@ func TestOutOfOrderSignals_ParseConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("defaults", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{}}
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("out_of_order_signals", nil)}
 		cfg, err := parseOutOfOrderSignalsConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, 10, cfg.signalsPerWorkflow)
@@ -179,11 +179,11 @@ func TestOutOfOrderSignals_ParseConfig(t *testing.T) {
 	})
 
 	t.Run("overrides", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("out_of_order_signals", map[string]string{
 			oooSignalsCountFlag:             "5",
 			oooSignalsShufflePercentageFlag: "50",
 			oooSignalsProcessingTimeFlag:    "250ms",
-		}}
+		})}
 		cfg, err := parseOutOfOrderSignalsConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, 5, cfg.signalsPerWorkflow)
@@ -200,7 +200,7 @@ func TestOutOfOrderSignals_ParseConfig(t *testing.T) {
 		}
 		for name, opts := range cases {
 			t.Run(name, func(t *testing.T) {
-				_, err := parseOutOfOrderSignalsConfig(&loadgen.ScenarioInfo{ScenarioOptions: opts})
+				_, err := parseOutOfOrderSignalsConfig(&loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("out_of_order_signals", opts)})
 				require.Error(t, err)
 			})
 		}

--- a/scenarios/project/project.go
+++ b/scenarios/project/project.go
@@ -116,20 +116,15 @@ func (e *projectScenarioExecutor) Run(ctx context.Context, info loadgen.Scenario
 func (e *projectScenarioExecutor) validate(info loadgen.ScenarioInfo) (projectScenarioOptions, error) {
 	var opts projectScenarioOptions
 
-	lang := info.ScenarioOptions["language"]
-	if lang == "" {
-		return opts, fmt.Errorf("--option language=<lang> is required")
-	}
+	// language and project-name are declared required, so the run fails before
+	// reaching here if either is missing.
+	lang := info.OptionString("language")
 	if err := opts.sdkOpts.Language.Set(lang); err != nil {
 		return opts, fmt.Errorf("unrecognized language: %s", lang)
 	}
 
-	projectName := info.ScenarioOptions["project-name"]
-	prebuiltDir := info.ScenarioOptions["prebuilt-project-dir"]
-	if projectName == "" {
-		return opts, fmt.Errorf("--option project-name=<name> is required")
-	}
-	opts.projectName = projectName
+	prebuiltDir := info.OptionString("prebuilt-project-dir")
+	opts.projectName = info.OptionString("project-name")
 
 	if prebuiltDir != "" {
 		abs, err := filepath.Abs(prebuiltDir)
@@ -139,12 +134,12 @@ func (e *projectScenarioExecutor) validate(info loadgen.ScenarioInfo) (projectSc
 		opts.prebuiltDir = abs
 	}
 
-	version := info.ScenarioOptions["version"]
+	version := info.OptionString("version")
 	if version != "" && opts.prebuiltDir == "" {
 		opts.sdkOpts.Version = version
 	}
 
-	if configPath := info.ScenarioOptions["project-config-file"]; configPath != "" {
+	if configPath := info.OptionString("project-config-file"); configPath != "" {
 		data, err := os.ReadFile(configPath)
 		if err != nil {
 			return opts, fmt.Errorf("failed to read config file %s: %w", configPath, err)
@@ -152,14 +147,7 @@ func (e *projectScenarioExecutor) validate(info loadgen.ScenarioInfo) (projectSc
 		opts.configJSON = data
 	}
 
-	opts.projectServerReadyTimeout = defaultClientReadyTimeout
-	if timeout := info.ScenarioOptions["project-server-ready-timeout"]; timeout != "" {
-		parsed, err := time.ParseDuration(timeout)
-		if err != nil {
-			return opts, fmt.Errorf("invalid project-server-ready-timeout %q: %w", timeout, err)
-		}
-		opts.projectServerReadyTimeout = parsed
-	}
+	opts.projectServerReadyTimeout = info.OptionDuration("project-server-ready-timeout")
 
 	return opts, nil
 }

--- a/scenarios/project/project.go
+++ b/scenarios/project/project.go
@@ -22,12 +22,16 @@ import (
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: `Run a self-contained project test. Builds (or loads) the project program, spawns a project-server, and drives iterations via gRPC.
-  Required: --option language=<lang>
-  Required: --option project-name=<name>  (app entrypoint; optional --option version=<version> override)
-  Optional: --option prebuilt-project-dir=<path>  (use pre-built root worker package)
-  Optional: --option project-config-file=<path>   (project-specific JSON config)
-  Optional: --option project-server-ready-timeout=<duration> (timeout to connect to project-server, default 15s)
   See README.md ("Project" section) for local usage examples and current limitations.`,
+		Options: func(o *loadgen.OptionSet) {
+			o.String("language", "", "Worker language the project is written in.")
+			o.String("project-name", "", "App entrypoint to run.")
+			o.MarkRequired("language", "project-name")
+			o.String("version", "", "SDK version override for the project build.")
+			o.String("prebuilt-project-dir", "", "Use this pre-built root worker package instead of building.")
+			o.String("project-config-file", "", "Project-specific JSON config file.")
+			o.Duration("project-server-ready-timeout", 15*time.Second, "Timeout waiting for project-server to accept connections.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return &projectScenarioExecutor{}
 		},

--- a/scenarios/scheduler_stress.go
+++ b/scenarios/scheduler_stress.go
@@ -21,21 +21,21 @@ import (
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: fmt.Sprintf("Stress test Temporal's scheduler functionality by creating, reading, updating, and deleting multiple schedules concurrently. "+
-			"Available parameters: '%s' (default: %d), '%s' (default: %d), '%s' (default: %d), '%s' (default: %v), '%s' (default: %d), '%s' (default: %v), '%s' (default: %v), "+
-			"'%s' (default: '%s'), '%s' (default: '%s', options: skip,buffer_one,buffer_all,cancel_other,terminate_other,all), "+
-			"'%s' (default: '%s', options: %s,%s), '%s' (default: %v)",
-			ScheduleCreationPerIterationFlag, DefaultScheduleCreationPerIteration,
-			ScheduleReadsPerCreationFlag, DefaultScheduleReadsPerCreation,
-			ScheduleUpdatesPerCreationFlag, DefaultScheduleUpdatesPerCreation,
-			SchedulerDurationPerIterationFlag, DefaultSchedulerDurationPerIteration,
-			PayloadSizeFlag, DefaultPayloadSize,
-			WaitTimeBeforeCleanupFlag, DefaultWaitTimeBeforeCleanup,
-			OperationIntervalFlag, DefaultOperationInterval,
-			CronExpressionFlag, DefaultCronExpression,
-			OverlapPolicyFlag, DefaultOverlapPolicy,
-			ScheduledWorkflowTypeFlag, DefaultScheduledWorkflowType, NoopScheduledWorkflowType, SleepScheduleWorkflowType,
-			EnableChasmSchedulerFlag, DefaultEnableChasmScheduler),
+		Description: "Stress test Temporal's scheduler functionality by creating, reading, updating, and deleting multiple schedules concurrently.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(ScheduleCreationPerIterationFlag, DefaultScheduleCreationPerIteration, "Schedules created per iteration.")
+			o.Int(ScheduleReadsPerCreationFlag, DefaultScheduleReadsPerCreation, "Schedule reads per created schedule.")
+			o.Int(ScheduleUpdatesPerCreationFlag, DefaultScheduleUpdatesPerCreation, "Schedule updates per created schedule.")
+			o.Duration(SchedulerDurationPerIterationFlag, DefaultSchedulerDurationPerIteration, "How long each iteration exercises its schedules.")
+			o.Int(PayloadSizeFlag, DefaultPayloadSize, "Payload size in bytes for scheduled workflows.")
+			o.Duration(WaitTimeBeforeCleanupFlag, DefaultWaitTimeBeforeCleanup, "Wait before deleting schedules.")
+			o.Duration(OperationIntervalFlag, DefaultOperationInterval, "Interval between schedule operations.")
+			o.String(CronExpressionFlag, DefaultCronExpression, "Cron expression for created schedules.")
+			o.String(OverlapPolicyFlag, DefaultOverlapPolicy, "Overlap policy: skip, buffer_one, buffer_all, cancel_other, terminate_other, all.")
+			o.String(ScheduledWorkflowTypeFlag, DefaultScheduledWorkflowType,
+				"Workflow type to schedule: "+NoopScheduledWorkflowType+" or "+SleepScheduleWorkflowType+".")
+			o.Bool(EnableChasmSchedulerFlag, DefaultEnableChasmScheduler, "Route schedule creation to the CHASM scheduler.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return &loadgen.GenericExecutor{
 				Execute: func(ctx context.Context, run *loadgen.Run) error {

--- a/scenarios/scheduler_stress.go
+++ b/scenarios/scheduler_stress.go
@@ -113,17 +113,17 @@ var (
 // Configure implements the loadgen.Configurable interface
 func (s *SchedulerExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config := &schedulerExecutorConfig{
-		ScheduleCreationPerIteration:  info.ScenarioOptionInt(ScheduleCreationPerIterationFlag, DefaultScheduleCreationPerIteration),
-		ScheduleReadsPerCreation:      info.ScenarioOptionInt(ScheduleReadsPerCreationFlag, DefaultScheduleReadsPerCreation),
-		ScheduleUpdatesPerCreation:    info.ScenarioOptionInt(ScheduleUpdatesPerCreationFlag, DefaultScheduleUpdatesPerCreation),
-		SchedulerDurationPerIteration: info.ScenarioOptionDuration(SchedulerDurationPerIterationFlag, DefaultSchedulerDurationPerIteration),
-		PayloadSize:                   info.ScenarioOptionInt(PayloadSizeFlag, DefaultPayloadSize),
-		WaitTimeBeforeCleanup:         info.ScenarioOptionDuration(WaitTimeBeforeCleanupFlag, DefaultWaitTimeBeforeCleanup),
-		OperationInterval:             info.ScenarioOptionDuration(OperationIntervalFlag, DefaultOperationInterval),
-		CronExpression:                info.ScenarioOptionString(CronExpressionFlag, DefaultCronExpression),
-		OverlapPolicy:                 parseOverlapPolicy(info.ScenarioOptionString(OverlapPolicyFlag, DefaultOverlapPolicy)),
-		ScheduledWorkflowType:         info.ScenarioOptionString(ScheduledWorkflowTypeFlag, DefaultScheduledWorkflowType),
-		EnableChasmScheduler:          info.ScenarioOptionBool(EnableChasmSchedulerFlag, DefaultEnableChasmScheduler),
+		ScheduleCreationPerIteration:  info.OptionInt(ScheduleCreationPerIterationFlag),
+		ScheduleReadsPerCreation:      info.OptionInt(ScheduleReadsPerCreationFlag),
+		ScheduleUpdatesPerCreation:    info.OptionInt(ScheduleUpdatesPerCreationFlag),
+		SchedulerDurationPerIteration: info.OptionDuration(SchedulerDurationPerIterationFlag),
+		PayloadSize:                   info.OptionInt(PayloadSizeFlag),
+		WaitTimeBeforeCleanup:         info.OptionDuration(WaitTimeBeforeCleanupFlag),
+		OperationInterval:             info.OptionDuration(OperationIntervalFlag),
+		CronExpression:                info.OptionString(CronExpressionFlag),
+		OverlapPolicy:                 parseOverlapPolicy(info.OptionString(OverlapPolicyFlag)),
+		ScheduledWorkflowType:         info.OptionString(ScheduledWorkflowTypeFlag),
+		EnableChasmScheduler:          info.OptionBool(EnableChasmSchedulerFlag),
 	}
 
 	if config.ScheduleCreationPerIteration <= 0 {

--- a/scenarios/serverless_burst.go
+++ b/scenarios/serverless_burst.go
@@ -59,9 +59,9 @@ func init() {
 					},
 				},
 				PrepareTestInput: func(_ context.Context, info loadgen.ScenarioInfo, params *TestInput) error {
-					fastCount := info.ScenarioOptionInt(sbFastActivityCountFlag, 5)
-					slowCount := info.ScenarioOptionInt(sbSlowActivityCountFlag, 2)
-					slowDuration := info.ScenarioOptionDuration(sbSlowActivityDuration, 2*time.Second)
+					fastCount := info.OptionInt(sbFastActivityCountFlag)
+					slowCount := info.OptionInt(sbSlowActivityCountFlag)
+					slowDuration := info.OptionDuration(sbSlowActivityDuration)
 
 					// StartToCloseTimeout must exceed the activity's own sleep duration.
 					slowTimeout := max(60*time.Second, slowDuration*2)

--- a/scenarios/serverless_burst.go
+++ b/scenarios/serverless_burst.go
@@ -45,10 +45,12 @@ func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "Burst workload for serverless workers: each iteration runs a workflow with " +
 			"concurrent fast (noop) and slow (delay) activities. Tests auto-scale speed from zero " +
-			"and sustained throughput under mixed I/O and compute load. " +
-			"Options: " + sbFastActivityCountFlag + " (default 5), " +
-			sbSlowActivityCountFlag + " (default 2), " +
-			sbSlowActivityDuration + " (default 2s).",
+			"and sustained throughput under mixed I/O and compute load.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(sbFastActivityCountFlag, 5, "Concurrent noop activities per iteration.")
+			o.Int(sbSlowActivityCountFlag, 2, "Concurrent delay activities per iteration.")
+			o.Duration(sbSlowActivityDuration, 2*time.Second, "How long each delay activity sleeps.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &TestInput{

--- a/scenarios/serverless_burst_test.go
+++ b/scenarios/serverless_burst_test.go
@@ -34,11 +34,11 @@ func TestServerlessBurst(t *testing.T) {
 					completed.Add(1)
 				},
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("serverless_burst", map[string]string{
 				sbFastActivityCountFlag: "5",
 				sbSlowActivityCountFlag: "2",
 				sbSlowActivityDuration:  "2s",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 		require.EqualValues(t, 3, completed.Load())
@@ -57,11 +57,11 @@ func TestServerlessBurst(t *testing.T) {
 					completed.Add(1)
 				},
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("serverless_burst", map[string]string{
 				sbFastActivityCountFlag: "3",
 				sbSlowActivityCountFlag: "1",
 				sbSlowActivityDuration:  "100ms",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 		require.EqualValues(t, 3, completed.Load())
@@ -80,10 +80,10 @@ func TestServerlessBurst(t *testing.T) {
 					completed.Add(1)
 				},
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("serverless_burst", map[string]string{
 				sbFastActivityCountFlag: "5",
 				sbSlowActivityCountFlag: "0",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 		require.EqualValues(t, 3, completed.Load())
@@ -102,11 +102,11 @@ func TestServerlessBurst(t *testing.T) {
 					completed.Add(1)
 				},
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("serverless_burst", map[string]string{
 				sbFastActivityCountFlag: "0",
 				sbSlowActivityCountFlag: "2",
 				sbSlowActivityDuration:  "200ms",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 		require.EqualValues(t, 2, completed.Load())

--- a/scenarios/state_transitions_steady.go
+++ b/scenarios/state_transitions_steady.go
@@ -13,10 +13,13 @@ import (
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: "Run a certain number of state transitions per second. This requires duration option to be set " +
-			"and the state-transitions-per-second scenario option to be set. Any iteration configuration is ignored. For " +
-			"example, can be run with: run-scenario-with-worker --scenario state_transitions_steady --language go " +
-			"--embedded-server --duration 5m --option state-transitions-per-second=3",
+		Description: "Run a certain number of state transitions per second. Requires --duration; any iteration " +
+			"configuration is ignored. For example: run-scenario-with-worker --scenario state_transitions_steady " +
+			"--language go --embedded-server --duration 5m --option state-transitions-per-second=3",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int("state-transitions-per-second", 0, "State transitions to sustain per second.")
+			o.MarkRequired("state-transitions-per-second")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.ExecutorFunc(func(ctx context.Context, runOptions loadgen.ScenarioInfo) error {
 				return (&stateTransitionsSteady{runOptions}).run(ctx)

--- a/scenarios/state_transitions_steady.go
+++ b/scenarios/state_transitions_steady.go
@@ -42,7 +42,7 @@ func (s *stateTransitionsSteady) run(ctx context.Context) error {
 	if s.Configuration.Duration == 0 {
 		return fmt.Errorf("duration required for this scenario")
 	}
-	stateTransitionsPerSecond := s.ScenarioOptionInt("state-transitions-per-second", 0)
+	stateTransitionsPerSecond := s.OptionInt("state-transitions-per-second")
 	if stateTransitionsPerSecond == 0 {
 		return fmt.Errorf("state-transitions-per-second scenario option required")
 	}

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -105,9 +105,22 @@ var _ loadgen.Configurable = (*tpsExecutor)(nil)
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: fmt.Sprintf(
-			"Throughput stress scenario. Use --option with '%s', '%s', '%s', '%s', '%s', '%s', '%s' to control internal parameters",
-			IterFlag, ContinueAsNewAfterIterFlag, IncludeRetryScenariosFlag, IncludeDescribeFlag, IncludeStandaloneNexusFlag, IncludeStandaloneActivityFlag, PayloadDistributionJsonFlag),
+		Description: "Throughput stress scenario.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(IterFlag, 10, "Internal iterations per workflow.")
+			o.Duration(IterTimeoutFlag, 0, "Timeout for internal iterations; defaults to the run duration plus a minute.")
+			o.Int(ContinueAsNewAfterIterFlag, 3, "Internal iterations before continue-as-new.")
+			o.Duration(SleepTimeFlag, time.Second, "How long each sleep activity sleeps.")
+			o.String(NexusEndpointFlag, "", "Nexus endpoint to exercise; empty disables Nexus operations.")
+			o.Duration(VisibilityVerificationTimeoutFlag, 3*time.Minute, "Timeout for the post-run visibility count check.")
+			o.String(SleepActivityJsonFlag, "", "JSON sleep-activity configuration; use @<file> to read from a file.")
+			o.Float64(MinThroughputPerHourFlag, 0, "Fail the run below this workflows-per-hour rate (0 disables).")
+			o.Bool(IncludeRetryScenariosFlag, false, "Include activities that exercise retries.")
+			o.Bool(IncludeDescribeFlag, false, "Include DescribeWorkflowExecution calls.")
+			o.Bool(IncludeStandaloneNexusFlag, false, "Include standalone Nexus operations.")
+			o.Bool(IncludeStandaloneActivityFlag, false, "Include standalone activities; requires server support.")
+			o.String(PayloadDistributionJsonFlag, "", "JSON payload-size distribution; use @<file> to read from a file.")
+		},
 		ExecutorFn: func() loadgen.Executor { return newThroughputStressExecutor() },
 	})
 }

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -162,10 +162,10 @@ func (t *tpsExecutor) LoadState(loader func(any) error) error {
 // Configure initializes tpsConfig. Largely, it reads and validates throughput_stress scenario options
 func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config := &tpsConfig{
-		InternalIterTimeout:  info.ScenarioOptionDuration(IterTimeoutFlag, cmp.Or(info.Configuration.Duration+1*time.Minute, 1*time.Minute)),
-		NexusEnabled:         info.ScenarioOptionBool(NexusEnabledFlag, false),
-		NexusEndpoint:        info.ScenarioOptions[NexusEndpointFlag],
-		MinThroughputPerHour: info.ScenarioOptionFloat(MinThroughputPerHourFlag, 0),
+		InternalIterTimeout:  info.OptionDuration(IterTimeoutFlag),
+		NexusEnabled:         info.OptionBool(NexusEnabledFlag),
+		NexusEndpoint:        info.OptionString(NexusEndpointFlag),
+		MinThroughputPerHour: info.OptionFloat64(MinThroughputPerHourFlag),
 		ScenarioRunID:        info.RunID,
 		ExecutionID:          info.ExecutionID,
 	}
@@ -175,50 +175,51 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	h.Write([]byte(info.RunID))
 	config.RngSeed = int64(h.Sum64())
 
-	config.SleepTime = info.ScenarioOptionDuration(SleepTimeFlag, 1*time.Second)
+	config.SleepTime = info.OptionDuration(SleepTimeFlag)
 	if config.SleepTime <= 0 {
 		return fmt.Errorf("%s must be positive, got %v", SleepTimeFlag, config.SleepTime)
 	}
 
-	config.InternalIterations = info.ScenarioOptionInt(IterFlag, 10)
+	config.InternalIterations = info.OptionInt(IterFlag)
 	if config.InternalIterations <= 0 {
 		return fmt.Errorf("internal-iterations must be positive, got %d", config.InternalIterations)
 	}
 
-	config.ContinueAsNewAfterIter = info.ScenarioOptionInt(ContinueAsNewAfterIterFlag, 3)
+	config.ContinueAsNewAfterIter = info.OptionInt(ContinueAsNewAfterIterFlag)
 	if config.ContinueAsNewAfterIter < 0 {
 		return fmt.Errorf("continue-as-new-after-iterations must be non-negative, got %d", config.ContinueAsNewAfterIter)
 	}
 
-	if sleepActivitiesStr, ok := info.ScenarioOptions[SleepActivityJsonFlag]; ok {
-		var err error
+	// The declared default is 0, meaning derive the timeout from the run.
+	if config.InternalIterTimeout == 0 {
+		config.InternalIterTimeout = cmp.Or(info.Configuration.Duration+time.Minute, time.Minute)
+	}
+
+	var err error
+	if sleepActivitiesStr := info.OptionString(SleepActivityJsonFlag); sleepActivitiesStr != "" {
 		config.SleepActivities, err = loadgen.ParseAndValidateSleepActivityConfig(sleepActivitiesStr, true, true)
 		if err != nil {
 			return fmt.Errorf("invalid %s: %w", SleepActivityJsonFlag, err)
 		}
 	}
 
-	var err error
-	config.VisibilityVerificationTimeout, err = time.ParseDuration(cmp.Or(info.ScenarioOptions[VisibilityVerificationTimeoutFlag], "3m"))
-	if err != nil {
-		return fmt.Errorf("invalid %s: %w", VisibilityVerificationTimeoutFlag, err)
-	}
+	config.VisibilityVerificationTimeout = info.OptionDuration(VisibilityVerificationTimeoutFlag)
 	if config.VisibilityVerificationTimeout <= 0 {
 		return fmt.Errorf("%s must be positive, got %v", VisibilityVerificationTimeoutFlag, config.VisibilityVerificationTimeout)
 	}
 
-	config.IncludeRetryScenarios = info.ScenarioOptionBool(IncludeRetryScenariosFlag, false)
-	config.IncludeDescribe = info.ScenarioOptionBool(IncludeDescribeFlag, false)
-	config.IncludeStandaloneNexus = info.ScenarioOptionBool(IncludeStandaloneNexusFlag, false)
+	config.IncludeRetryScenarios = info.OptionBool(IncludeRetryScenariosFlag)
+	config.IncludeDescribe = info.OptionBool(IncludeDescribeFlag)
+	config.IncludeStandaloneNexus = info.OptionBool(IncludeStandaloneNexusFlag)
 	if config.IncludeStandaloneNexus && !config.NexusEnabled {
 		return fmt.Errorf("%s requires %s", IncludeStandaloneNexusFlag, NexusEnabledFlag)
 	}
 	if config.NexusEndpoint != "" && !config.NexusEnabled {
 		return fmt.Errorf("%s was set but %s is false", NexusEndpointFlag, NexusEnabledFlag)
 	}
-	config.IncludeStandaloneActivity = info.ScenarioOptionBool(IncludeStandaloneActivityFlag, false)
+	config.IncludeStandaloneActivity = info.OptionBool(IncludeStandaloneActivityFlag)
 
-	if payloadStr, ok := info.ScenarioOptions[PayloadDistributionJsonFlag]; ok {
+	if payloadStr := info.OptionString(PayloadDistributionJsonFlag); payloadStr != "" {
 		config.Payload, err = loadgen.ParseAndValidatePayloadConfig(payloadStr)
 		if err != nil {
 			return fmt.Errorf("invalid %s: %w", PayloadDistributionJsonFlag, err)

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -28,7 +28,11 @@ const (
 	ContinueAsNewAfterIterFlag = "continue-as-new-after-iterations"
 	// SleepTimeFlag controls the duration used for internal timer-based sleep actions (e.g. signal/update timers).
 	// Default is 1s.
-	SleepTimeFlag     = "sleep-time"
+	SleepTimeFlag = "sleep-time"
+	// NexusEnabledFlag turns Nexus operations on.
+	NexusEnabledFlag = "nexus-enabled"
+	// NexusEndpointFlag names the Nexus endpoint to use. Empty means one is created
+	// for this run. Only consulted when NexusEnabledFlag is set.
 	NexusEndpointFlag = "nexus-endpoint"
 	// VisibilityVerificationTimeoutFlag is the timeout for verifying the total visibility count at the end of the scenario.
 	// It needs to account for a backlog of tasks and, if used, ElasticSearch's eventual consistency.
@@ -76,6 +80,7 @@ type tpsConfig struct {
 	InternalIterations            int
 	InternalIterTimeout           time.Duration
 	ContinueAsNewAfterIter        int
+	NexusEnabled                  bool
 	NexusEndpoint                 string
 	SleepTime                     time.Duration
 	SleepActivities               *loadgen.SleepActivityConfig
@@ -108,10 +113,11 @@ func init() {
 		Description: "Throughput stress scenario.",
 		Options: func(o *loadgen.OptionSet) {
 			o.Int(IterFlag, 10, "Internal iterations per workflow.")
-			o.Duration(IterTimeoutFlag, 0, "Timeout for internal iterations; defaults to the run duration plus a minute.")
+			o.Duration(IterTimeoutFlag, 0, "Timeout for internal iterations. 0 means auto: the run duration plus a minute.")
 			o.Int(ContinueAsNewAfterIterFlag, 3, "Internal iterations before continue-as-new.")
 			o.Duration(SleepTimeFlag, time.Second, "How long each sleep activity sleeps.")
-			o.String(NexusEndpointFlag, "", "Nexus endpoint to exercise; empty disables Nexus operations.")
+			o.Bool(NexusEnabledFlag, false, "Include Nexus operations.")
+			o.String(NexusEndpointFlag, "", "Nexus endpoint to use when Nexus is enabled. Empty creates one for this run.")
 			o.Duration(VisibilityVerificationTimeoutFlag, 3*time.Minute, "Timeout for the post-run visibility count check.")
 			o.String(SleepActivityJsonFlag, "", "JSON sleep-activity configuration; use @<file> to read from a file.")
 			o.Float64(MinThroughputPerHourFlag, 0, "Fail the run below this workflows-per-hour rate (0 disables).")
@@ -157,6 +163,7 @@ func (t *tpsExecutor) LoadState(loader func(any) error) error {
 func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config := &tpsConfig{
 		InternalIterTimeout:  info.ScenarioOptionDuration(IterTimeoutFlag, cmp.Or(info.Configuration.Duration+1*time.Minute, 1*time.Minute)),
+		NexusEnabled:         info.ScenarioOptionBool(NexusEnabledFlag, false),
 		NexusEndpoint:        info.ScenarioOptions[NexusEndpointFlag],
 		MinThroughputPerHour: info.ScenarioOptionFloat(MinThroughputPerHourFlag, 0),
 		ScenarioRunID:        info.RunID,
@@ -203,8 +210,11 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config.IncludeRetryScenarios = info.ScenarioOptionBool(IncludeRetryScenariosFlag, false)
 	config.IncludeDescribe = info.ScenarioOptionBool(IncludeDescribeFlag, false)
 	config.IncludeStandaloneNexus = info.ScenarioOptionBool(IncludeStandaloneNexusFlag, false)
-	if config.IncludeStandaloneNexus && config.NexusEndpoint == "" {
-		return fmt.Errorf("%s requires %s to be set", IncludeStandaloneNexusFlag, NexusEndpointFlag)
+	if config.IncludeStandaloneNexus && !config.NexusEnabled {
+		return fmt.Errorf("%s requires %s", IncludeStandaloneNexusFlag, NexusEnabledFlag)
+	}
+	if config.NexusEndpoint != "" && !config.NexusEnabled {
+		return fmt.Errorf("%s was set but %s is false", NexusEndpointFlag, NexusEnabledFlag)
 	}
 	config.IncludeStandaloneActivity = info.ScenarioOptionBool(IncludeStandaloneActivityFlag, false)
 
@@ -232,6 +242,17 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 		return fmt.Errorf("failed to parse scenario configuration: %w", err)
 	}
 	t.runID = info.RunID
+
+	// Creating the endpoint needs a context, so it happens here rather than in
+	// Configure.
+	if t.config.NexusEnabled && t.config.NexusEndpoint == "" {
+		endpoint, err := info.EnsureNexusEndpoint(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create nexus endpoint: %w", err)
+		}
+		t.config.NexusEndpoint = endpoint
+		info.Logger.Infof("Using nexus endpoint %q", endpoint)
+	}
 
 	// Track start time of current run
 	currentRunStartTime := time.Now()
@@ -507,7 +528,7 @@ func (t *tpsExecutor) createActionsChunk(
 		}
 
 		// Add Nexus operations, if configured.
-		if t.config.NexusEndpoint != "" {
+		if t.config.NexusEnabled {
 			asyncActions = append(asyncActions, t.createNexusEchoSyncAction())
 			asyncActions = append(asyncActions, t.createNexusEchoAsyncAction())
 			asyncActions = append(asyncActions, t.createNexusWaitForCancelAction())

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -29,13 +29,14 @@ func TestThroughputStress(t *testing.T) {
 		Configuration: loadgen.RunConfiguration{
 			Iterations: 2,
 		},
-		ScenarioOptions: map[string]string{
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
 			IterFlag:                          "2",
 			ContinueAsNewAfterIterFlag:        "1",
+			NexusEnabledFlag:                  "true",
 			NexusEndpointFlag:                 env.NexusEndpointName(),
 			SleepTimeFlag:                     "1ms", // reduce to safe time
 			VisibilityVerificationTimeoutFlag: "10s", // lower timeout to fail fast
-		},
+		}),
 	}
 
 	t.Run("Run executor", func(t *testing.T) {
@@ -83,9 +84,9 @@ func TestThroughputStressConfigurePayload(t *testing.T) {
 	executor := newThroughputStressExecutor()
 	info := loadgen.ScenarioInfo{
 		RunID: "tps-payload",
-		ScenarioOptions: map[string]string{
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
 			PayloadDistributionJsonFlag: `{"size":{"type":"discrete","weights":{"1024":1}}}`,
-		},
+		}),
 	}
 	require.NoError(t, executor.Configure(info))
 	require.NotNil(t, executor.config.Payload)
@@ -99,7 +100,10 @@ func TestThroughputStressConfigureNoPayload(t *testing.T) {
 
 	// Without the option, payload sizing falls back to the previous hardcoded 256.
 	executor := newThroughputStressExecutor()
-	require.NoError(t, executor.Configure(loadgen.ScenarioInfo{RunID: "tps-no-payload"}))
+	require.NoError(t, executor.Configure(loadgen.ScenarioInfo{
+		RunID:   "tps-no-payload",
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", nil),
+	}))
 	require.Nil(t, executor.config.Payload)
 	require.Equal(t, 256, executor.samplePayloadSize(rand.New(rand.NewSource(1))))
 }
@@ -110,9 +114,9 @@ func TestThroughputStressConfigureInvalidPayload(t *testing.T) {
 	executor := newThroughputStressExecutor()
 	info := loadgen.ScenarioInfo{
 		RunID: "tps-payload-invalid",
-		ScenarioOptions: map[string]string{
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
 			PayloadDistributionJsonFlag: `{"size":{"type":"bogus"}}`,
-		},
+		}),
 	}
 	require.Error(t, executor.Configure(info))
 }
@@ -129,11 +133,11 @@ func TestThroughputStressPayloadSequenceAcrossContinueAsNew(t *testing.T) {
 		RunID:       "tps-can-seq",
 		ExecutionID: "exec",
 		Logger:      zap.NewNop().Sugar(),
-		ScenarioOptions: map[string]string{
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
 			IterFlag:                    "4", // > ContinueAsNewAfterIter, so chunks are nested via CAN
 			ContinueAsNewAfterIterFlag:  "1",
 			PayloadDistributionJsonFlag: `{"size":{"type":"uniform","min":"1","max":"1000000"}}`,
-		},
+		}),
 	}
 	require.NoError(t, executor.Configure(info))
 

--- a/scenarios/workflow_on_many_task_queues.go
+++ b/scenarios/workflow_on_many_task_queues.go
@@ -11,8 +11,11 @@ import (
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
 		Description: "Each iteration executes a single workflow on one of the task queues. " +
-			"Workers must be started with --task-queue-suffix-index-end as one less than task queue count here. " +
-			"Additional options: task-queue-count (required).",
+			"Workers must be started with --task-queue-suffix-index-end as one less than task queue count here.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int("task-queue-count", 0, "Number of task queues to spread iterations across.")
+			o.MarkRequired("task-queue-count")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &kitchensink.TestInput{
@@ -21,13 +24,6 @@ func init() {
 							kitchensink.NoOpSingleActivityActionSet(),
 						},
 					},
-				},
-				PrepareTestInput: func(ctx context.Context, opts loadgen.ScenarioInfo, params *kitchensink.TestInput) error {
-					// Require task queue count
-					if opts.ScenarioOptionInt("task-queue-count", 0) == 0 {
-						return fmt.Errorf("task-queue-count option required")
-					}
-					return nil
 				},
 				UpdateWorkflowOptions: func(ctx context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
 					// Add suffix to the task queue based on modulus of iteration

--- a/scenarios/workflow_on_many_task_queues.go
+++ b/scenarios/workflow_on_many_task_queues.go
@@ -28,7 +28,7 @@ func init() {
 				UpdateWorkflowOptions: func(ctx context.Context, run *loadgen.Run, options *loadgen.KitchenSinkWorkflowOptions) error {
 					// Add suffix to the task queue based on modulus of iteration
 					options.StartOptions.TaskQueue +=
-						fmt.Sprintf("-%v", run.Iteration%run.ScenarioInfo.ScenarioOptionInt("task-queue-count", 0))
+						fmt.Sprintf("-%v", run.Iteration%run.ScenarioInfo.OptionInt("task-queue-count"))
 					return nil
 				},
 			}

--- a/scenarios/workflow_with_many_actions.go
+++ b/scenarios/workflow_with_many_actions.go
@@ -35,8 +35,8 @@ func init() {
 						append(params.WorkflowInput.InitialActions, actionSet)
 
 					// Get options
-					children := opts.ScenarioOptionInt("children-per-workflow", 30)
-					activities := opts.ScenarioOptionInt("activities-per-workflow", 30)
+					children := opts.OptionInt("children-per-workflow")
+					activities := opts.OptionInt("activities-per-workflow")
 					opts.Logger.Infof("Preparing to run with %v child workflow(s) and %v activity execution(s)", children, activities)
 
 					childInput, err := converter.GetDefaultDataConverter().ToPayload(

--- a/scenarios/workflow_with_many_actions.go
+++ b/scenarios/workflow_with_many_actions.go
@@ -13,8 +13,11 @@ import (
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: "Each iteration executes a single workflow with a number of child workflows and/or activities. " +
-			"Additional options: children-per-workflow (default 30), activities-per-workflow (default 30).",
+		Description: "Each iteration executes a single workflow with a number of child workflows and/or activities.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int("children-per-workflow", 30, "Number of child workflows started per iteration.")
+			o.Int("activities-per-workflow", 30, "Number of activities executed per iteration.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &kitchensink.TestInput{

--- a/scenarios/workflow_with_many_timers.go
+++ b/scenarios/workflow_with_many_timers.go
@@ -33,14 +33,13 @@ const (
 
 func init() {
 	loadgen.MustRegisterScenario(loadgen.Scenario{
-		Description: fmt.Sprintf(
-			"Run workflows that hold many concurrent active timers. "+
-				"Options: '%s' (default 30), '%s' (default 10s), '%s' (default 0), '%s' (default 1).",
-			manyTimersConcurrentTimersFlag,
-			manyTimersTimerDurationFlag,
-			manyTimersTimerJitterFlag,
-			manyTimersIterationsFlag,
-		),
+		Description: "Run workflows that hold many concurrent active timers.",
+		Options: func(o *loadgen.OptionSet) {
+			o.Int(manyTimersConcurrentTimersFlag, 30, "Concurrent active timers per workflow.")
+			o.Duration(manyTimersTimerDurationFlag, 10*time.Second, "Base duration of each timer.")
+			o.Duration(manyTimersTimerJitterFlag, 0, "Random jitter added to each timer duration.")
+			o.Int(manyTimersIterationsFlag, 1, "Timer rounds per workflow.")
+		},
 		ExecutorFn: func() loadgen.Executor {
 			return loadgen.KitchenSinkExecutor{
 				TestInput: &kitchensink.TestInput{

--- a/scenarios/workflow_with_many_timers.go
+++ b/scenarios/workflow_with_many_timers.go
@@ -69,10 +69,10 @@ type manyTimersConfig struct {
 
 func parseManyTimersConfig(info *loadgen.ScenarioInfo) (*manyTimersConfig, error) {
 	cfg := &manyTimersConfig{
-		concurrentTimers: info.ScenarioOptionInt(manyTimersConcurrentTimersFlag, 30),
-		timerDuration:    info.ScenarioOptionDuration(manyTimersTimerDurationFlag, 10*time.Second),
-		timerJitter:      info.ScenarioOptionDuration(manyTimersTimerJitterFlag, 0),
-		iterations:       info.ScenarioOptionInt(manyTimersIterationsFlag, 1),
+		concurrentTimers: info.OptionInt(manyTimersConcurrentTimersFlag),
+		timerDuration:    info.OptionDuration(manyTimersTimerDurationFlag),
+		timerJitter:      info.OptionDuration(manyTimersTimerJitterFlag),
+		iterations:       info.OptionInt(manyTimersIterationsFlag),
 	}
 	if cfg.concurrentTimers <= 0 {
 		return nil, fmt.Errorf("%s must be > 0, got %d", manyTimersConcurrentTimersFlag, cfg.concurrentTimers)

--- a/scenarios/workflow_with_many_timers_test.go
+++ b/scenarios/workflow_with_many_timers_test.go
@@ -15,7 +15,7 @@ func TestWorkflowWithManyTimers_ParseConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("defaults", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{}}
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("workflow_with_many_timers", nil)}
 		cfg, err := parseManyTimersConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, 30, cfg.concurrentTimers)
@@ -25,12 +25,12 @@ func TestWorkflowWithManyTimers_ParseConfig(t *testing.T) {
 	})
 
 	t.Run("overrides", func(t *testing.T) {
-		info := &loadgen.ScenarioInfo{ScenarioOptions: map[string]string{
+		info := &loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("workflow_with_many_timers", map[string]string{
 			manyTimersConcurrentTimersFlag: "4",
 			manyTimersTimerDurationFlag:    "10ms",
 			manyTimersTimerJitterFlag:      "5ms",
 			manyTimersIterationsFlag:       "3",
-		}}
+		})}
 		cfg, err := parseManyTimersConfig(info)
 		require.NoError(t, err)
 		require.Equal(t, 4, cfg.concurrentTimers)
@@ -48,7 +48,7 @@ func TestWorkflowWithManyTimers_ParseConfig(t *testing.T) {
 		}
 		for name, opts := range cases {
 			t.Run(name, func(t *testing.T) {
-				_, err := parseManyTimersConfig(&loadgen.ScenarioInfo{ScenarioOptions: opts})
+				_, err := parseManyTimersConfig(&loadgen.ScenarioInfo{Options: loadgen.MustResolveScenarioOptions("workflow_with_many_timers", opts)})
 				require.Error(t, err)
 			})
 		}
@@ -139,11 +139,11 @@ func TestWorkflowWithManyTimers(t *testing.T) {
 				Iterations:    3,
 				MaxConcurrent: 3,
 			},
-			ScenarioOptions: map[string]string{
+			Options: loadgen.MustResolveScenarioOptions("workflow_with_many_timers", map[string]string{
 				manyTimersConcurrentTimersFlag: "5",
 				manyTimersTimerDurationFlag:    "10ms",
 				manyTimersIterationsFlag:       "2",
-			},
+			}),
 		}, clioptions.LangGo)
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
> **Stacked on #434** — review/merge that first. This PR's base is `lilydoar/omes-docs-authoring`, so the diff here is only this change. GitHub retargets the base to `main` when #434 merges.

Scenario options were an untyped map. A scenario read `--option` values lazily with an inline default, so nothing knew which options existed:

- A malformed value **panicked** from inside the run (`--option children-per-workflow=abc` → stack trace).
- An unknown or misspelled name was **silently ignored** — the run proceeded at the default, quietly producing a differently-shaped load than asked for.
- `list-scenarios` had nothing to show, so options were undiscoverable without reading source. Several scenarios worked around that by listing options in prose in their `Description`, which then drifted from the code.
- A default lived in **two** places — the declaration and the inline argument at every read site — with nothing keeping them in sync.

Three commits, each reviewable on its own.

## 1. Declare options with pflag — `d5a52c6`

```go
Options: func(o *loadgen.OptionSet) {
    o.Int("children-per-workflow", 30, "Child workflows per iteration.")
    o.Int("task-queue-count", 0, "Task queues to spread iterations across.")
    o.MarkRequired("task-queue-count")
},
```

`OptionSet` embeds a `pflag.FlagSet` — already a dependency for omes's own CLI flags — so every typed registrar, the type checking, and default rendering come from pflag rather than a bespoke type and parser. `loadgen` adds only `MarkRequired`, and phrases errors in terms of `--option name=value` instead of pflag's `--flag`.

```
$ omes run-scenario --scenario throughput_stress --run-id t --option sleep-tim=5s
invalid --option values for scenario "throughput_stress":
unknown option "sleep-tim"; this scenario accepts: continue-as-new-after-iterations, include-describe, ...

$ omes run-scenario --scenario project --run-id t
invalid --option values for scenario "project":
option "language" is required
option "project-name" is required
```

- Unknown names rejected, listing what the scenario does accept.
- Malformed values rejected **before the client dial**, with every problem reported at once instead of one per attempt.
- `list-scenarios` shows each option's type, default, requiredness, and usage.
- A rejected option prints as a plain usage error via a typed `InvalidOptionsError`, not a fatal-level stack trace. Genuine run failures keep the existing fatal path.
- `Scenario.DefaultConfiguration` supersedes the `HasDefaultConfiguration` executor interface, which **no in-repo scenario implemented** — which is why `list-scenarios` never printed default configuration for any of them. The interface still works.

All 13 option-using scenarios are migrated, and the prose option lists in their `Description`s are removed now that `list-scenarios` renders the real thing.

## 2. Make the declarations honest — `9846967`

Declaring surfaced four options whose declared default could not describe what the code did. Each is fixed at the source rather than documented around.

**`internal-iterations-timeout` has a computed default** (run duration + 1 minute), which no static default can express. `0` stays the sentinel and the usage string now says what `0` means.

**`nexus-endpoint` meant two opposite things** — in `throughput_stress` an empty value disabled Nexus; in `fuzzer` it meant "create an endpoint for this run". The enabled/disabled concept is now its own flag:

- `throughput_stress` gains `nexus-enabled` (default `false`, preserving Nexus being off unless asked for).
- `nexus-endpoint` means the same thing everywhere: empty creates one for this run.
- `include-standalone-nexus` requires `nexus-enabled` rather than a non-empty endpoint — what it always meant.
- Supplying an endpoint while `nexus-enabled` is false is an error instead of being silently ignored.

Nexus stays structural in `fuzzer`, so it gets no `nexus-enabled` flag; a switch that cannot be turned off is worse than none. Creating the endpoint needs a context, so `throughput_stress` resolves it in `Run` rather than `Configure`, via a new `ScenarioInfo.EnsureNexusEndpoint`.

**`phase-time` is deleted** — a deprecated alias whose value became `period`'s default, the one case of an option feeding another option's default. Both defaults were already `60s`, so nobody relying on the default is affected, and anyone passing it explicitly now gets an error naming `period` instead of silence.

**`no-output-file` becomes `output-file`** — a path rather than a negated boolean. It was previously checked by key *presence*, so `no-output-file=false` skipped the file anyway. Default is the same file, empty writes nothing, and the path is now configurable.

## 3. Read from the declarations, drop the map — `b7e2740`

Declarations are now the only home for a default. `ScenarioInfo` carries the resolved `OptionSet` instead of a `map[string]string`, and the accessors take no default:

```go
children := info.OptionInt("children-per-workflow")
```

Values arrive from pflag already typed, so scenarios no longer parse strings themselves. Two sites that had been hand-parsing are plain reads now: `throughput_stress`'s `visibility-count-timeout` (was `ParseDuration` over a `cmp.Or`-defaulted string, with its own error branch) and `project`'s `project-server-ready-timeout`.

Where a default genuinely cannot be a constant, the sentinel is resolved explicitly in code rather than hidden in an accessor argument.

Tests build their options with `loadgen.MustResolveScenarioOptions`, which resolves through the scenario's real declarations — so a test that misspells an option now fails instead of quietly exercising a default. That caught a `throughput_stress` fixture setting `nexus-endpoint` without `nexus-enabled`.

## Breaking changes

- **Declaration is mandatory.** A scenario accepts exactly what it declares, so passing an option to a scenario that declares none is an error naming the scenario. Scenarios outside this repository must declare their options to read them — they fail to *compile* rather than silently reading zero values.
- **`ScenarioInfo.ScenarioOptions` and the `ScenarioOption*` accessors are gone**, replaced by `ScenarioInfo.Options` and `Option*`.
- **Renamed/removed options:** `no-output-file` → `output-file`; `phase-time` deleted; `nexus-endpoint` on `throughput_stress` now requires `nexus-enabled`.

## Downstream

`saas-cicd` vendors omes as a library and builds `ScenarioInfo` itself, so it needs three matching adjustments — the resolved-options call, `nexus-enabled` alongside the endpoint it already injects, and `output-file` instead of `no-output-file`. Those are written on `lilydoar/omes-option-api-bump` and must land together with the omes pin bump, since they don't compile against the currently pinned omes.

## Verification

`go test ./loadgen ./scenarios/...` passes; build and `gofmt` clean. End-to-end checks against a real CLI and an embedded server: typo rejection, type errors, required options, the `nexus-enabled` guard, the deleted `phase-time` alias, a scenario declaring no options rejecting one, and a run with no options completing on declared defaults.

`TestKitchenSink` is excluded above because it fails identically on unmodified `main` in my environment — it builds a real dev server plus language-SDK workers. CI is the gate for it.
