### PR TITLE
docs: correct the option-validation gotcha

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -122,8 +122,8 @@ go run ./cmd/omes run-scenario-with-worker \
 - **Language names and aliases.** `--language` accepts `go`, `python` (`py`), `java`, `typescript`
   (`ts`), `dotnet` (`cs`), `ruby` (`rb`). If you pass an unknown value the error message lists the
   accepted set.
-- **Option validation depends on the scenario declaring its options.** When a scenario declares them
-  (most do), an unknown name or a malformed value is rejected before the run starts, and
-  `list-scenarios` shows you what it accepts. A scenario that declares none accepts any option name and
-  parses values on first read, so a typo there is silently ignored and the default is used.
+- **A scenario accepts exactly the options it declares.** An unknown name or a value of the wrong type
+  is rejected before the run starts — before omes even connects — and every problem is reported at once.
+  `list-scenarios` shows what each scenario accepts, including defaults. A scenario that declares no
+  options accepts none.
 - **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected at run time.


### PR DESCRIPTION
`docs/running.md` still described the halfway state of the option work, from before declaration became mandatory in #435:

> A scenario that declares none accepts any option name and parses values on first read, so a typo there is silently ignored and the default is used.

That is no longer true — and it advertises the exact silent-misconfiguration trap #435 removed. The shipped code says the opposite:

```
$ omes run-scenario --scenario workflow_with_single_noop_activity --run-id t --option anything=1
invalid --option values for scenario "workflow_with_single_noop_activity":
unknown option "anything"; this scenario accepts no options
```

Replaces it with what actually happens. Each claim in the new text was checked against the CLI rather than reasoned about:

```
$ omes run-scenario --scenario throughput_stress --run-id t --option internal-iterations=lots --option bogus=1
invalid --option values for scenario "throughput_stress":
unknown option "bogus"; this scenario accepts: continue-as-new-after-iterations, include-describe, ...
option "internal-iterations" expects type int, got "lots"
```

— confirming "accepts none", "rejected before omes connects", and "every problem reported at once".

Docs only, one paragraph. I also swept the other omes docs for the same stale claim; this was the only instance.