### PR TITLE
Report bad input as a message, and show which config channel each knob belongs to

### DIFF
--- a/cmd/omes/cleanup_scenario.go
+++ b/cmd/omes/cleanup_scenario.go
@@ -23,12 +23,13 @@ func cleanupScenarioCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cleanup-scenario",
 		Short: "Cleanup scenario",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			c.logger = c.loggingOptions.MustCreateLogger()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
-			if err := c.run(ctx); err != nil {
-				c.logger.Fatal(err)
-			}
+			exitOnError(c.logger, c.run(ctx))
 		},
 	}
 	c.addCLIFlags(cmd.Flags())
@@ -55,12 +56,10 @@ func (c *scenarioCleaner) addCLIFlags(fs *pflag.FlagSet) {
 }
 
 func (c *scenarioCleaner) run(ctx context.Context) error {
-	c.logger = c.loggingOptions.MustCreateLogger()
-	scenario := loadgen.GetScenario(c.scenario.Scenario)
-	if scenario == nil {
-		return fmt.Errorf("scenario not found")
+	if scenario := loadgen.GetScenario(c.scenario.Scenario); scenario == nil {
+		return loadgen.NewScenarioNotFoundError(c.scenario.Scenario)
 	} else if c.scenario.RunID == "" {
-		return fmt.Errorf("run ID not found")
+		return loadgen.NewUsageError("--run-id must not be empty")
 	}
 	metrics := c.metricsOptions.MustCreateMetrics(ctx, c.logger)
 	defer metrics.Shutdown(ctx, c.logger, c.scenario.Scenario, c.scenario.RunID, c.scenario.RunFamily)

--- a/cmd/omes/list_scenarios.go
+++ b/cmd/omes/list_scenarios.go
@@ -30,38 +30,50 @@ func describeScenario(name string, scen *loadgen.Scenario) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Scenario: %v\n    Description: %v\n", name, scen.Description)
 
-	if config, ok := scen.GetDefaultConfiguration(); ok {
-		config.ApplyDefaults()
-		b.WriteString("    Default configuration:\n")
-		if config.Iterations != 0 {
-			fmt.Fprintf(&b, "        Iterations: %v\n", config.Iterations)
-		}
-		if config.Duration != 0 {
-			fmt.Fprintf(&b, "        Duration: %v\n", config.Duration)
-		}
-		if config.MaxConcurrent != 0 {
-			fmt.Fprintf(&b, "        Max concurrent: %v\n", config.MaxConcurrent)
-		}
-		if config.Timeout != 0 {
-			fmt.Fprintf(&b, "        Timeout: %v\n", config.Timeout)
+	// Naming the flag that sets each value is what tells a reader this knob is a
+	// run flag rather than an --option. Attribute the values too: most scenarios
+	// set none of their own, and omes's defaults shown unattributed read as a
+	// scenario's intent.
+	config, declared := scen.GetDefaultConfiguration()
+	config.ApplyDefaults()
+	source := "omes defaults, as this scenario sets none"
+	if declared {
+		source = "this scenario's defaults"
+	}
+	fmt.Fprintf(&b, "    Run configuration (%s) — applies to every scenario, override with these flags:\n", source)
+	// A zero here carries no information — an unset timeout just means unlimited —
+	// so only settings with a value are worth printing.
+	flag := func(name string, value any, isSet bool) {
+		if isSet {
+			fmt.Fprintf(&b, "        %s %v\n", name, value)
 		}
 	}
+	flag("--iterations", config.Iterations, config.Iterations != 0)
+	flag("--duration", config.Duration, config.Duration != 0)
+	flag("--max-concurrent", config.MaxConcurrent, config.MaxConcurrent != 0)
+	flag("--max-iteration-attempts", config.MaxIterationAttempts, config.MaxIterationAttempts != 0)
+	flag("--max-iterations-per-second", config.MaxIterationsPerSecond, config.MaxIterationsPerSecond != 0)
+	flag("--timeout", config.Timeout, config.Timeout != 0)
+	b.WriteString("        (run 'omes run-scenario --help' for the full set)\n")
 
-	if opts := scen.DeclaredOptions(); len(opts) > 0 {
-		b.WriteString("    Options (set with --option <name>=<value>):\n")
-		for _, o := range opts {
-			fmt.Fprintf(&b, "        %s (%s)", o.Name, o.Type)
-			switch {
-			case o.Required:
-				b.WriteString(" [required]")
-			case o.Default != "":
-				fmt.Fprintf(&b, " [default: %s]", o.Default)
-			}
-			if o.Usage != "" {
-				fmt.Fprintf(&b, "\n            %s", o.Usage)
-			}
-			b.WriteString("\n")
+	opts := scen.DeclaredOptions()
+	if len(opts) == 0 {
+		fmt.Fprintf(&b, "    Scenario options: none — %s accepts no --option values.\n", name)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "    Scenario options — specific to %s, set with --option <name>=<value>:\n", name)
+	for _, o := range opts {
+		fmt.Fprintf(&b, "        %s (%s)", o.Name, o.Type)
+		switch {
+		case o.Required:
+			b.WriteString(" [required]")
+		case o.Default != "":
+			fmt.Fprintf(&b, " [default: %s]", o.Default)
 		}
+		if o.Usage != "" {
+			fmt.Fprintf(&b, "\n            %s", o.Usage)
+		}
+		b.WriteString("\n")
 	}
 
 	return b.String()

--- a/cmd/omes/main.go
+++ b/cmd/omes/main.go
@@ -21,8 +21,8 @@ func main() {
 	rootCmd.AddCommand(runScenarioWithWorkerCmd())
 	rootCmd.AddCommand(runWorkerCmd())
 
-	// Execute has already reported the error; printing it again here put a second
-	// copy below the usage text, where it read as a second, separate failure.
+	// Execute prints the error itself. Printing it again here would land a second
+	// copy below the usage text, reading as a second, separate failure.
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/omes/main.go
+++ b/cmd/omes/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -22,8 +21,9 @@ func main() {
 	rootCmd.AddCommand(runScenarioWithWorkerCmd())
 	rootCmd.AddCommand(runWorkerCmd())
 
+	// Execute has already reported the error; printing it again here put a second
+	// copy below the usage text, where it read as a second, separate failure.
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/omes/prepare_worker.go
+++ b/cmd/omes/prepare_worker.go
@@ -20,11 +20,11 @@ func prepareWorkerCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repoDir, err := getRepoDir()
 			if err != nil {
-				b.Logger.Fatal(fmt.Errorf("failed to get root directory: %w", err))
+				exitOnError(b.Logger, fmt.Errorf("failed to get root directory: %w", err))
 			}
 			baseDir := workerctl.BaseDir(repoDir, b.SdkOptions.Language)
 			if _, err := b.Build(cmd.Context(), baseDir); err != nil {
-				b.Logger.Fatal(err)
+				exitOnError(b.Logger, err)
 			}
 		},
 	}

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -27,16 +26,7 @@ func runScenarioCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
-			if err := r.run(ctx); err != nil {
-				// A rejected --option is a usage error. Print it plainly instead
-				// of as a fatal-level stack trace, which reads as a crash.
-				var invalidOptions *loadgen.InvalidOptionsError
-				if errors.As(err, &invalidOptions) {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(1)
-				}
-				r.logger.Fatal(err)
-			}
+			exitOnError(r.logger, r.run(ctx))
 		},
 	}
 	r.addCLIFlags(cmd.Flags())
@@ -102,14 +92,22 @@ func (r *scenarioRunner) preRun() {
 	r.logger = r.loggingOptions.MustCreateLogger()
 }
 
-func (r *scenarioRunner) run(ctx context.Context) error {
+// validateInput checks everything that can be judged from the command line alone
+// and resolves the scenario's options.
+//
+// It touches nothing external — no server, no worker, no files beyond the @-file
+// option values — so callers can run it before doing expensive setup and report a
+// typo immediately rather than after a build or a connection attempt.
+func (r *scenarioRunner) validateInput() (*loadgen.Scenario, *loadgen.OptionSet, error) {
 	scenario := loadgen.GetScenario(r.scenario.Scenario)
 	if scenario == nil {
-		return fmt.Errorf("scenario not found")
+		return nil, nil, loadgen.NewScenarioNotFoundError(r.scenario.Scenario)
 	} else if r.scenario.RunID == "" {
-		return fmt.Errorf("run ID not found")
+		return nil, nil, loadgen.NewUsageError("--run-id must not be empty")
 	} else if r.iterations > 0 && r.duration > 0 {
-		return fmt.Errorf("cannot provide both iterations and duration")
+		return nil, nil, loadgen.NewUsageError("--iterations and --duration cannot be combined; " +
+			"use --iterations to run a fixed number of times, or --duration to keep starting " +
+			"iterations for a period")
 	}
 
 	// Parse options
@@ -117,7 +115,7 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	for _, v := range r.scenarioOptions {
 		pieces := strings.SplitN(v, "=", 2)
 		if len(pieces) != 2 {
-			return fmt.Errorf("option does not have '='")
+			return nil, nil, loadgen.NewUsageError("--option %q is not in key=value format", v)
 		}
 		key, value := pieces[0], pieces[1]
 
@@ -126,25 +124,31 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 			filePath := after
 			data, err := os.ReadFile(filePath)
 			if err != nil {
-				return fmt.Errorf("failed to read file %s: %w", filePath, err)
+				return nil, nil, loadgen.NewUsageError("--option %s reads from file %q, which could not be read: %v",
+					key, filePath, err)
 			}
 			value = string(data)
 		}
 		scenarioOptions[key] = value
 	}
 
-	// Validate before dialing, so a bad option fails immediately rather than
-	// after a connection attempt.
 	resolvedOptions, resolveErr := scenario.ResolveOptions(scenarioOptions)
 	if resolveErr != nil {
-		return &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: resolveErr}
+		return nil, nil, &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: resolveErr}
+	}
+	return scenario, resolvedOptions, nil
+}
+
+func (r *scenarioRunner) run(ctx context.Context) error {
+	scenario, resolvedOptions, err := r.validateInput()
+	if err != nil {
+		return err
 	}
 
 	metrics := r.metricsOptions.MustCreateMetrics(ctx, r.logger)
 	defer metrics.Shutdown(ctx, r.logger, r.scenario.Scenario, r.scenario.RunID, r.scenario.RunFamily)
 	start := time.Now()
 	var client client.Client
-	var err error
 	for {
 		client, err = r.clientOptions.Dial(metrics, r.logger)
 		if err == nil {

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -78,7 +78,8 @@ func (r *scenarioRunConfig) addCLIFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&r.timeout, "timeout", 0, "If set, the scenario will stop after this amount of"+
 		" time has elapsed. Any still-running iterations will be cancelled, and omes will exit nonzero.")
 	fs.IntVar(&r.maxConcurrent, "max-concurrent", 0, "Override max-concurrent for the scenario")
-	fs.StringArrayVar(&r.scenarioOptions, "option", nil, "Additional options for the scenario, in key=value format")
+	fs.StringArrayVar(&r.scenarioOptions, "option", nil, "Option specific to the chosen scenario, in key=value format."+
+		" Repeatable. Run 'omes list-scenarios' to see which options a scenario accepts, with their types and defaults")
 	fs.BoolVar(&r.doNotRegisterSearchAttributes, "do-not-register-search-attributes", false,
 		"Do not register the default search attributes used by scenarios. "+
 			"If the search attributes are not registed by the scenario they must be registered through some other method")
@@ -164,10 +165,10 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	defer client.Close()
 
 	// Finalize any capability-gated feature options against the namespace under
-	// test. This needs a dialed client, so it can't happen alongside
-	// ResolveOptions above. Wrapped as an InvalidOptionsError so an
-	// explicitly-enabled-but-unsupported feature prints as the usage error it
-	// is, rather than a fatal stack trace.
+	// test. This needs a dialed client, so it cannot happen in validateInput with
+	// the rest of the option resolution. Wrapped as an InvalidOptionsError so an
+	// explicitly-enabled-but-unsupported feature prints as the usage error it is,
+	// rather than a fatal stack trace.
 	if err := loadgen.ResolveFeatureOptions(ctx, client, r.clientOptions.Namespace, resolvedOptions, r.logger); err != nil {
 		return &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: err}
 	}

--- a/cmd/omes/run_scenario_test.go
+++ b/cmd/omes/run_scenario_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/loadgen"
+)
+
+// newRunner builds a runner with the minimum valid input, so each case below
+// changes only the one thing it is about.
+func newRunner(scenario string) *scenarioRunner {
+	return &scenarioRunner{
+		scenario: clioptions.ScenarioID{Scenario: scenario, RunID: "test-run"},
+	}
+}
+
+// Bad input must be reported as a usage error rather than as a failure during a
+// run: that is what keeps a stack trace off the screen for a typo.
+func TestValidateInputClassifiesBadInputAsUsageErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*scenarioRunner)
+		wantMsg string
+	}{
+		{
+			name:    "unknown scenario",
+			mutate:  func(r *scenarioRunner) { r.scenario.Scenario = "no_such_scenario" },
+			wantMsg: `unknown scenario "no_such_scenario"`,
+		},
+		{
+			name:    "empty run id",
+			mutate:  func(r *scenarioRunner) { r.scenario.RunID = "" },
+			wantMsg: "--run-id must not be empty",
+		},
+		{
+			name: "iterations with duration",
+			mutate: func(r *scenarioRunner) {
+				r.iterations = 5
+				r.duration = time.Minute
+			},
+			wantMsg: "cannot be combined",
+		},
+		{
+			name:    "option without equals",
+			mutate:  func(r *scenarioRunner) { r.scenarioOptions = []string{"novalue"} },
+			wantMsg: `--option "novalue" is not in key=value format`,
+		},
+		{
+			name:    "unknown option name",
+			mutate:  func(r *scenarioRunner) { r.scenarioOptions = []string{"not-an-option=1"} },
+			wantMsg: `unknown option "not-an-option"`,
+		},
+		{
+			name: "unreadable option file",
+			mutate: func(r *scenarioRunner) {
+				missing := filepath.Join(t.TempDir(), "absent.json")
+				r.scenarioOptions = []string{"sleep-activity-json=@" + missing}
+			},
+			wantMsg: "could not be read",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRunner("throughput_stress")
+			tc.mutate(r)
+
+			_, _, err := r.validateInput()
+			if err == nil {
+				t.Fatal("expected validation to reject this input")
+			}
+			var usage loadgen.UsageError
+			if !errors.As(err, &usage) {
+				t.Errorf("want a usage error so it prints without a stack trace, got %T: %v", err, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error should mention %q, got: %v", tc.wantMsg, err)
+			}
+		})
+	}
+}
+
+func TestValidateInputAcceptsGoodInput(t *testing.T) {
+	r := newRunner("throughput_stress")
+	r.scenarioOptions = []string{"sleep-time=3s"}
+
+	scenario, options, err := r.validateInput()
+	if err != nil {
+		t.Fatalf("expected valid input to pass, got %v", err)
+	}
+	if scenario == nil || options == nil {
+		t.Fatal("valid input should yield both the scenario and its resolved options")
+	}
+	info := &loadgen.ScenarioInfo{ScenarioName: "throughput_stress", Options: options}
+	if got := info.OptionDuration("sleep-time"); got != 3*time.Second {
+		t.Errorf("sleep-time: want 3s, got %v", got)
+	}
+}

--- a/cmd/omes/run_scenario_with_worker.go
+++ b/cmd/omes/run_scenario_with_worker.go
@@ -21,9 +21,7 @@ func runScenarioWithWorkerCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
-			if err := r.run(ctx); err != nil {
-				r.Logger.Fatal(err)
-			}
+			exitOnError(r.Logger, r.run(ctx))
 		},
 	}
 	r.addCLIFlags(cmd.Flags())
@@ -51,6 +49,17 @@ func (r *workerWithScenarioRunner) preRun() {
 func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// Reject bad input before building and starting a worker, which for some
+	// languages takes minutes. Judging that needs only the scenario name and run
+	// config, so this throwaway runner deliberately carries no client options.
+	if _, _, err := (&scenarioRunner{
+		scenario:          r.ScenarioID,
+		scenarioRunConfig: r.scenarioRunConfig,
+	}).validateInput(); err != nil {
+		return err
+	}
+
 	// Start worker and wait on error or started
 	workerErrCh := make(chan error, 1)
 	workerStartCh := make(chan struct{})
@@ -69,7 +78,8 @@ func (r *workerWithScenarioRunner) run(ctx context.Context) error {
 	case <-workerStartCh:
 	}
 
-	// Run scenario
+	// Run scenario. The client options are read only now that the worker has
+	// started, since starting an embedded server rewrites the server address.
 	scenarioRunner := scenarioRunner{
 		logger:            r.Logger,
 		scenario:          r.ScenarioID,

--- a/cmd/omes/run_worker.go
+++ b/cmd/omes/run_worker.go
@@ -31,9 +31,7 @@ func runWorkerCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := withCancelOnInterrupt(cmd.Context())
 			defer cancel()
-			if err := r.run(ctx); err != nil {
-				r.Logger.Fatal(err)
-			}
+			exitOnError(r.Logger, r.run(ctx))
 		},
 	}
 	r.addCLIFlags(cmd.Flags())

--- a/cmd/omes/util.go
+++ b/cmd/omes/util.go
@@ -3,10 +3,35 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/temporalio/omes/loadgen"
+	"go.uber.org/zap"
 )
+
+// exitOnError ends the process on err, choosing how to report it by what kind of
+// error it is.
+//
+// Bad input gets the message alone, on the reasoning in [loadgen.UsageError].
+// errors.As unwraps, so a usage error still reads as one after a caller has
+// wrapped it with run context; the wrapping is dropped from the output, since
+// prefixes like "scenario failed" describe a run that never started. Anything
+// else is a genuine failure and keeps the fatal-level treatment.
+func exitOnError(logger *zap.SugaredLogger, err error) {
+	if err == nil {
+		return
+	}
+	var usage loadgen.UsageError
+	if errors.As(err, &usage) {
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(1)
+	}
+	logger.Fatal(err)
+}
 
 func getRepoDir() (string, error) {
 	_, filename, _, ok := runtime.Caller(0)

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -148,6 +148,15 @@ Scenario configuration arrives through **two separate channels**, and knowing wh
    [running.md](./running.md#configuring-the-load) for the list.
 2. **Your own options** — `--option key=value` pairs that you **declare** on the scenario.
 
+The dividing line is that run flags shape the load while options decide what the load does. Two
+consequences when you add a knob:
+
+- **Don't declare an option for something a run flag already controls.** If you want fewer iterations or
+  less concurrency, that is the user's `--iterations` or `--max-concurrent`, not an option of yours.
+- **Don't borrow a run flag's vocabulary for a different meaning.** `throughput_stress` has
+  `internal-iterations`, which is not `--iterations`; a user who confuses them gets a valid run at the
+  wrong load rather than an error. Name the thing your option actually controls.
+
 ### Declare them
 
 Declare options with the same typed registrars used for omes's own CLI flags — an `OptionSet` embeds a

--- a/docs/running.md
+++ b/docs/running.md
@@ -67,9 +67,9 @@ If you set neither `--iterations` nor `--duration`, the scenario's own default a
 
 ### 2. Per-scenario options (`--option key=value`)
 
-Scenario-specific knobs are passed as repeated `--option key=value` pairs. The valid keys are defined by
-each scenario (read the scenario source or its `list-scenarios` description). A value may be loaded from
-a file with `@`: `--option sleep-activity-json=@sleep.json`.
+Scenario-specific knobs are passed as repeated `--option key=value` pairs. Each scenario declares the
+options it accepts; `list-scenarios` prints them with their types and defaults. A value may be loaded
+from a file with `@`: `--option sleep-activity-json=@sleep.json`.
 
 Some options are feature options: they turn on by default when the namespace under test reports
 support for the underlying capability, off when it does not. Pass `=false` to force one off
@@ -129,10 +129,16 @@ go run ./cmd/omes run-scenario-with-worker \
   (`ts`), `dotnet` (`cs`), `ruby` (`rb`). If you pass an unknown value the error message lists the
   accepted set.
 - **A scenario accepts exactly the options it declares.** An unknown name or a value of the wrong type
-  is rejected before the run starts — before omes even connects — and every problem is reported at once.
+  is rejected before the run starts — before omes even connects, and before
+  `run-scenario-with-worker` builds a worker — and every problem is reported at once.
   `list-scenarios` shows what each scenario accepts, including defaults. A scenario that declares no
   options accepts none.
 - **Feature options are on by default against a capable namespace.** They resolve after omes connects,
   by probing the namespace's reported capabilities, so pass `=false` explicitly to force one off.
   Explicitly passing `=true` against a namespace that doesn't report the capability fails the run.
-- **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected at run time.
+- **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected before the run
+  starts.
+- **Bad input prints as a message, not a stack trace.** An unknown scenario or option, a malformed
+  `--option`, a feature the namespace doesn't support, or conflicting run flags print one line and exit
+  non-zero. A stack trace means something failed *during* the run — so if you see one, read it as a real
+  failure rather than a typo.

--- a/docs/running.md
+++ b/docs/running.md
@@ -48,7 +48,16 @@ Run any command with `--help` for the full, authoritative flag list.
 
 ## Configuring the load
 
-Run configuration comes in **two separate channels**:
+Run configuration comes in **two separate channels**, split along one line:
+
+> **Run flags shape the load. Scenario options decide what the load does.**
+>
+> How many iterations, how fast, how long, how many at once — that is the same question for every
+> scenario, so it is a built-in flag. What each iteration actually executes is particular to one
+> scenario, so it is an `--option`.
+
+`list-scenarios` shows both for a given scenario: the run configuration it will use, with the flag that
+overrides each value, and the options it accepts.
 
 ### 1. Built-in run flags (typed)
 
@@ -63,7 +72,9 @@ These apply to every scenario and override its defaults:
 | `--max-iteration-attempts` | Attempts per iteration (default 1). |
 | `--timeout` | Hard stop; cancels in-flight iterations and exits non-zero. |
 
-If you set neither `--iterations` nor `--duration`, the scenario's own default applies.
+If you set neither `--iterations` nor `--duration`, the scenario's own default applies — and most
+scenarios declare none, in which case omes's default does. `list-scenarios` states which is the case for
+each scenario.
 
 ### 2. Per-scenario options (`--option key=value`)
 
@@ -142,3 +153,7 @@ go run ./cmd/omes run-scenario-with-worker \
   `--option`, a feature the namespace doesn't support, or conflicting run flags print one line and exit
   non-zero. A stack trace means something failed *during* the run — so if you see one, read it as a real
   failure rather than a typo.
+- **Some option names read like run flags but are not.** `throughput_stress` accepts
+  `--option internal-iterations`, which sets how much work happens *inside* one iteration; `--iterations`
+  sets how many iterations run. Setting the wrong one produces a valid run at the wrong load rather than
+  an error, so check `list-scenarios` when a name looks familiar.

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -189,6 +189,8 @@ func (e *InvalidOptionsError) Error() string {
 
 func (e *InvalidOptionsError) Unwrap() error { return e.Err }
 
+func (e *InvalidOptionsError) isUsageError() {}
+
 // ResolveOptions validates user-supplied options against the scenario's
 // declarations and returns the set the run should read from.
 //

--- a/loadgen/usage_errors.go
+++ b/loadgen/usage_errors.go
@@ -1,0 +1,60 @@
+package loadgen
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// UsageError marks an error as caused by bad input rather than by a failure
+// during a run.
+//
+// The distinction matters at the point where omes exits. A stack trace taken
+// there describes omes's own call stack, not the mistake the user made, so
+// printing one for a bad flag buries the message that would fix it. Callers
+// detect this interface with errors.As and print the message alone.
+type UsageError interface {
+	error
+	isUsageError()
+}
+
+// NewUsageError builds a [UsageError] with a formatted message, for input
+// problems that need no structure beyond what they say.
+func NewUsageError(format string, args ...any) UsageError {
+	return &usageError{msg: fmt.Sprintf(format, args...)}
+}
+
+type usageError struct{ msg string }
+
+func (e *usageError) Error() string { return e.msg }
+
+func (e *usageError) isUsageError() {}
+
+// ScenarioNotFoundError reports a scenario name that is not registered, and
+// lists the names that are.
+type ScenarioNotFoundError struct {
+	Name string
+	// Available holds the registered scenario names, sorted.
+	Available []string
+}
+
+// NewScenarioNotFoundError builds the error for name from the global registry.
+func NewScenarioNotFoundError(name string) *ScenarioNotFoundError {
+	available := make([]string, 0, len(registeredScenarios))
+	for scenarioName := range registeredScenarios {
+		available = append(available, scenarioName)
+	}
+	sort.Strings(available)
+	return &ScenarioNotFoundError{Name: name, Available: available}
+}
+
+func (e *ScenarioNotFoundError) Error() string {
+	if e.Name == "" {
+		return fmt.Sprintf("no scenario given; available scenarios: %s",
+			strings.Join(e.Available, ", "))
+	}
+	return fmt.Sprintf("unknown scenario %q; available scenarios: %s",
+		e.Name, strings.Join(e.Available, ", "))
+}
+
+func (e *ScenarioNotFoundError) isUsageError() {}

--- a/loadgen/usage_errors_test.go
+++ b/loadgen/usage_errors_test.go
@@ -1,0 +1,58 @@
+package loadgen
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestUsageErrorSurvivesWrapping(t *testing.T) {
+	// The command layer wraps a scenario error with run context before returning
+	// it. A usage error has to stay recognizable through that, or it reverts to
+	// being reported as a crash.
+	wrapped := fmt.Errorf("scenario failed: %w", NewUsageError("--run-id must not be empty"))
+
+	var usage UsageError
+	if !errors.As(wrapped, &usage) {
+		t.Fatal("a wrapped usage error should still be detected as one")
+	}
+	if got := usage.Error(); got != "--run-id must not be empty" {
+		t.Errorf("the unwrapped error should carry the message alone, got %q", got)
+	}
+}
+
+func TestInvalidOptionsErrorIsAUsageError(t *testing.T) {
+	err := error(&InvalidOptionsError{ScenarioName: "s", Err: errors.New("boom")})
+	var usage UsageError
+	if !errors.As(err, &usage) {
+		t.Error("a rejected --option is bad input, so it should be a usage error")
+	}
+}
+
+func TestScenarioNotFoundErrorListsAvailableScenarios(t *testing.T) {
+	// MustRegisterScenario names a scenario after its caller's file, so seed the
+	// registry directly to get a predictable name to assert on.
+	registeredScenarios["zzz_usage_errors_test"] = &Scenario{}
+	t.Cleanup(func() { delete(registeredScenarios, "zzz_usage_errors_test") })
+
+	err := NewScenarioNotFoundError("typoed")
+	if !strings.Contains(err.Error(), `unknown scenario "typoed"`) {
+		t.Errorf("error should name the scenario that was not found, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "zzz_usage_errors_test") {
+		t.Errorf("error should list registered scenarios, got: %v", err)
+	}
+
+	var usage UsageError
+	if !errors.As(error(err), &usage) {
+		t.Error("an unknown scenario name is bad input, so it should be a usage error")
+	}
+}
+
+func TestScenarioNotFoundErrorHandlesEmptyName(t *testing.T) {
+	err := NewScenarioNotFoundError("")
+	if !strings.Contains(err.Error(), "no scenario given") {
+		t.Errorf("an empty name should not be quoted back as a name, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

Two commits, one per half.

**Bad input prints as a message, not a stack trace.** `loadgen.UsageError` is a marker interface for errors caused by input, and every command now exits through a shared `exitOnError`. It matches with `errors.As`, so a usage error is still recognized after a caller wraps it with run context — and the wrapping is dropped from the output, since `"scenario failed"` describes a run that never started. Genuine run failures still go through `logger.Fatal`.

| | before | after |
|---|---|---|
| unknown scenario, malformed `--option`, `--iterations` with `--duration` | fatal-level stack trace | one line, exit 1 |
| bad `--option` on `run-scenario-with-worker` | reported after building *and* starting a worker | reported before either |
| unknown `--scenario` | `scenario not found` | lists the registered names |
| any flag error | printed twice, the second copy below the usage text | printed once |

**Which config channel a knob belongs to is now stated.** `list-scenarios` prints run configuration as the flags that override it rather than as prose field names, and says whether the values are the scenario's own defaults or omes's; a scenario with no options says so instead of omitting the section. `--option`'s help points at `list-scenarios`. `docs/running.md` states the dividing line — run flags shape the load, scenario options decide what the load does — and `docs/authoring-scenarios.md` turns it into two rules for authors.

```
Scenario: fuzzer
    Run configuration (this scenario's defaults) — applies to every scenario, override with these flags:
        --iterations 10
        --max-concurrent 10
        --max-iteration-attempts 1
        (run 'omes run-scenario --help' for the full set)
    Scenario options — specific to fuzzer, set with --option <name>=<value>:
        ...
```

## Why

A typo produced a stack trace describing omes's own call stack rather than the mistake, burying the one line that would fix it — and on `run-scenario-with-worker`, the command the docs recommend for development, only after a worker build that takes minutes for Java/TS/dotnet. Separately, the split between run flags and per-scenario options is sound but was stated nowhere, so the boundary had to be inferred from source.

## Details worth reviewing

**The validation hoist in `run_scenario_with_worker.go`.** Running `validateInput` before the worker starts means it must not capture `ClientOptions`: `workerctl/run.go:70` rewrites the server address once the embedded server picks a random port, so a captured copy would dial the default `127.0.0.1:7233` — a silent run against the wrong server if a local Temporal is up. Validation uses a throwaway runner carrying no client options, with a comment at both sites.

**`throughput_stress`'s `internal-iterations` option is not the `--iterations` run flag.** Confusing them yields a valid run at the wrong load rather than an error. Renaming it would be clearer but breaks saas-cicd, the ring-0 payload, and the runbook examples, so both docs record the collision instead.
