### PR TITLE
loadgen: gate feature options on namespace capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,11 @@ The throughput_stress scenario can generate Nexus load if the scenario is starte
 #### Standalone activities
 
 The throughput_stress scenario can generate standalone-activity load (activities started outside
-any workflow context via `StartActivityExecution`) with `--option include-standalone-activity=true`.
-This requires server support for standalone activities (dynamic config `activity.enableStandalone`).
-Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
+any workflow context via `StartActivityExecution`). This turns on automatically when the namespace
+under test reports support for standalone activities (dynamic config `activity.enableStandalone`);
+pass `--option include-standalone-activity=false` to force it off. Passing
+`--option include-standalone-activity=true` against a namespace that doesn't report support fails
+the run. Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
 
 ### Fuzzer
 

--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -159,6 +159,15 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	}
 	defer client.Close()
 
+	// Finalize any capability-gated feature options against the namespace under
+	// test. This needs a dialed client, so it can't happen alongside
+	// ResolveOptions above. Wrapped as an InvalidOptionsError so an
+	// explicitly-enabled-but-unsupported feature prints as the usage error it
+	// is, rather than a fatal stack trace.
+	if err := loadgen.ResolveFeatureOptions(ctx, client, r.clientOptions.Namespace, resolvedOptions, r.logger); err != nil {
+		return &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: err}
+	}
+
 	repoDir, err := getRepoDir()
 	if err != nil {
 		return fmt.Errorf("failed to get root directory: %w", err)

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -163,6 +163,10 @@ loadgen.MustRegisterScenario(loadgen.Scenario{
 
 		o.Int("task-queue-count", 0, "Number of task queues to spread iterations across.")
 		o.MarkRequired("task-queue-count")
+
+		// Gated on a namespace capability; see "Feature options" below.
+		o.Feature("include-standalone-activity", "Include standalone activities.",
+			func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneActivities() })
 	},
 	ExecutorFn: /* ... */,
 })
@@ -211,6 +215,33 @@ too:
 ```go
 DefaultConfiguration: &loadgen.RunConfiguration{Iterations: 100, MaxConcurrent: 5},
 ```
+
+### Feature options
+
+An option can also be gated on namespace capability, rather than fixed at declaration time,
+with `o.Feature`:
+
+```go
+o.Feature("include-standalone-nexus", "Include standalone Nexus operations.",
+	func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneNexusOperation() })
+```
+
+| Config | Namespace reports capability | Result |
+| --- | --- | --- |
+| unset | yes | enabled |
+| unset | no | disabled |
+| `=false` | either | disabled |
+| `=true` | yes | enabled |
+| `=true` | no | run fails with a usage error |
+| unset | probe failed after retries | run fails |
+
+Resolution needs a dialed client, so it happens in `loadgen.ResolveFeatureOptions` after the run
+connects, not at declaration or `ResolveOptions` time. A test that calls `Configure` directly
+without also calling `ResolveFeatureOptions` sees the feature at its pflag default (`false`), not
+its capability-resolved value.
+
+Reach for `o.Feature` only when a matching field exists on `NamespaceInfo_Capabilities` (from
+`DescribeNamespace`); an ordinary knob that every server supports stays a plain `o.Bool`.
 
 ### Conventions for options
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -71,6 +71,12 @@ Scenario-specific knobs are passed as repeated `--option key=value` pairs. The v
 each scenario (read the scenario source or its `list-scenarios` description). A value may be loaded from
 a file with `@`: `--option sleep-activity-json=@sleep.json`.
 
+Some options are feature options: they turn on by default when the namespace under test reports
+support for the underlying capability, off when it does not. Pass `=false` to force one off
+regardless of what the namespace supports; explicitly passing `=true` against a namespace that
+doesn't report support fails the run. `list-scenarios` marks these with a dynamic default instead
+of a fixed one.
+
 ```sh
 go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
   --option nexus-endpoint=my-endpoint --run-id my-run
@@ -126,4 +132,7 @@ go run ./cmd/omes run-scenario-with-worker \
   is rejected before the run starts — before omes even connects — and every problem is reported at once.
   `list-scenarios` shows what each scenario accepts, including defaults. A scenario that declares no
   options accepts none.
+- **Feature options are on by default against a capable namespace.** They resolve after omes connects,
+  by probing the namespace's reported capabilities, so pass `=false` explicitly to force one off.
+  Explicitly passing `=true` against a namespace that doesn't report the capability fails the run.
 - **`--iterations` and `--duration` are mutually exclusive.** Setting both is rejected at run time.

--- a/internal/workertest/env.go
+++ b/internal/workertest/env.go
@@ -223,6 +223,12 @@ func (env *TestEnvironment) RunExecutorTest(
 	scenarioInfo.Client = env.temporalClient
 	scenarioInfo.Namespace = testNamespace
 
+	// Resolve any capability-gated feature options against the dev server, so
+	// integration tests exercise the same code path as the CLI.
+	if err := loadgen.ResolveFeatureOptions(testCtx, env.temporalClient, testNamespace, scenarioInfo.Options, logger); err != nil {
+		return TestResult{ObservedLogs: observedLogs}, err
+	}
+
 	taskQueueName := loadgen.TaskQueueForRun(scenarioInfo.RunID)
 	workerShutdownCh := env.workerPool.startWorker(testCtx, logger, sdk, taskQueueName, scenarioInfo, cfg.errOnUnimplemented)
 

--- a/loadgen/features.go
+++ b/loadgen/features.go
@@ -1,0 +1,56 @@
+package loadgen
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+)
+
+// featureProbeBackoff is the wait after each failed capability probe, so the
+// probe makes up to len(featureProbeBackoff)+1 attempts before giving up.
+var featureProbeBackoff = []time.Duration{300 * time.Millisecond, 600 * time.Millisecond, 1200 * time.Millisecond}
+
+// ResolveFeatureOptions finalizes capability-gated options declared with
+// [OptionSet.Feature] against the namespace under test. It is a no-op for a
+// scenario that declares none, so such a scenario never pays for a
+// DescribeNamespace call and can't be broken by one failing.
+func ResolveFeatureOptions(
+	ctx context.Context, cl client.Client, namespace string, opts *OptionSet, logger *zap.SugaredLogger,
+) error {
+	if opts == nil || !opts.hasFeatures() {
+		return nil
+	}
+
+	var resp *workflowservice.DescribeNamespaceResponse
+	var err error
+	for attempt := 0; ; attempt++ {
+		resp, err = cl.WorkflowService().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+			Namespace: namespace,
+		})
+		if err == nil {
+			break
+		}
+		if attempt >= len(featureProbeBackoff) {
+			return fmt.Errorf("failed to probe namespace capabilities: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("failed to probe namespace capabilities: %w", ctx.Err())
+		case <-time.After(featureProbeBackoff[attempt]):
+		}
+	}
+
+	if err := opts.resolveFeatures(resp.GetNamespaceInfo().GetCapabilities()); err != nil {
+		return err
+	}
+
+	for _, name := range opts.sortedFeatureNames() {
+		enabled, _ := opts.GetBool(name)
+		logger.Infof("feature %s enabled for namespace %q? %v", name, namespace, enabled)
+	}
+	return nil
+}

--- a/loadgen/features_test.go
+++ b/loadgen/features_test.go
@@ -1,0 +1,34 @@
+package loadgen
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestResolveFeatureOptionsNoopWithoutFeatures(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Int("count", 0, "")
+	}}
+	set := s.MustResolveOptions(nil)
+
+	// A nil client would panic if ResolveFeatureOptions tried to use it. Passing
+	// nil here proves the no-features short circuit never touches the client.
+	if err := ResolveFeatureOptions(context.Background(), nil, "default", set, zap.NewNop().Sugar()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestResolveFeatureOptionsNoopWithNilOptions(t *testing.T) {
+	// A scenario built without an Options func (common in tests) has a nil
+	// OptionSet; this must not panic.
+	if err := ResolveFeatureOptions(context.Background(), nil, "default", nil, zap.NewNop().Sugar()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// Probe retry/failure paths need a WorkflowService stub. There is no existing
+// fake in loadgen or internal for this, so those cases are left untested here
+// rather than introduce a new mocking dependency; see the plan doc for the
+// intended behavior (3 attempts, 300ms/600ms/1.2s backoff).

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/pflag"
+	namespacev1 "go.temporal.io/api/namespace/v1"
 )
 
 // OptionSet declares the options a scenario accepts via `--option <name>=<value>`.
@@ -17,6 +19,14 @@ import (
 type OptionSet struct {
 	*pflag.FlagSet
 	required map[string]struct{}
+	// explicit tracks which names were supplied via `--option`, as distinct from
+	// left at their declared default. pflag's own Flag.Changed is unusable here:
+	// resolveFeatures writes to the flag for names left unset, which would make
+	// Changed true for those too.
+	explicit map[string]struct{}
+	// features holds the capability predicate for each option declared with
+	// Feature, keyed by name.
+	features map[string]func(*namespacev1.NamespaceInfo_Capabilities) bool
 }
 
 // MarkRequired fails any run that does not explicitly supply the named options.
@@ -26,13 +36,80 @@ func (o *OptionSet) MarkRequired(names ...string) {
 	}
 }
 
+// Feature declares a boolean option gated on a namespace capability. It is enabled
+// by default when the namespace under test reports support, disabled when it does
+// not, and always follows an explicit `--option name=<bool>` instead. Explicitly
+// enabling a feature the namespace does not report fails the run.
+//
+// Resolution happens after the client dials, via [ResolveFeatureOptions]; until
+// then the option reads as its pflag default (false). The predicate is passed the
+// namespace's reported capabilities, which may be nil for a server that reports
+// none, so read them through the generated getters rather than dereferencing.
+func (o *OptionSet) Feature(name, usage string, supported func(*namespacev1.NamespaceInfo_Capabilities) bool) {
+	o.Bool(name, false, usage)
+	o.features[name] = supported
+}
+
+// UserSpecified reports whether name was supplied via `--option name=value`, as opposed
+// to being read at its declared (or feature-resolved) default.
+func (o *OptionSet) UserSpecified(name string) bool {
+	_, ok := o.explicit[name]
+	return ok
+}
+
+// hasFeatures reports whether the set declares any Feature options. A scenario
+// that declares none never needs a capability probe.
+func (o *OptionSet) hasFeatures() bool {
+	return len(o.features) > 0
+}
+
+// sortedFeatureNames returns the declared feature names in sorted order, for
+// deterministic error and log ordering.
+func (o *OptionSet) sortedFeatureNames() []string {
+	names := make([]string, 0, len(o.features))
+	for name := range o.features {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// resolveFeatures finalizes every Feature option against the namespace's
+// reported capabilities: an unset option takes the capability's value, and an
+// explicit true against an unsupported capability is collected as an error.
+// Every unsupported feature is reported at once.
+func (o *OptionSet) resolveFeatures(caps *namespacev1.NamespaceInfo_Capabilities) error {
+	var errs []error
+	for _, name := range o.sortedFeatureNames() {
+		supported := o.features[name](caps)
+		flag := o.Lookup(name)
+		if !o.UserSpecified(name) {
+			if err := flag.Value.Set(strconv.FormatBool(supported)); err != nil {
+				errs = append(errs, fmt.Errorf("option %q: %w", name, err))
+			}
+			continue
+		}
+		if flag.Value.String() == "true" && !supported {
+			errs = append(errs, fmt.Errorf(
+				"option %q was explicitly enabled, but the namespace does not report support for it",
+				name))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func newOptionSet(name string) *OptionSet {
 	fs := pflag.NewFlagSet(name+" options", pflag.ContinueOnError)
 	// Options are surfaced by `list-scenarios` and validation errors, never by
 	// pflag printing its own usage.
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
-	return &OptionSet{FlagSet: fs, required: make(map[string]struct{})}
+	return &OptionSet{
+		FlagSet:  fs,
+		required: make(map[string]struct{}),
+		explicit: make(map[string]struct{}),
+		features: make(map[string]func(*namespacev1.NamespaceInfo_Capabilities) bool),
+	}
 }
 
 func (o *OptionSet) names() []string {
@@ -42,6 +119,10 @@ func (o *OptionSet) names() []string {
 	return names
 }
 
+// featureDefaultDisplay is the [DeclaredOption.Default] shown for a Feature
+// option: its real default depends on the namespace under test, not a constant.
+const featureDefaultDisplay = "auto (enabled when the namespace supports it)"
+
 // DeclaredOption describes one declared option for display.
 type DeclaredOption struct {
 	Name     string
@@ -49,6 +130,10 @@ type DeclaredOption struct {
 	Default  string
 	Usage    string
 	Required bool
+	// IsFeature is true for an option declared with Feature: its default is
+	// resolved from the namespace's capabilities rather than fixed at
+	// declaration time.
+	IsFeature bool
 }
 
 // DeclaredOptions returns the scenario's declared options, sorted by name. It is
@@ -61,12 +146,18 @@ func (s *Scenario) DeclaredOptions() []DeclaredOption {
 	var out []DeclaredOption
 	set.VisitAll(func(f *pflag.Flag) {
 		_, required := set.required[f.Name]
+		_, isFeature := set.features[f.Name]
+		def := f.DefValue
+		if isFeature {
+			def = featureDefaultDisplay
+		}
 		out = append(out, DeclaredOption{
-			Name:     f.Name,
-			Type:     f.Value.Type(),
-			Default:  f.DefValue,
-			Usage:    f.Usage,
-			Required: required,
+			Name:      f.Name,
+			Type:      f.Value.Type(),
+			Default:   def,
+			Usage:     f.Usage,
+			Required:  required,
+			IsFeature: isFeature,
 		})
 	})
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -132,7 +223,9 @@ func (s *Scenario) ResolveOptions(provided map[string]string) (*OptionSet, error
 		if err := set.Set(name, provided[name]); err != nil {
 			errs = append(errs, fmt.Errorf("option %q expects type %s, got %q",
 				name, flag.Value.Type(), provided[name]))
+			continue
 		}
+		set.explicit[name] = struct{}{}
 	}
 
 	for _, name := range sortedRequired(set.required) {

--- a/loadgen/options_test.go
+++ b/loadgen/options_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	namespacev1 "go.temporal.io/api/namespace/v1"
 )
 
 func TestResolveOptionsRejectsWhenNoneDeclared(t *testing.T) {
@@ -216,6 +218,157 @@ func TestGetDefaultConfigurationPrefersScenarioDeclaration(t *testing.T) {
 	s = &Scenario{ExecutorFn: func() Executor { return ExecutorFunc(nil) }}
 	if _, ok := s.GetDefaultConfiguration(); ok {
 		t.Error("expected no default configuration to be reported")
+	}
+}
+
+func nexusOperationCapability(supported bool) *namespacev1.NamespaceInfo_Capabilities {
+	return &namespacev1.NamespaceInfo_Capabilities{StandaloneNexusOperation: supported}
+}
+
+func TestFeatureUnsetEnabledWhenCapabilitySupported(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	set := s.MustResolveOptions(nil)
+	if err := set.resolveFeatures(nexusOperationCapability(true)); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	info := &ScenarioInfo{Options: set}
+	if !info.OptionBool("nexus") {
+		t.Error("want feature enabled when the namespace reports support")
+	}
+}
+
+func TestFeatureUnsetDisabledWhenCapabilityUnsupported(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	set := s.MustResolveOptions(nil)
+	if err := set.resolveFeatures(nexusOperationCapability(false)); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	info := &ScenarioInfo{Options: set}
+	if info.OptionBool("nexus") {
+		t.Error("want feature disabled when the namespace does not report support")
+	}
+}
+
+func TestFeatureExplicitFalseStaysFalseUnderSupportingCaps(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	set := s.MustResolveOptions(map[string]string{"nexus": "false"})
+	if err := set.resolveFeatures(nexusOperationCapability(true)); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	info := &ScenarioInfo{Options: set}
+	if info.OptionBool("nexus") {
+		t.Error("want explicit false to stay false even when the namespace supports the feature")
+	}
+}
+
+func TestFeatureExplicitTrueUnderSupportingCapsSucceeds(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	set := s.MustResolveOptions(map[string]string{"nexus": "true"})
+	if err := set.resolveFeatures(nexusOperationCapability(true)); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	info := &ScenarioInfo{Options: set}
+	if !info.OptionBool("nexus") {
+		t.Error("want explicit true to stay true when the namespace supports the feature")
+	}
+}
+
+func TestFeatureExplicitTrueUnderNonSupportingCapsErrors(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	set := s.MustResolveOptions(map[string]string{"nexus": "true"})
+	err := set.resolveFeatures(nexusOperationCapability(false))
+	if err == nil {
+		t.Fatal("expected an error: feature explicitly enabled but namespace does not support it")
+	}
+	if !strings.Contains(err.Error(), "nexus") {
+		t.Errorf("error should name the offending option, got: %v", err)
+	}
+}
+
+func TestFeatureTwoUnsupportedExplicitErrorsJoined(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+		o.Feature("activity", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneActivities()
+		})
+	}}
+	set := s.MustResolveOptions(map[string]string{"nexus": "true", "activity": "true"})
+	err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{})
+	if err == nil {
+		t.Fatal("expected an error naming both unsupported features")
+	}
+	for _, want := range []string{"nexus", "activity"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected both problems reported together, %q missing from: %v", want, err)
+		}
+	}
+}
+
+func TestUserSpecifiedReflectsExplicitSupply(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Bool("on", true, "")
+	}}
+	set := s.MustResolveOptions(map[string]string{"on": "false"})
+	if !set.UserSpecified("on") {
+		t.Error("want UserSpecified true for an option explicitly supplied as false")
+	}
+	if set.UserSpecified("never-provided") {
+		t.Error("want UserSpecified false for a name never provided")
+	}
+}
+
+func TestDeclaredOptionsReportsFeatureDefault(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "Include standalone Nexus operations.", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	opts := s.DeclaredOptions()
+	if len(opts) != 1 {
+		t.Fatalf("want 1 declared option, got %d", len(opts))
+	}
+	if !opts[0].IsFeature {
+		t.Error("want IsFeature true for a Feature declaration")
+	}
+	if opts[0].Default != "auto (enabled when the namespace supports it)" {
+		t.Errorf("want the dynamic default string, got %q", opts[0].Default)
+	}
+}
+
+func TestResolveOptionsRejectsMalformedFeatureValue(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
+			return c.GetStandaloneNexusOperation()
+		})
+	}}
+	_, err := s.ResolveOptions(map[string]string{"nexus": "notabool"})
+	if err == nil {
+		t.Fatal("expected an error for a malformed feature value")
+	}
+	if !strings.Contains(err.Error(), "bool") {
+		t.Errorf("error should name the expected type, got: %v", err)
 	}
 }
 

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -226,6 +226,14 @@ func (s *ScenarioInfo) OptionString(name string) string {
 	return v
 }
 
+// OptionUserSpecified reports whether name was explicitly supplied via
+// `--option name=value`, as opposed to reading its declared (or feature-resolved)
+// default. Use it when the presence of a value matters, not just its content, as
+// with the standalone-nexus/nexus-enabled interaction in throughput_stress.
+func (s *ScenarioInfo) OptionUserSpecified(name string) bool {
+	return s.options().UserSpecified(name)
+}
+
 // options returns the resolved set, or an empty one so a ScenarioInfo built
 // without options (in tests, say) reads zero values rather than panicking.
 func (s *ScenarioInfo) options() *OptionSet {

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/temporalio/omes/loadgen/kitchensink"
 	"go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	namespacev1 "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -50,13 +51,13 @@ const (
 	// Default is false.
 	IncludeDescribeFlag = "include-describe"
 	// IncludeStandaloneNexusFlag enables standalone Nexus operations in throughput_stress.
-	// Requires nexus-endpoint to also be set.
-	// Default is false.
+	// On by default when the namespace under test reports support; pass
+	// include-standalone-nexus=false to force off.
 	IncludeStandaloneNexusFlag = "include-standalone-nexus"
 	// IncludeStandaloneActivityFlag enables standalone activities (activities started outside
 	// any workflow context via StartActivityExecution) in throughput_stress.
-	// Requires server support for standalone activities (dynamic config `activity.enableStandalone`).
-	// Default is false.
+	// On by default when the namespace under test reports support (dynamic config
+	// activity.enableStandalone); pass include-standalone-activity=false to force off.
 	IncludeStandaloneActivityFlag = "include-standalone-activity"
 	// PayloadDistributionJsonFlag is a JSON string (or @file) configuring a weighted
 	// activity payload-size distribution. See loadgen.PayloadConfig for details.
@@ -123,8 +124,10 @@ func init() {
 			o.Float64(MinThroughputPerHourFlag, 0, "Fail the run below this workflows-per-hour rate (0 disables).")
 			o.Bool(IncludeRetryScenariosFlag, false, "Include activities that exercise retries.")
 			o.Bool(IncludeDescribeFlag, false, "Include DescribeWorkflowExecution calls.")
-			o.Bool(IncludeStandaloneNexusFlag, false, "Include standalone Nexus operations.")
-			o.Bool(IncludeStandaloneActivityFlag, false, "Include standalone activities; requires server support.")
+			o.Feature(IncludeStandaloneNexusFlag, "Include standalone Nexus operations.",
+				func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneNexusOperation() })
+			o.Feature(IncludeStandaloneActivityFlag, "Include standalone activities.",
+				func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneActivities() })
 			o.String(PayloadDistributionJsonFlag, "", "JSON payload-size distribution; use @<file> to read from a file.")
 		},
 		ExecutorFn: func() loadgen.Executor { return newThroughputStressExecutor() },
@@ -212,7 +215,19 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 	config.IncludeDescribe = info.OptionBool(IncludeDescribeFlag)
 	config.IncludeStandaloneNexus = info.OptionBool(IncludeStandaloneNexusFlag)
 	if config.IncludeStandaloneNexus && !config.NexusEnabled {
-		return fmt.Errorf("%s requires %s", IncludeStandaloneNexusFlag, NexusEnabledFlag)
+		// Standalone Nexus can auto-enable via a capability probe without the user
+		// ever touching nexus-enabled; in that case turn Nexus on too, rather than
+		// fail on an option nobody set. An explicit nexus-enabled=false still wins.
+		if info.OptionUserSpecified(NexusEnabledFlag) {
+			return fmt.Errorf("%s requires %s, which was explicitly disabled",
+				IncludeStandaloneNexusFlag, NexusEnabledFlag)
+		}
+		// Configure is also called directly by tests, which may not set a Logger.
+		if info.Logger != nil {
+			info.Logger.Infof("enabling %s because %s is enabled",
+				NexusEnabledFlag, IncludeStandaloneNexusFlag)
+		}
+		config.NexusEnabled = true
 	}
 	if config.NexusEndpoint != "" && !config.NexusEnabled {
 		return fmt.Errorf("%s was set but %s is false", NexusEndpointFlag, NexusEnabledFlag)

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
 	ks "github.com/temporalio/omes/loadgen/kitchensink"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
 	"go.uber.org/zap"
 )
@@ -76,6 +77,66 @@ func TestThroughputStress(t *testing.T) {
 		_, err = env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
 		require.NoError(t, err, "Executor should complete successfully when resuming from end")
 	})
+}
+
+// TestThroughputStressFeatureAutoEnable exercises capability-gated feature options
+// end to end. The dev server runs with the standalone-activity and standalone-Nexus
+// gates on, and the scenario passes neither feature option, so both have to resolve
+// from what the namespace reports.
+func TestThroughputStressFeatureAutoEnable(t *testing.T) {
+	t.Parallel()
+
+	runID := fmt.Sprintf("tps-feature-%d", time.Now().Unix())
+
+	// No WithNexusEndpoint here: if standalone Nexus auto-enables, the scenario
+	// enables Nexus itself and creates its own endpoint, which is the path under
+	// test. Pre-creating one would collide on the same NexusEndpointForRun name.
+	env := workertest.SetupTestEnvironment(t,
+		workertest.WithExecutorTimeout(1*time.Minute),
+		workertest.WithDynamicConfig(map[string]any{
+			// Gates the capabilities the two feature options read.
+			"activity.enableStandalone":       true,
+			"nexusoperation.enableStandalone": true,
+			// Standalone Nexus system callbacks require CHASM callbacks.
+			"history.enableCHASMCallbacks": true,
+		}))
+
+	// Without the namespace advertising standalone activities there is nothing for
+	// the feature option to resolve from, and the rest of this test proves nothing.
+	desc, err := env.TemporalClient().WorkflowService().DescribeNamespace(t.Context(),
+		&workflowservice.DescribeNamespaceRequest{Namespace: "default"})
+	require.NoError(t, err)
+	caps := desc.GetNamespaceInfo().GetCapabilities()
+	require.True(t, caps.GetStandaloneActivities(),
+		"namespace should report standalone activities with activity.enableStandalone on")
+
+	scenarioInfo := loadgen.ScenarioInfo{
+		RunID: runID,
+		Configuration: loadgen.RunConfiguration{
+			Iterations: 1,
+		},
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
+			IterFlag:                          "1",
+			ContinueAsNewAfterIterFlag:        "1",
+			SleepTimeFlag:                     "1ms",
+			VisibilityVerificationTimeoutFlag: "10s",
+		}),
+	}
+
+	executor := newThroughputStressExecutor()
+	_, err = env.RunExecutorTest(t, executor, scenarioInfo, clioptions.LangGo)
+	require.NoError(t, err, "Executor should complete successfully")
+
+	require.True(t, executor.config.IncludeStandaloneActivity,
+		"standalone activities should auto-enable from the namespace capability")
+	// Standalone Nexus follows whatever this server version reports. When it is on,
+	// the scenario turns nexus-enabled on by itself.
+	require.Equal(t, caps.GetStandaloneNexusOperation(), executor.config.IncludeStandaloneNexus)
+	if caps.GetStandaloneNexusOperation() {
+		require.True(t, executor.config.NexusEnabled,
+			"auto-enabled standalone Nexus should also enable Nexus")
+	}
+	require.Equal(t, 1, executor.Snapshot().(tpsState).CompletedIterations)
 }
 
 func TestThroughputStressConfigurePayload(t *testing.T) {

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -108,6 +108,77 @@ func TestThroughputStressConfigureNoPayload(t *testing.T) {
 	require.Equal(t, 256, executor.samplePayloadSize(rand.New(rand.NewSource(1))))
 }
 
+// TestThroughputStressConfigureFeatureAutoEnablesNexus covers the interaction
+// added for capability-gated feature options: when include-standalone-nexus
+// resolves to true (as it would after ResolveFeatureOptions probes a capable
+// namespace) and nexus-enabled was never touched by the user, Configure turns
+// Nexus on rather than failing on an option the user never set.
+//
+// ResolveFeatureOptions itself needs a dialed client, so this simulates its
+// outcome directly on the resolved option set with Set, exactly as
+// resolveFeatures would for an unset feature option.
+func TestThroughputStressConfigureFeatureAutoEnablesNexus(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID:  "tps-feature-auto",
+		Logger: zap.NewNop().Sugar(),
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
+			SleepActivityJsonFlag: "", // keep defaults minimal
+		}),
+	}
+	require.NoError(t, info.Options.Set(IncludeStandaloneNexusFlag, "true"))
+
+	require.NoError(t, executor.Configure(info))
+	require.True(t, executor.config.NexusEnabled)
+	require.True(t, executor.config.IncludeStandaloneNexus)
+}
+
+// TestThroughputStressConfigureFeatureRespectsExplicitNexusDisabled covers the
+// other half: an explicit nexus-enabled=false must not be silently overridden
+// even when the feature auto-enables standalone Nexus.
+func TestThroughputStressConfigureFeatureRespectsExplicitNexusDisabled(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID:  "tps-feature-explicit-off",
+		Logger: zap.NewNop().Sugar(),
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
+			NexusEnabledFlag: "false",
+		}),
+	}
+	require.NoError(t, info.Options.Set(IncludeStandaloneNexusFlag, "true"))
+
+	err := executor.Configure(info)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), IncludeStandaloneNexusFlag)
+	require.Contains(t, err.Error(), NexusEnabledFlag)
+}
+
+// TestThroughputStressConfigureExplicitStandaloneNexusRequiresNexusEnabled
+// preserves the pre-existing behavior: a user who explicitly asks for standalone
+// Nexus while explicitly disabling Nexus gets an error either way.
+func TestThroughputStressConfigureExplicitStandaloneNexusRequiresNexusEnabled(t *testing.T) {
+	t.Parallel()
+
+	executor := newThroughputStressExecutor()
+	info := loadgen.ScenarioInfo{
+		RunID:  "tps-explicit-both",
+		Logger: zap.NewNop().Sugar(),
+		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
+			IncludeStandaloneNexusFlag: "true",
+			NexusEnabledFlag:           "false",
+		}),
+	}
+
+	err := executor.Configure(info)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), IncludeStandaloneNexusFlag)
+	require.Contains(t, err.Error(), NexusEnabledFlag)
+}
+
 func TestThroughputStressConfigureInvalidPayload(t *testing.T) {
 	t.Parallel()
 

--- a/workers/java/io/temporal/omes/workerlib/kitchensink/ClientActionExecutor.java
+++ b/workers/java/io/temporal/omes/workerlib/kitchensink/ClientActionExecutor.java
@@ -195,7 +195,11 @@ public class ClientActionExecutor {
             ActivityClientOptions.newBuilder()
                 .setNamespace(client.getOptions().getNamespace())
                 .build());
-    activityClient.execute(dispatch.type, options.build(), dispatch.args.toArray());
+    // Ask for byte[]: the payload activity returns raw bytes, and the raw converter
+    // only deserializes into a byte array. The result-less execute overload asks for
+    // java.lang.Void and fails on any activity that returns something. Activities
+    // that return nothing send a null payload, which converts to null for any type.
+    activityClient.execute(dispatch.type, byte[].class, options.build(), dispatch.args.toArray());
   }
 
   private void executeQueryAction(KitchenSink.DoQuery query) {

--- a/workers/typescript/workerlib/kitchensink/client-action-executor.ts
+++ b/workers/typescript/workerlib/kitchensink/client-action-executor.ts
@@ -1,7 +1,11 @@
 import { Client, WithStartWorkflowOperation } from '@temporalio/client';
-import { ApplicationFailure, decompileRetryPolicy } from '@temporalio/common';
+import { ApplicationFailure } from '@temporalio/common';
 import { WorkflowIdConflictPolicy } from '@temporalio/client';
-import { activityNameAndArgs, durationConvertMaybeUndefined } from './proto_help';
+import {
+  activityNameAndArgs,
+  durationConvertMaybeUndefined,
+  retryPolicyFromProto,
+} from './proto_help';
 import { temporal } from './protos/root';
 import IClientSequence = temporal.omes.kitchen_sink.IClientSequence;
 import IClientActionSet = temporal.omes.kitchen_sink.IClientActionSet;
@@ -165,7 +169,7 @@ export class ClientActionExecutor {
       startToCloseTimeout: durationConvertMaybeUndefined(act.startToCloseTimeout),
       scheduleToStartTimeout: durationConvertMaybeUndefined(act.scheduleToStartTimeout),
       heartbeatTimeout: durationConvertMaybeUndefined(act.heartbeatTimeout),
-      retry: decompileRetryPolicy(act.retryPolicy),
+      retry: retryPolicyFromProto(act.retryPolicy),
     });
   }
 

--- a/workers/typescript/workerlib/kitchensink/proto_help.ts
+++ b/workers/typescript/workerlib/kitchensink/proto_help.ts
@@ -1,9 +1,25 @@
 // Convert a protobuf duration to milliseconds
+import { decompileRetryPolicy, RetryPolicy } from '@temporalio/common';
 import { google, temporal } from './protos/root';
 import Long from 'long';
 
 import IDuration = google.protobuf.IDuration;
 import IExecuteActivityAction = temporal.omes.kitchen_sink.IExecuteActivityAction;
+import IRetryPolicy = temporal.api.common.v1.IRetryPolicy;
+
+// Convert a protobuf retry policy to the SDK's, treating an unset maximumAttempts as unlimited.
+// decompileRetryPolicy passes proto's 0 (unlimited) straight through, but compileRetryPolicy then
+// rejects 0 as not a positive integer. That throws a ValueError, which the client masks as
+// "Unexpected error while making gRPC request" with no cause.
+export function retryPolicyFromProto(
+  retryPolicy: IRetryPolicy | null | undefined
+): RetryPolicy | undefined {
+  const policy = decompileRetryPolicy(retryPolicy);
+  if (policy?.maximumAttempts === 0) {
+    return { ...policy, maximumAttempts: undefined };
+  }
+  return policy;
+}
 
 // Map an ExecuteActivityAction to its registered activity name and args.
 // Shared by the workflow-scheduled path and the standalone-activity path.

--- a/workers/typescript/workerlib/kitchensink/proto_help.ts
+++ b/workers/typescript/workerlib/kitchensink/proto_help.ts
@@ -12,7 +12,7 @@ import IRetryPolicy = temporal.api.common.v1.IRetryPolicy;
 // rejects 0 as not a positive integer. That throws a ValueError, which the client masks as
 // "Unexpected error while making gRPC request" with no cause.
 export function retryPolicyFromProto(
-  retryPolicy: IRetryPolicy | null | undefined
+  retryPolicy: IRetryPolicy | null | undefined,
 ): RetryPolicy | undefined {
   const policy = decompileRetryPolicy(retryPolicy);
   if (policy?.maximumAttempts === 0) {

--- a/workers/typescript/workerlib/kitchensink/workflows/kitchen_sink.ts
+++ b/workers/typescript/workerlib/kitchensink/workflows/kitchen_sink.ts
@@ -23,7 +23,6 @@ import {
 import {
   ActivityOptions,
   decodePriority,
-  decompileRetryPolicy,
   LocalActivityOptions,
   SearchAttributes,
 } from '@temporalio/common';
@@ -33,6 +32,7 @@ import {
   durationConvert,
   durationConvertMaybeUndefined,
   numify,
+  retryPolicyFromProto,
 } from '../proto_help';
 import WorkflowInput = temporal.omes.kitchen_sink.WorkflowInput;
 import WorkflowState = temporal.omes.kitchen_sink.WorkflowState;
@@ -278,7 +278,7 @@ function launchActivity(execActivity: IExecuteActivityAction): Promise<unknown> 
     scheduleToCloseTimeout: durationConvertMaybeUndefined(execActivity.scheduleToCloseTimeout),
     startToCloseTimeout: durationConvertMaybeUndefined(execActivity.startToCloseTimeout),
     scheduleToStartTimeout: durationConvertMaybeUndefined(execActivity.scheduleToStartTimeout),
-    retry: decompileRetryPolicy(execActivity.retryPolicy),
+    retry: retryPolicyFromProto(execActivity.retryPolicy),
     priority: decodePriority(execActivity.priority),
   };
 


### PR DESCRIPTION
## What was changed

I've added a new kind of option for Omes: _features_. `o.Feature(name, usage, func(caps *namespacev1.NamespaceInfo_Capabilities) bool)` declares a
boolean scenario option that is automatically enabled if the corresponding feature is enabled for the testing namespace. 

`include-standalone-nexus` and `include-standalone-activity` in throughput_stress have been ported to use it; this way those features are automatically exercised if the namespace we're testing supports it.


This also fixes a Java worker bug it uncovered: `ClientActionExecutor.executeStandaloneActivity` used the result-less `ActivityClient.execute` overload, which asks the SDK to deserialize the result into `java.lang.Void`. The raw payload converter rejects that for any activity returning bytes, and the enclosing client-action activity retries without bound, so the iteration hung to the run timeout instead of failing. It now requests `byte[]`.

## Why?

Our feature release process is a bit of a mess right now, and one of the manual steps is "Remember to update oss-cicd as well as VCR to exercise your feature but only after its actually supported".

That's a lot and easy to get wrong, as the feature would need to be enabled _everywhere_ that the corresponding version of omes runs. Which means:
- Every test cell
- Release validation, but only when that release is being validated
- etc

Automatically enabling load exercise when the namespace reports support is a simple solution to this.

## How was this tested
- unit tests for the full option resolution matrix (unset/explicit crossed with supported/unsupported, joined errors for multiple unsupported features, `list-scenarios` rendering of the dynamic default)
- The existing throughput_stress integration test now exercises the probe against the dev server.
- a new integration test that checks this functionality
