### PR TITLE
Move the throughput_stress details out of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ benchmark features and situations. Backwards compatibility may not be maintained
   profiles, and running against a specific SDK version.
 - **[Authoring scenarios](./docs/authoring-scenarios.md)** — writing a new scenario, choosing an
   executor, exposing options, and authoring conventions.
+- **[The throughput_stress scenario](./docs/throughput-stress.md)** — sleep activities, Nexus,
+  standalone activities, and standalone Nexus operations.
 
 ## Why the weird name?
 
@@ -244,48 +246,12 @@ with `--app` for workers and `--option project-name=...` for project scenarios.
 
 ### ThroughputStress
 
-#### Sleep Activity
+The general-purpose load scenario, used for release validation and standing load. It drives
+workflows with child workflows, activities, signals, queries, updates, continue-as-new, and
+optionally Nexus operations.
 
-The throughput_stress scenario can be configured to run "sleep" activities with different configurations.
-
-The configuration is done via a JSON file, which is passed to the scenario with the
-`--option sleep-activity-per-priority-json=@<file>` flag. Example:
-
-```
-echo '{"count":{"type":"fixed","value":5},"groups":{"high":{"weight":2,"sleepDuration":{"type":"uniform","min":"2s","max":"4s"}},"low":{"weight":3,"sleepDuration":{"type":"discrete","weights":{"5s":3,"10s":1}}}}}' > sleep.json
-go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option sleep-activity-json=@sleep.json --run-id default-run-id
-```
-
-This runs 5 sleep activities per iteration, where "high" has a weight of 2 and sleeps for a random duration between 2-4s,
-and "low" has a weight of 3 and sleeps for either 5s or 10s.
-
-Look at `DistributionField` to learn more about different kinds of distrbutions.
-
-#### Nexus 
-
-The throughput_stress scenario can generate Nexus load if the scenario is started with `--option nexus-endpoint=my-nexus-endpoint`:
-
-   ```
-   temporal operator nexus endpoint create \
-   --name my-nexus-endpoint \
-   --target-namespace default \ # Change if needed
-   --target-task-queue throughput_stress:default-run-id
-   ```
-
-1. Start the scenario with the given run-id:
-
-  ```
-  go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option nexus-endpoint=my-nexus-endpoint --run-id default-run-id
-  ```
-
-#### Standalone activities
-
-The throughput_stress scenario can generate standalone-activity load (activities started outside
-any workflow context via `StartActivityExecution`). This turns on automatically when the namespace
-under test reports support for standalone activities (dynamic config `activity.enableStandalone`);
-pass `--option include-standalone-activity=false` to force it off. Passing
-`--option include-standalone-activity=true` against a namespace that doesn't report support fails
-the run. Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
+Its options — sleep activities, Nexus, standalone activities and standalone Nexus operations — are
+documented in **[The throughput_stress scenario](./docs/throughput-stress.md)**.
 
 ### Fuzzer
 

--- a/docs/throughput-stress.md
+++ b/docs/throughput-stress.md
@@ -1,0 +1,64 @@
+# The throughput_stress scenario
+
+`throughput_stress` is the general-purpose load scenario: it drives workflows with child workflows,
+activities, signals, queries, updates, continue-as-new, and optionally Nexus operations. It is the
+scenario used for release validation and for standing load.
+
+For the commands that run it, the built-in run flags, and how `--option` works in general, see
+[Running omes](./running.md). This page covers the options specific to this scenario.
+
+Run `omes list-scenarios` for the authoritative list of options with their types and defaults.
+
+## Sleep activities
+
+The scenario can run "sleep" activities with different configurations, described by a JSON document
+passed with `--option sleep-activity-json`. Use `@<file>` to read it from a file:
+
+```sh
+echo '{"count":{"type":"fixed","value":5},"groups":{"high":{"weight":2,"sleepDuration":{"type":"uniform","min":"2s","max":"4s"}},"low":{"weight":3,"sleepDuration":{"type":"discrete","weights":{"5s":3,"10s":1}}}}}' > sleep.json
+
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+  --option sleep-activity-json=@sleep.json --run-id my-run
+```
+
+That runs 5 sleep activities per iteration: `high` has weight 2 and sleeps a random 2–4s, `low` has
+weight 3 and sleeps either 5s or 10s. See `DistributionField` for the kinds of distribution
+available.
+
+## Nexus
+
+`nexus-enabled` decides whether the run generates Nexus load. Nexus needs an endpoint targeting the
+run's task queue, and the scenario creates one for the run when `nexus-endpoint` is empty.
+
+To use an endpoint you manage instead, create it against the run's task queue — which is
+`omes-<run-id>` — and name it with `--option nexus-endpoint`:
+
+```sh
+temporal operator nexus endpoint create \
+  --name my-nexus-endpoint \
+  --target-namespace default \
+  --target-task-queue omes-my-run
+
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+  --option nexus-enabled=true --option nexus-endpoint=my-nexus-endpoint --run-id my-run
+```
+
+Naming an endpoint while Nexus is off is rejected, rather than accepting an endpoint the run would
+never use.
+
+## Standalone activities
+
+The scenario can generate standalone-activity load — activities started outside any workflow context
+via `StartActivityExecution`. This is a feature option, described under per-scenario options in
+[Running omes](./running.md): it turns on by itself when the namespace reports support for
+standalone activities (dynamic config `activity.enableStandalone`), and
+`--option include-standalone-activity=false` forces it off. Requesting it against a namespace that
+does not report support fails the run.
+
+Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
+
+## Standalone Nexus operations
+
+`include-standalone-nexus` is a feature option in the same way, but standalone operations are Nexus
+operations, so they also need `nexus-enabled`. Asking for standalone Nexus while Nexus is off fails
+the run.


### PR DESCRIPTION
Stacked PRs:
 * #444
 * #443
 * #442
 * __->__#441


--- --- ---

### Move the throughput_stress details out of the README


Per-scenario detail was most of the README. The throughput_stress section moves
to docs/throughput-stress.md, leaving a pointer and an index entry; generic
option and run-flag behavior stays in docs/running.md, which the new page
references rather than restates.

Two errors in the moved text are corrected rather than carried over: the prose
named a sleep-activity option that does not exist (the declared one is
sleep-activity-json, which the adjacent example already used), and the manual
Nexus endpoint example targeted task queue "throughput_stress:default-run-id"
when task queues are "omes-<run-id>", so it could not have worked as written.
