### PR TITLE
Report a missed capability probe instead of reading false

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ benchmark features and situations. Backwards compatibility may not be maintained
   profiles, and running against a specific SDK version.
 - **[Authoring scenarios](./docs/authoring-scenarios.md)** — writing a new scenario, choosing an
   executor, exposing options, and authoring conventions.
+- **[The throughput_stress scenario](./docs/throughput-stress.md)** — sleep activities, Nexus,
+  standalone activities, and standalone Nexus operations.
 
 ## Why the weird name?
 
@@ -244,48 +246,12 @@ with `--app` for workers and `--option project-name=...` for project scenarios.
 
 ### ThroughputStress
 
-#### Sleep Activity
+The general-purpose load scenario, used for release validation and standing load. It drives
+workflows with child workflows, activities, signals, queries, updates, continue-as-new, and
+optionally Nexus operations.
 
-The throughput_stress scenario can be configured to run "sleep" activities with different configurations.
-
-The configuration is done via a JSON file, which is passed to the scenario with the
-`--option sleep-activity-per-priority-json=@<file>` flag. Example:
-
-```
-echo '{"count":{"type":"fixed","value":5},"groups":{"high":{"weight":2,"sleepDuration":{"type":"uniform","min":"2s","max":"4s"}},"low":{"weight":3,"sleepDuration":{"type":"discrete","weights":{"5s":3,"10s":1}}}}}' > sleep.json
-go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option sleep-activity-json=@sleep.json --run-id default-run-id
-```
-
-This runs 5 sleep activities per iteration, where "high" has a weight of 2 and sleeps for a random duration between 2-4s,
-and "low" has a weight of 3 and sleeps for either 5s or 10s.
-
-Look at `DistributionField` to learn more about different kinds of distrbutions.
-
-#### Nexus 
-
-The throughput_stress scenario can generate Nexus load if the scenario is started with `--option nexus-endpoint=my-nexus-endpoint`:
-
-   ```
-   temporal operator nexus endpoint create \
-   --name my-nexus-endpoint \
-   --target-namespace default \ # Change if needed
-   --target-task-queue throughput_stress:default-run-id
-   ```
-
-1. Start the scenario with the given run-id:
-
-  ```
-  go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go --option nexus-endpoint=my-nexus-endpoint --run-id default-run-id
-  ```
-
-#### Standalone activities
-
-The throughput_stress scenario can generate standalone-activity load (activities started outside
-any workflow context via `StartActivityExecution`). This turns on automatically when the namespace
-under test reports support for standalone activities (dynamic config `activity.enableStandalone`);
-pass `--option include-standalone-activity=false` to force it off. Passing
-`--option include-standalone-activity=true` against a namespace that doesn't report support fails
-the run. Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
+Its options — sleep activities, Nexus, standalone activities and standalone Nexus operations — are
+documented in **[The throughput_stress scenario](./docs/throughput-stress.md)**.
 
 ### Fuzzer
 

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -248,6 +248,15 @@ Resolution needs a dialed client, so it happens in `loadgen.ResolveFeatureOption
 connects, not at declaration or `ResolveOptions` time. A test that calls `Configure` directly
 without also calling `ResolveFeatureOptions` sees the feature at its pflag default (`false`), not
 its capability-resolved value.
+**If you drive a scenario as a library rather than through the omes CLI, you must call
+`loadgen.ResolveFeatureOptions` yourself** once the client is dialed. The CLI does it for you; code
+that builds a `ScenarioInfo` and calls `executor.Run` directly does not get it for free. Skipping it
+does not fail the run — every feature option reads `false`, so the load quietly omits the feature —
+so reading an unresolved feature logs an error naming the option and this function. Treat that line
+as a bug in the calling code.
+
+A feature option cannot also be `MarkRequired`: required means the user must supply a value, gated
+means the namespace supplies it. Declaring both is rejected when options resolve.
 
 Reach for `o.Feature` only when a matching field exists on `NamespaceInfo_Capabilities` (from
 `DescribeNamespace`); an ordinary knob that every server supports stays a plain `o.Bool`.

--- a/docs/throughput-stress.md
+++ b/docs/throughput-stress.md
@@ -1,0 +1,64 @@
+# The throughput_stress scenario
+
+`throughput_stress` is the general-purpose load scenario: it drives workflows with child workflows,
+activities, signals, queries, updates, continue-as-new, and optionally Nexus operations. It is the
+scenario used for release validation and for standing load.
+
+For the commands that run it, the built-in run flags, and how `--option` works in general, see
+[Running omes](./running.md). This page covers the options specific to this scenario.
+
+Run `omes list-scenarios` for the authoritative list of options with their types and defaults.
+
+## Sleep activities
+
+The scenario can run "sleep" activities with different configurations, described by a JSON document
+passed with `--option sleep-activity-json`. Use `@<file>` to read it from a file:
+
+```sh
+echo '{"count":{"type":"fixed","value":5},"groups":{"high":{"weight":2,"sleepDuration":{"type":"uniform","min":"2s","max":"4s"}},"low":{"weight":3,"sleepDuration":{"type":"discrete","weights":{"5s":3,"10s":1}}}}}' > sleep.json
+
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+  --option sleep-activity-json=@sleep.json --run-id my-run
+```
+
+That runs 5 sleep activities per iteration: `high` has weight 2 and sleeps a random 2–4s, `low` has
+weight 3 and sleeps either 5s or 10s. See `DistributionField` for the kinds of distribution
+available.
+
+## Nexus
+
+`nexus-enabled` decides whether the run generates Nexus load. Nexus needs an endpoint targeting the
+run's task queue, and the scenario creates one for the run when `nexus-endpoint` is empty.
+
+To use an endpoint you manage instead, create it against the run's task queue — which is
+`omes-<run-id>` — and name it with `--option nexus-endpoint`:
+
+```sh
+temporal operator nexus endpoint create \
+  --name my-nexus-endpoint \
+  --target-namespace default \
+  --target-task-queue omes-my-run
+
+go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
+  --option nexus-enabled=true --option nexus-endpoint=my-nexus-endpoint --run-id my-run
+```
+
+Naming an endpoint while Nexus is off is rejected, rather than accepting an endpoint the run would
+never use.
+
+## Standalone activities
+
+The scenario can generate standalone-activity load — activities started outside any workflow context
+via `StartActivityExecution`. This is a feature option, described under per-scenario options in
+[Running omes](./running.md): it turns on by itself when the namespace reports support for
+standalone activities (dynamic config `activity.enableStandalone`), and
+`--option include-standalone-activity=false` forces it off. Requesting it against a namespace that
+does not report support fails the run.
+
+Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
+
+## Standalone Nexus operations
+
+`include-standalone-nexus` is a feature option in the same way, but standalone operations are Nexus
+operations, so they also need `nexus-enabled`. Asking for standalone Nexus while Nexus is off fails
+the run.

--- a/loadgen/feature_resolution_test.go
+++ b/loadgen/feature_resolution_test.go
@@ -1,0 +1,161 @@
+package loadgen
+
+import (
+	"strings"
+	"testing"
+
+	namespacev1 "go.temporal.io/api/namespace/v1"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// featureScenario declares a single capability-gated option, whose capability the
+// namespace is taken to support or not per supported.
+func featureScenario(supported bool) *Scenario {
+	return &Scenario{Options: func(o *OptionSet) {
+		o.Feature("gated", "", func(*namespacev1.NamespaceInfo_Capabilities) bool { return supported })
+	}}
+}
+
+// observedInfo returns a ScenarioInfo logging into a buffer, so a test can assert
+// on what a scenario author or operator would actually see.
+func observedInfo(t *testing.T, set *OptionSet) (*ScenarioInfo, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	return &ScenarioInfo{
+		ScenarioName: "s",
+		Namespace:    "ns",
+		Options:      set,
+		Logger:       zap.New(core).Sugar(),
+	}, logs
+}
+
+func loggedMessages(logs *observer.ObservedLogs) string {
+	var b strings.Builder
+	for _, entry := range logs.All() {
+		b.WriteString(entry.Message)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// A library caller that never probes reads false for every feature, so the run
+// quietly omits the load instead of failing. That has to be reported.
+func TestUnresolvedFeatureReadIsReported(t *testing.T) {
+	set, err := featureScenario(true).ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	info, logs := observedInfo(t, set)
+
+	if info.OptionBool("gated") {
+		t.Error("an unresolved feature reads false; that is the value being warned about")
+	}
+	got := loggedMessages(logs)
+	if !strings.Contains(got, "before resolving capabilities") {
+		t.Errorf("reading an unresolved feature should be reported, got: %q", got)
+	}
+	if !strings.Contains(got, "ResolveFeatureOptions") {
+		t.Errorf("the report should name the call that fixes it, got: %q", got)
+	}
+}
+
+func TestResolvedFeatureReadIsQuiet(t *testing.T) {
+	set, err := featureScenario(true).ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{}); err != nil {
+		t.Fatalf("resolveFeatures: %v", err)
+	}
+	info, logs := observedInfo(t, set)
+
+	if !info.OptionBool("gated") {
+		t.Error("a resolved feature should report the capability's value")
+	}
+	if got := loggedMessages(logs); got != "" {
+		t.Errorf("a resolved read should log nothing, got: %q", got)
+	}
+}
+
+// An explicit value is authoritative with or without a probe, so warning about it
+// would be noise.
+func TestExplicitFeatureReadIsQuietWithoutResolution(t *testing.T) {
+	set, err := featureScenario(true).ResolveOptions(map[string]string{"gated": "true"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	info, logs := observedInfo(t, set)
+
+	if !info.OptionBool("gated") {
+		t.Error("an explicitly supplied feature should keep the supplied value")
+	}
+	if got := loggedMessages(logs); got != "" {
+		t.Errorf("an explicit value needs no probe, so it should log nothing, got: %q", got)
+	}
+}
+
+// Set is how library callers and tests supply a value directly; it has to count as
+// deliberate, or resolution would overwrite it and reads would be reported.
+func TestSetMarksOptionAsUserSpecified(t *testing.T) {
+	set, err := featureScenario(false).ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := set.Set("gated", "true"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if !set.UserSpecified("gated") {
+		t.Fatal("a value supplied through Set should count as user-specified")
+	}
+
+	// Resolution must reject it rather than silently flip it to false.
+	err = set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{})
+	if err == nil {
+		t.Fatal("enabling a feature the namespace lacks should fail, however it was supplied")
+	}
+	if !strings.Contains(err.Error(), "explicitly enabled") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestUnresolvedFeatureReadFallsBackWithoutLogger(t *testing.T) {
+	set, err := featureScenario(true).ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// A nil Logger must not panic: library callers build ScenarioInfo by hand.
+	info := &ScenarioInfo{ScenarioName: "s", Namespace: "ns", Options: set}
+	info.OptionBool("gated")
+}
+
+func TestFailedResolutionLeavesFeaturesUnresolved(t *testing.T) {
+	// A rejected resolution must not mark the set resolved, or a later read would
+	// look trustworthy after the run had already been told it was wrong.
+	set, err := featureScenario(false).ResolveOptions(map[string]string{"gated": "true"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{}); err == nil {
+		t.Fatal("expected resolution to reject an unsupported explicit enable")
+	}
+	if set.featuresResolved {
+		t.Error("a failed resolution should not mark the set resolved")
+	}
+}
+
+func TestRequiredFeatureIsRejected(t *testing.T) {
+	s := &Scenario{Options: func(o *OptionSet) {
+		o.Feature("gated", "", func(*namespacev1.NamespaceInfo_Capabilities) bool { return true })
+		o.MarkRequired("gated")
+	}}
+	_, err := s.ResolveOptions(map[string]string{"gated": "true"})
+	if err == nil {
+		t.Fatal("required and capability-gated contradict, so declaring both should fail")
+	}
+	if !strings.Contains(err.Error(), "contradict") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/loadgen/features.go
+++ b/loadgen/features.go
@@ -8,6 +8,8 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
+
+	"github.com/temporalio/omes/clioptions"
 )
 
 // featureProbeBackoff is the wait after each failed capability probe, so the
@@ -50,7 +52,14 @@ func ResolveFeatureOptions(
 
 	for _, name := range opts.sortedFeatureNames() {
 		enabled, _ := opts.GetBool(name)
-		logger.Infof("feature %s enabled for namespace %q? %v", name, namespace, enabled)
+		msg := fmt.Sprintf("feature %s enabled for namespace %q? %v", name, namespace, enabled)
+		// Library callers reach this without a zap logger; a nil one would panic
+		// here and take down a run that had otherwise resolved correctly.
+		if logger != nil {
+			logger.Info(msg)
+		} else {
+			clioptions.BackupLogger.Println(msg)
+		}
 	}
 	return nil
 }

--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -46,7 +46,7 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 	endpointName := info.OptionString("nexus-endpoint")
 	if endpointName == "" {
 		var err error
-		endpointName, err = ensureNexusEndpoint(ctx, info.Client, info.Namespace, info.RunID)
+		endpointName, err = info.EnsureNexusEndpoint(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create nexus endpoint: %w", err)
 		}

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -27,6 +27,23 @@ type OptionSet struct {
 	// features holds the capability predicate for each option declared with
 	// Feature, keyed by name.
 	features map[string]func(*namespacev1.NamespaceInfo_Capabilities) bool
+	// featuresResolved records that the set has been reconciled against reported
+	// capabilities. Until it is, an unset feature option reads false whether or not
+	// it is supported, which is the wrong answer rather than a missing one — so
+	// reads before then are reported.
+	featuresResolved bool
+}
+
+// Set records the value as deliberately chosen, on top of pflag's own
+// bookkeeping. Values that arrive this way are authoritative and are left alone
+// by capability resolution, so a caller that sets an option directly gets the
+// same treatment as a user passing `--option`.
+func (o *OptionSet) Set(name, value string) error {
+	if err := o.FlagSet.Set(name, value); err != nil {
+		return err
+	}
+	o.explicit[name] = struct{}{}
+	return nil
 }
 
 // MarkRequired fails any run that does not explicitly supply the named options.
@@ -95,7 +112,22 @@ func (o *OptionSet) resolveFeatures(caps *namespacev1.NamespaceInfo_Capabilities
 				name))
 		}
 	}
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	o.featuresResolved = true
+	return nil
+}
+
+// unresolvedFeature reports whether reading name would return a value that has
+// not been reconciled against reported capabilities. An explicitly supplied
+// value is authoritative on its own, so only an untouched option qualifies.
+func (o *OptionSet) unresolvedFeature(name string) bool {
+	if o.featuresResolved || o.UserSpecified(name) {
+		return false
+	}
+	_, isFeature := o.features[name]
+	return isFeature
 }
 
 func newOptionSet(name string) *OptionSet {
@@ -227,13 +259,19 @@ func (s *Scenario) ResolveOptions(provided map[string]string) (*OptionSet, error
 				name, flag.Value.Type(), provided[name]))
 			continue
 		}
-		set.explicit[name] = struct{}{}
 	}
 
 	for _, name := range sortedRequired(set.required) {
 		flag := set.Lookup(name)
 		if flag == nil {
 			errs = append(errs, fmt.Errorf("option %q is marked required but not declared", name))
+			continue
+		}
+		if _, isFeature := set.features[name]; isFeature {
+			// Required means the user must supply it; a feature supplies itself from
+			// the namespace. Declaring both is a scenario bug, not user error.
+			errs = append(errs, fmt.Errorf(
+				"option %q is declared as both required and capability-gated, which contradict", name))
 			continue
 		}
 		if !flag.Changed {

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -206,6 +206,8 @@ func (s *ScenarioInfo) OptionBool(name string) bool {
 	v, err := s.options().GetBool(name)
 	if err != nil {
 		s.undeclaredOption(name, err)
+	} else if s.options().unresolvedFeature(name) {
+		s.unresolvedFeatureOption(name)
 	}
 	return v
 }
@@ -241,6 +243,34 @@ func (s *ScenarioInfo) options() *OptionSet {
 		s.Options = newOptionSet("")
 	}
 	return s.Options
+}
+
+// logf logs at info level, tolerating a ScenarioInfo built without a logger —
+// library callers assemble one by hand and need not set every field.
+func (s *ScenarioInfo) logf(format string, args ...any) {
+	if s.Logger != nil {
+		s.Logger.Infof(format, args...)
+	} else {
+		clioptions.BackupLogger.Printf(format, args...)
+	}
+}
+
+// unresolvedFeatureOption reports a feature option read before any namespace
+// probe ran, which leaves it false and quietly drops the feature from the load.
+// It is an error rather than a warning because a run generating less load than
+// intended otherwise looks exactly like one that worked. Callers driving a
+// scenario as a library, rather than through the omes CLI, must call
+// [ResolveFeatureOptions] once the client is dialed.
+func (s *ScenarioInfo) unresolvedFeatureOption(name string) {
+	msg := fmt.Sprintf("scenario %q read feature option %q before resolving capabilities for "+
+		"namespace %q, so it reads false whether or not the option is supported; "+
+		"call loadgen.ResolveFeatureOptions after dialing to fix this",
+		s.ScenarioName, name, s.Namespace)
+	if s.Logger != nil {
+		s.Logger.Error(msg)
+	} else {
+		clioptions.BackupLogger.Println(msg)
+	}
 }
 
 func (s *ScenarioInfo) undeclaredOption(name string, err error) {
@@ -401,8 +431,20 @@ func TaskQueueForRun(runID string) string {
 
 // EnsureNexusEndpoint returns the Nexus endpoint for this run, creating it if it
 // does not already exist. Call this when Nexus is enabled without a named endpoint.
+//
+// Creating an endpoint changes the namespace, and a capability probe can enable
+// Nexus without the user asking for it, so a created endpoint is logged
+// distinctly from a reused one: on a shared or production namespace, that line is
+// how an operator sees that this run added something.
 func (s *ScenarioInfo) EnsureNexusEndpoint(ctx context.Context) (string, error) {
-	return ensureNexusEndpoint(ctx, s.Client, s.Namespace, s.RunID)
+	endpoint, created, err := ensureNexusEndpoint(ctx, s.Client, s.Namespace, s.RunID)
+	if err != nil {
+		return "", err
+	}
+	if created {
+		s.logf("Created Nexus endpoint %q in namespace %q for this run", endpoint, s.Namespace)
+	}
+	return endpoint, nil
 }
 
 // NexusEndpointForRun returns a sanitized Nexus endpoint name for the given run ID.
@@ -412,7 +454,9 @@ func NexusEndpointForRun(runID string) string {
 }
 
 // ensureNexusEndpoint creates a Nexus endpoint for the given run, or returns nil if it already exists.
-func ensureNexusEndpoint(ctx context.Context, cl client.Client, namespace, runID string) (string, error) {
+// ensureNexusEndpoint returns the run's endpoint name and whether this call was
+// the one that created it.
+func ensureNexusEndpoint(ctx context.Context, cl client.Client, namespace, runID string) (string, bool, error) {
 	endpointName := NexusEndpointForRun(runID)
 	taskQueue := TaskQueueForRun(runID)
 	_, err := cl.OperatorService().CreateNexusEndpoint(ctx,
@@ -431,11 +475,11 @@ func ensureNexusEndpoint(ctx context.Context, cl client.Client, namespace, runID
 		})
 	if err != nil {
 		if status.Code(err) == codes.AlreadyExists {
-			return endpointName, nil
+			return endpointName, false, nil
 		}
-		return "", err
+		return "", false, err
 	}
-	return endpointName, nil
+	return endpointName, true, nil
 }
 
 func (r *Run) TaskQueue() string {


### PR DESCRIPTION
Stacked PRs:
 * #444
 * #443
 * __->__#442
 * #441


--- --- ---

### Report a missed capability probe instead of reading false


Feature options are resolved by ResolveFeatureOptions, which only the omes CLI
calls. Code driving a scenario as a library — VCR and oss-cicd build a
ScenarioInfo and call executor.Run directly — never resolves them, so every
feature option reads false and the run omits the feature it was meant to
exercise, indistinguishable from a run that worked.

The OptionSet now tracks resolution, and reading an unresolved feature reports
the option and the call that fixes it. An explicitly supplied value is
authoritative without a probe, so only an untouched option is reported, and a
failed resolution leaves the set unresolved. OptionSet.Set records a value as
deliberately chosen, which is what lets a library caller or a test set an option
directly and have it treated like a user passing --option.

Also:

- ResolveFeatureOptions no longer panics on a nil logger, which library callers
  are the ones to pass.
- A created Nexus endpoint is logged distinctly from a reused one, so an operator
  can see the run added something to the namespace. FuzzExecutor goes through the
  same path instead of duplicating it.
- Declaring an option both required and capability-gated is rejected: required
  means the user must supply it, gated means the namespace does.
