### PR TITLE
Bound the capability probe and stop retrying refusals

### DIFF
--- a/loadgen/features.go
+++ b/loadgen/features.go
@@ -8,6 +8,8 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/omes/clioptions"
 )
@@ -15,6 +17,12 @@ import (
 // featureProbeBackoff is the wait after each failed capability probe, so the
 // probe makes up to len(featureProbeBackoff)+1 attempts before giving up.
 var featureProbeBackoff = []time.Duration{300 * time.Millisecond, 600 * time.Millisecond, 1200 * time.Millisecond}
+
+// featureProbeTimeout bounds a single attempt. Without it a server that answers
+// slowly rather than not at all would hang the start of the run indefinitely: the
+// context here carries no deadline, and retries never begin because the attempt
+// never ends.
+const featureProbeTimeout = 10 * time.Second
 
 // ResolveFeatureOptions finalizes capability-gated options declared with
 // [OptionSet.Feature] against the namespace under test. It is a no-op for a
@@ -27,23 +35,13 @@ func ResolveFeatureOptions(
 		return nil
 	}
 
-	var resp *workflowservice.DescribeNamespaceResponse
-	var err error
-	for attempt := 0; ; attempt++ {
-		resp, err = cl.WorkflowService().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
-			Namespace: namespace,
+	resp, err := probe(ctx, "namespace capabilities",
+		func(ctx context.Context) (*workflowservice.DescribeNamespaceResponse, error) {
+			return cl.WorkflowService().DescribeNamespace(ctx,
+				&workflowservice.DescribeNamespaceRequest{Namespace: namespace})
 		})
-		if err == nil {
-			break
-		}
-		if attempt >= len(featureProbeBackoff) {
-			return fmt.Errorf("failed to probe namespace capabilities: %w", err)
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("failed to probe namespace capabilities: %w", ctx.Err())
-		case <-time.After(featureProbeBackoff[attempt]):
-		}
+	if err != nil {
+		return err
 	}
 
 	if err := opts.resolveFeatures(resp.GetNamespaceInfo().GetCapabilities()); err != nil {
@@ -62,4 +60,46 @@ func ResolveFeatureOptions(
 		}
 	}
 	return nil
+}
+
+// probe calls get until it succeeds, giving each attempt featureProbeTimeout and
+// waiting out featureProbeBackoff in between. Resolution is all-or-nothing:
+// guessing at a capability would silently change the load, so a probe that never
+// answers fails the run.
+func probe[T any](ctx context.Context, what string, get func(context.Context) (T, error)) (T, error) {
+	var resp T
+	var err error
+	for attempt := 0; ; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, featureProbeTimeout)
+		resp, err = get(attemptCtx)
+		cancel()
+		if err == nil {
+			return resp, nil
+		}
+		// Retrying a refusal only delays the report: the answer will not change.
+		if !retryableProbeError(err) || attempt >= len(featureProbeBackoff) {
+			return resp, fmt.Errorf("failed to probe %s: %w", what, err)
+		}
+		select {
+		case <-ctx.Done():
+			return resp, fmt.Errorf("failed to probe %s: %w", what, ctx.Err())
+		case <-time.After(featureProbeBackoff[attempt]):
+		}
+	}
+}
+
+// retryableProbeError reports whether another attempt could plausibly answer.
+// Rejections that describe the caller rather than the server's condition —
+// missing permission, an unimplemented call — are settled on the first attempt.
+func retryableProbeError(err error) bool {
+	switch status.Code(err) {
+	case codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.Unimplemented,
+		codes.InvalidArgument,
+		codes.NotFound,
+		codes.FailedPrecondition:
+		return false
+	}
+	return true
 }

--- a/loadgen/features_test.go
+++ b/loadgen/features_test.go
@@ -28,7 +28,5 @@ func TestResolveFeatureOptionsNoopWithNilOptions(t *testing.T) {
 	}
 }
 
-// Probe retry/failure paths need a WorkflowService stub. There is no existing
-// fake in loadgen or internal for this, so those cases are left untested here
-// rather than introduce a new mocking dependency; see the plan doc for the
-// intended behavior (3 attempts, 300ms/600ms/1.2s backoff).
+// Retrying, giving up, and bounding an attempt are covered in probe_test.go,
+// which drives probe directly rather than through a WorkflowService stub.

--- a/loadgen/probe_test.go
+++ b/loadgen/probe_test.go
@@ -1,0 +1,184 @@
+package loadgen
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// shortenProbeBackoff keeps the retrying tests fast without changing the number
+// of attempts, which is what they are about.
+func shortenProbeBackoff(t *testing.T) {
+	t.Helper()
+	original := featureProbeBackoff
+	featureProbeBackoff = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { featureProbeBackoff = original })
+}
+
+func TestRetryableProbeError(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		// A refusal describes the caller, and says the same thing every time.
+		{name: "permission denied", err: status.Error(codes.PermissionDenied, "no"), retryable: false},
+		{name: "unauthenticated", err: status.Error(codes.Unauthenticated, "no"), retryable: false},
+		{name: "unimplemented", err: status.Error(codes.Unimplemented, "no"), retryable: false},
+		{name: "invalid argument", err: status.Error(codes.InvalidArgument, "no"), retryable: false},
+		{name: "not found", err: status.Error(codes.NotFound, "no"), retryable: false},
+		{name: "failed precondition", err: status.Error(codes.FailedPrecondition, "no"), retryable: false},
+
+		// These describe the server's condition, which can change.
+		{name: "unavailable", err: status.Error(codes.Unavailable, "later"), retryable: true},
+		{name: "deadline exceeded", err: status.Error(codes.DeadlineExceeded, "slow"), retryable: true},
+		{name: "resource exhausted", err: status.Error(codes.ResourceExhausted, "busy"), retryable: true},
+		{name: "internal", err: status.Error(codes.Internal, "oops"), retryable: true},
+
+		// Not a gRPC status at all: nothing says it is permanent, so retry.
+		{name: "plain error", err: errors.New("boom"), retryable: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := retryableProbeError(tc.err); got != tc.retryable {
+				t.Errorf("retryable: want %v, got %v", tc.retryable, got)
+			}
+		})
+	}
+}
+
+func TestProbeSucceedsWithoutRetrying(t *testing.T) {
+	attempts := 0
+	got, err := probe(t.Context(), "thing", func(context.Context) (string, error) {
+		attempts++
+		return "answer", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "answer" {
+		t.Errorf("want the value the call returned, got %q", got)
+	}
+	if attempts != 1 {
+		t.Errorf("a call that succeeds should be made once, made %d", attempts)
+	}
+}
+
+func TestProbeRetriesUntilItSucceeds(t *testing.T) {
+	shortenProbeBackoff(t)
+
+	attempts := 0
+	got, err := probe(t.Context(), "thing", func(context.Context) (string, error) {
+		attempts++
+		if attempts < 3 {
+			return "", status.Error(codes.Unavailable, "not yet")
+		}
+		return "answer", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "answer" || attempts != 3 {
+		t.Errorf("want the value once available after 3 attempts, got %q after %d", got, attempts)
+	}
+}
+
+// A probe that never answers has to end, and end the run: guessing at a
+// capability would silently change the load.
+func TestProbeGivesUpAfterExhaustingBackoff(t *testing.T) {
+	shortenProbeBackoff(t)
+
+	attempts := 0
+	_, err := probe(t.Context(), "server capabilities", func(context.Context) (string, error) {
+		attempts++
+		return "", status.Error(codes.Unavailable, "down")
+	})
+	if err == nil {
+		t.Fatal("expected a probe that never answers to fail")
+	}
+	if want := len(featureProbeBackoff) + 1; attempts != want {
+		t.Errorf("want %d attempts, made %d", want, attempts)
+	}
+	if !strings.Contains(err.Error(), "server capabilities") {
+		t.Errorf("error should name what was being probed, got: %v", err)
+	}
+}
+
+func TestProbeDoesNotRetryAPermanentRejection(t *testing.T) {
+	shortenProbeBackoff(t)
+
+	attempts := 0
+	_, err := probe(t.Context(), "thing", func(context.Context) (string, error) {
+		attempts++
+		return "", status.Error(codes.PermissionDenied, "not allowed")
+	})
+	if err == nil {
+		t.Fatal("expected a refused probe to fail")
+	}
+	if attempts != 1 {
+		t.Errorf("a refusal should not be retried; made %d attempts", attempts)
+	}
+}
+
+// Each attempt is bounded, so a server that answers slowly rather than not at all
+// cannot hang the start of the run.
+func TestProbeBoundsEachAttempt(t *testing.T) {
+	deadline, ok := probeAttemptDeadline(t)
+	if !ok {
+		t.Fatal("each attempt should carry a deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > featureProbeTimeout {
+		t.Errorf("attempt deadline should be within the probe timeout, got %v remaining", remaining)
+	}
+}
+
+func probeAttemptDeadline(t *testing.T) (time.Time, bool) {
+	t.Helper()
+	var deadline time.Time
+	var ok bool
+	_, err := probe(t.Context(), "thing", func(ctx context.Context) (string, error) {
+		deadline, ok = ctx.Deadline()
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return deadline, ok
+}
+
+// Cancelling the run stops the probe rather than working through the backoff, and
+// the reason stays recognizable.
+func TestProbeStopsWhenTheRunIsCancelled(t *testing.T) {
+	original := featureProbeBackoff
+	featureProbeBackoff = []time.Duration{time.Hour}
+	t.Cleanup(func() { featureProbeBackoff = original })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	attempts := 0
+	done := make(chan error, 1)
+	go func() {
+		_, err := probe(ctx, "thing", func(context.Context) (string, error) {
+			attempts++
+			cancel()
+			return "", status.Error(codes.Unavailable, "down")
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("want a cancelled context to surface, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("probe kept waiting after the run was cancelled")
+	}
+	if attempts != 1 {
+		t.Errorf("want 1 attempt before cancellation, made %d", attempts)
+	}
+}


### PR DESCRIPTION
Stacked PRs:
 * #444
 * __->__#443


--- --- ---

### Bound the capability probe and stop retrying refusals


The probe had no per-attempt timeout and runs under a context with no deadline —
--connect-timeout covers dialing only. A server answering slowly rather than not
at all would hang the start of every run of a scenario that declares features,
with the retries never beginning because the attempt never ended. Each attempt is
now bounded, so the worst case is a bounded failure.

It also retried every failure. A refusal that describes the caller rather than
the server's condition — missing permission, an unimplemented call — says the
same thing on every attempt, so those now fail on the first.

The retry loop moves into a helper that takes the call as a function, which is
what lets the retry, give-up, no-retry, timeout, and cancellation paths be tested
without a WorkflowService stub.
