### PR TITLE
Share the Nexus options and gate them on reported capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
             --run-id ${{ github.run_id }} \
             --connect-timeout 1m \
             --iterations 5
+      # This checks that a built worker can run the scenario at all, so the load
+      # shape is pinned rather than following what the server supports. Nexus is
+      # on by default and needs the worker to handle Nexus operations, which not
+      # every language does; Nexus itself is covered by the Go tests.
       - name: Smoke test throughput_stress to confirm build is usable against ${{ matrix.sdk }} worker
         timeout-minutes: 10
         run: |
@@ -174,7 +178,8 @@ jobs:
             --option internal-iterations=2 \
             --option continue-as-new-after-iterations=1 \
             --option sleep-time=1ms \
-            --option visibility-count-timeout=2m
+            --option visibility-count-timeout=2m \
+            --option nexus-enabled=false
 
   build-worker-from-source:
     runs-on: ubuntu-latest
@@ -249,7 +254,8 @@ jobs:
             --option internal-iterations=2 \
             --option continue-as-new-after-iterations=1 \
             --option sleep-time=1ms \
-            --option visibility-count-timeout=2m
+            --option visibility-count-timeout=2m \
+            --option nexus-enabled=false
 
   build-project:
     runs-on: ubuntu-latest

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -175,7 +175,7 @@ loadgen.MustRegisterScenario(loadgen.Scenario{
 
 		// Gated on a namespace capability; see "Feature options" below.
 		o.Feature("include-standalone-activity", "Include standalone activities.",
-			func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneActivities() })
+			func(c loadgen.Capabilities) bool { return c.Namespace.GetStandaloneActivities() })
 	},
 	ExecutorFn: /* ... */,
 })
@@ -192,6 +192,14 @@ Declaring buys you three things:
 
 If your scenario uses a shared executor that reads options of its own, call that executor's declaration
 helper from yours — for example `loadgen.DeclareFuzzExecutorOptions(o)`.
+
+Options shared by several scenarios are declared the same way, so their names, defaults, and meaning
+are defined once. If your scenario can generate Nexus load, declare it with
+`loadgen.DeclareNexusOptions(o)` and settle it at run time with
+`info.ResolveNexusConfig(ctx)`, which decides whether the server supports Nexus and creates an
+endpoint if the run needs one. For an option that adds to Nexus load rather than producing it — a
+standalone-operations switch, say — gate it with `loadgen.IncludeNexusSubFeature`, so Nexus being off
+takes its sub-features with it instead of failing the run.
 
 ### Read them
 
@@ -232,10 +240,10 @@ with `o.Feature`:
 
 ```go
 o.Feature("include-standalone-nexus", "Include standalone Nexus operations.",
-	func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneNexusOperation() })
+	func(c loadgen.Capabilities) bool { return c.Namespace.GetStandaloneNexusOperation() })
 ```
 
-| Config | Namespace reports capability | Result |
+| Config | Capability reported | Result |
 | --- | --- | --- |
 | unset | yes | enabled |
 | unset | no | disabled |
@@ -248,6 +256,7 @@ Resolution needs a dialed client, so it happens in `loadgen.ResolveFeatureOption
 connects, not at declaration or `ResolveOptions` time. A test that calls `Configure` directly
 without also calling `ResolveFeatureOptions` sees the feature at its pflag default (`false`), not
 its capability-resolved value.
+
 **If you drive a scenario as a library rather than through the omes CLI, you must call
 `loadgen.ResolveFeatureOptions` yourself** once the client is dialed. The CLI does it for you; code
 that builds a `ScenarioInfo` and calls `executor.Run` directly does not get it for free. Skipping it
@@ -258,8 +267,10 @@ as a bug in the calling code.
 A feature option cannot also be `MarkRequired`: required means the user must supply a value, gated
 means the namespace supplies it. Declaring both is rejected when options resolve.
 
-Reach for `o.Feature` only when a matching field exists on `NamespaceInfo_Capabilities` (from
-`DescribeNamespace`); an ordinary knob that every server supports stays a plain `o.Bool`.
+The predicate is handed a `loadgen.Capabilities`, carrying both what the namespace reports
+(`DescribeNamespace`) and what the server as a whole reports (`GetSystemInfo`) — gate on whichever
+answers your question. Reach for `o.Feature` only when one of them has a matching field; an ordinary
+knob that every server supports stays a plain `o.Bool`.
 
 ### Conventions for options
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -82,11 +82,11 @@ Scenario-specific knobs are passed as repeated `--option key=value` pairs. Each 
 options it accepts; `list-scenarios` prints them with their types and defaults. A value may be loaded
 from a file with `@`: `--option sleep-activity-json=@sleep.json`.
 
-Some options are feature options: they turn on by default when the namespace under test reports
-support for the underlying capability, off when it does not. Pass `=false` to force one off
-regardless of what the namespace supports; explicitly passing `=true` against a namespace that
-doesn't report support fails the run. `list-scenarios` marks these with a dynamic default instead
-of a fixed one.
+Some options are feature options: they turn on by default when the server reports support for the
+underlying capability — some capabilities are reported per namespace, others by the server as a whole
+— and off when it does not. Pass `=false` to force one off regardless; explicitly passing `=true`
+where support is not reported fails the run. `list-scenarios` marks these with a dynamic default
+instead of a fixed one.
 
 ```sh
 go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \

--- a/docs/throughput-stress.md
+++ b/docs/throughput-stress.md
@@ -27,8 +27,14 @@ available.
 
 ## Nexus
 
-`nexus-enabled` decides whether the run generates Nexus load. Nexus needs an endpoint targeting the
-run's task queue, and the scenario creates one for the run when `nexus-endpoint` is empty.
+`nexus-enabled` decides whether the run generates Nexus load. It is a feature option gated on the
+server supporting Nexus, and **on by default wherever it does** — omes is a testing tool, so the
+useful default is to exercise what the server can do. Against a server without Nexus it turns itself
+off, so the default is safe anywhere; asking for Nexus explicitly there fails instead, since the run
+cannot do what was asked.
+
+Nexus needs an endpoint targeting the run's task queue. The scenario creates one for the run when
+`nexus-endpoint` is empty, and logs that it did.
 
 To use an endpoint you manage instead, create it against the run's task queue — which is
 `omes-<run-id>` — and name it with `--option nexus-endpoint`:
@@ -40,11 +46,11 @@ temporal operator nexus endpoint create \
   --target-task-queue omes-my-run
 
 go run ./cmd/omes run-scenario-with-worker --scenario throughput_stress --language go \
-  --option nexus-enabled=true --option nexus-endpoint=my-nexus-endpoint --run-id my-run
+  --option nexus-endpoint=my-nexus-endpoint --run-id my-run
 ```
 
-Naming an endpoint while Nexus is off is rejected, rather than accepting an endpoint the run would
-never use.
+To generate no Nexus load at all, pass `--option nexus-enabled=false`. Naming an endpoint while Nexus
+is off is rejected, rather than accepting an endpoint the run would never use.
 
 ## Standalone activities
 
@@ -59,6 +65,15 @@ Implemented for the Go, Python, TypeScript, .NET, Java, and Ruby workers.
 
 ## Standalone Nexus operations
 
-`include-standalone-nexus` is a feature option in the same way, but standalone operations are Nexus
-operations, so they also need `nexus-enabled`. Asking for standalone Nexus while Nexus is off fails
-the run.
+`include-standalone-nexus` is a feature option in the same way, but it only adds to a run that is
+already generating Nexus load. `nexus-enabled` governs that, and a capability probe never turns it
+on: the probe decides whether standalone operations are *part of* the Nexus load, not whether there
+is any.
+
+| `nexus-enabled` | Standalone Nexus reported | Result |
+| --- | --- | --- |
+| on (default) | yes | Nexus load including standalone operations |
+| on (default) | no | Nexus load without standalone operations |
+| `=false` | either | no Nexus load; standalone Nexus not included |
+
+Asking for `include-standalone-nexus=true` while Nexus is off is a contradiction, and fails the run.

--- a/loadgen/feature_resolution_test.go
+++ b/loadgen/feature_resolution_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	namespacev1 "go.temporal.io/api/namespace/v1"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -15,7 +13,7 @@ import (
 // namespace is taken to support or not per supported.
 func featureScenario(supported bool) *Scenario {
 	return &Scenario{Options: func(o *OptionSet) {
-		o.Feature("gated", "", func(*namespacev1.NamespaceInfo_Capabilities) bool { return supported })
+		o.Feature("gated", "", func(Capabilities) bool { return supported })
 	}}
 }
 
@@ -67,7 +65,7 @@ func TestResolvedFeatureReadIsQuiet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{}); err != nil {
+	if err := set.resolveFeatures(Capabilities{}); err != nil {
 		t.Fatalf("resolveFeatures: %v", err)
 	}
 	info, logs := observedInfo(t, set)
@@ -112,7 +110,7 @@ func TestSetMarksOptionAsUserSpecified(t *testing.T) {
 	}
 
 	// Resolution must reject it rather than silently flip it to false.
-	err = set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{})
+	err = set.resolveFeatures(Capabilities{})
 	if err == nil {
 		t.Fatal("enabling a feature the namespace lacks should fail, however it was supplied")
 	}
@@ -138,7 +136,7 @@ func TestFailedResolutionLeavesFeaturesUnresolved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{}); err == nil {
+	if err := set.resolveFeatures(Capabilities{}); err == nil {
 		t.Fatal("expected resolution to reject an unsupported explicit enable")
 	}
 	if set.featuresResolved {
@@ -148,7 +146,7 @@ func TestFailedResolutionLeavesFeaturesUnresolved(t *testing.T) {
 
 func TestRequiredFeatureIsRejected(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("gated", "", func(*namespacev1.NamespaceInfo_Capabilities) bool { return true })
+		o.Feature("gated", "", func(Capabilities) bool { return true })
 		o.MarkRequired("gated")
 	}}
 	_, err := s.ResolveOptions(map[string]string{"gated": "true"})

--- a/loadgen/features.go
+++ b/loadgen/features.go
@@ -14,8 +14,8 @@ import (
 	"github.com/temporalio/omes/clioptions"
 )
 
-// featureProbeBackoff is the wait after each failed capability probe, so the
-// probe makes up to len(featureProbeBackoff)+1 attempts before giving up.
+// featureProbeBackoff is the wait after each failed capability probe, so a probe
+// makes up to len(featureProbeBackoff)+1 attempts before giving up.
 var featureProbeBackoff = []time.Duration{300 * time.Millisecond, 600 * time.Millisecond, 1200 * time.Millisecond}
 
 // featureProbeTimeout bounds a single attempt. Without it a server that answers
@@ -25,9 +25,9 @@ var featureProbeBackoff = []time.Duration{300 * time.Millisecond, 600 * time.Mil
 const featureProbeTimeout = 10 * time.Second
 
 // ResolveFeatureOptions finalizes capability-gated options declared with
-// [OptionSet.Feature] against the namespace under test. It is a no-op for a
-// scenario that declares none, so such a scenario never pays for a
-// DescribeNamespace call and can't be broken by one failing.
+// [OptionSet.Feature] against what the server reports. It is a no-op for a
+// scenario that declares none, so such a scenario never pays for the calls and
+// cannot be broken by one failing.
 func ResolveFeatureOptions(
 	ctx context.Context, cl client.Client, namespace string, opts *OptionSet, logger *zap.SugaredLogger,
 ) error {
@@ -35,16 +35,11 @@ func ResolveFeatureOptions(
 		return nil
 	}
 
-	resp, err := probe(ctx, "namespace capabilities",
-		func(ctx context.Context) (*workflowservice.DescribeNamespaceResponse, error) {
-			return cl.WorkflowService().DescribeNamespace(ctx,
-				&workflowservice.DescribeNamespaceRequest{Namespace: namespace})
-		})
+	caps, err := fetchCapabilities(ctx, cl, namespace)
 	if err != nil {
 		return err
 	}
-
-	if err := opts.resolveFeatures(resp.GetNamespaceInfo().GetCapabilities()); err != nil {
+	if err := opts.ResolveFeaturesFromCapabilities(caps); err != nil {
 		return err
 	}
 
@@ -60,6 +55,33 @@ func ResolveFeatureOptions(
 		}
 	}
 	return nil
+}
+
+// fetchCapabilities reads both what the namespace reports and what the server as
+// a whole reports, since a feature may be gated on either.
+func fetchCapabilities(ctx context.Context, cl client.Client, namespace string) (Capabilities, error) {
+	var caps Capabilities
+
+	ns, err := probe(ctx, "namespace capabilities",
+		func(ctx context.Context) (*workflowservice.DescribeNamespaceResponse, error) {
+			return cl.WorkflowService().DescribeNamespace(ctx,
+				&workflowservice.DescribeNamespaceRequest{Namespace: namespace})
+		})
+	if err != nil {
+		return Capabilities{}, err
+	}
+	caps.Namespace = ns.GetNamespaceInfo().GetCapabilities()
+
+	sys, err := probe(ctx, "server capabilities",
+		func(ctx context.Context) (*workflowservice.GetSystemInfoResponse, error) {
+			return cl.WorkflowService().GetSystemInfo(ctx, &workflowservice.GetSystemInfoRequest{})
+		})
+	if err != nil {
+		return Capabilities{}, err
+	}
+	caps.System = sys.GetCapabilities()
+
+	return caps, nil
 }
 
 // probe calls get until it succeeds, giving each attempt featureProbeTimeout and

--- a/loadgen/fuzz_executor.go
+++ b/loadgen/fuzz_executor.go
@@ -33,7 +33,7 @@ type FuzzExecutor struct {
 // Scenarios using it should call this from their own Options declaration so the
 // options validate and appear in `list-scenarios`.
 func DeclareFuzzExecutorOptions(o *OptionSet) {
-	o.String("nexus-endpoint", "", "Nexus endpoint to use. Empty creates one for this run.")
+	declareNexusEndpointOption(o)
 	o.String("kitchen-sink-gen", "", "Name of, or absolute path to, the kitchen-sink-gen executable.")
 }
 
@@ -42,16 +42,15 @@ func (k FuzzExecutor) Run(ctx context.Context, info ScenarioInfo) error {
 		return fmt.Errorf("InitInputs must be specified")
 	}
 
-	// Use a user-provided nexus endpoint, or auto-create one for this run
-	endpointName := info.OptionString("nexus-endpoint")
-	if endpointName == "" {
-		var err error
-		endpointName, err = info.EnsureNexusEndpoint(ctx)
-		if err != nil {
+	// The generated actions drive Nexus operations against this endpoint, so it has
+	// to exist before they run, and InitInputs below names the same one. An endpoint
+	// the user named is theirs to have created.
+	if info.OptionString(NexusEndpointOption) == "" {
+		if _, err := info.EnsureNexusEndpoint(ctx); err != nil {
 			return fmt.Errorf("failed to create nexus endpoint: %w", err)
 		}
 	}
-	info.Logger.Infof("Using nexus endpoint %q", endpointName)
+	info.Logger.Infof("Using nexus endpoint %q", info.NexusEndpointName())
 
 	var testInputs []*kitchensink.TestInput
 	// Load or generate inputs

--- a/loadgen/nexus.go
+++ b/loadgen/nexus.go
@@ -1,0 +1,91 @@
+package loadgen
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// NexusEnabledOption governs whether a run generates Nexus load at all.
+	NexusEnabledOption = "nexus-enabled"
+	// NexusEndpointOption names the endpoint to drive Nexus operations through.
+	NexusEndpointOption = "nexus-endpoint"
+)
+
+// DeclareNexusOptions declares the options shared by every scenario that can
+// generate Nexus load, so the names, defaults, and meaning are defined once.
+// Scenarios call it from their own Options declaration.
+//
+// Nexus is gated on the server supporting it, and enabled by default where it
+// does: omes is a testing tool, so the useful default is to exercise what the
+// server can do. Set the option false to generate no Nexus load regardless, which
+// also keeps the run from creating a Nexus endpoint.
+func DeclareNexusOptions(o *OptionSet) {
+	o.Feature(NexusEnabledOption, "Generate Nexus load.",
+		func(c Capabilities) bool { return c.System.GetNexus() })
+	declareNexusEndpointOption(o)
+}
+
+func declareNexusEndpointOption(o *OptionSet) {
+	o.String(NexusEndpointOption, "", "Nexus endpoint to use. Empty creates one for this run.")
+}
+
+// NexusConfig is the resolved Nexus setup for a run.
+type NexusConfig struct {
+	// Enabled reports whether this run should generate Nexus load. It is false
+	// when the option is off and when the server does not support Nexus.
+	Enabled bool
+	// Endpoint is the endpoint to drive operations through, empty when disabled.
+	Endpoint string
+}
+
+// NexusEndpointName returns the endpoint this run drives Nexus operations
+// through: the one the user named, or the conventional name for the run. It does
+// not create anything, so it is safe to call while building generator input.
+func (s *ScenarioInfo) NexusEndpointName() string {
+	if endpoint := s.OptionString(NexusEndpointOption); endpoint != "" {
+		return endpoint
+	}
+	return NexusEndpointForRun(s.RunID)
+}
+
+// ResolveNexusConfig settles whether the run generates Nexus load and against
+// which endpoint, creating the endpoint if the run needs one. Call it once the
+// client is dialed, and after [ResolveFeatureOptions]: nexus-enabled is gated on
+// the server supporting Nexus, so it is that call which decides the default.
+func (s *ScenarioInfo) ResolveNexusConfig(ctx context.Context) (NexusConfig, error) {
+	endpoint := s.OptionString(NexusEndpointOption)
+	if !s.OptionBool(NexusEnabledOption) {
+		if endpoint != "" {
+			return NexusConfig{}, fmt.Errorf("%s was set but %s is false",
+				NexusEndpointOption, NexusEnabledOption)
+		}
+		return NexusConfig{}, nil
+	}
+
+	if endpoint == "" {
+		var err error
+		endpoint, err = s.EnsureNexusEndpoint(ctx)
+		if err != nil {
+			return NexusConfig{}, fmt.Errorf("failed to create nexus endpoint: %w", err)
+		}
+	}
+	return NexusConfig{Enabled: true, Endpoint: endpoint}, nil
+}
+
+// IncludeNexusSubFeature settles an option that adds to Nexus load rather than
+// producing it, such as standalone operations. Nexus being off wins over a
+// sub-feature a capability probe switched on, since there is no Nexus load to add
+// to; asking for one explicitly with Nexus off is a contradiction and an error.
+func IncludeNexusSubFeature(info *ScenarioInfo, option string, nexusEnabled bool) (bool, error) {
+	include := info.OptionBool(option)
+	if !include || nexusEnabled {
+		return include, nil
+	}
+	if info.OptionUserSpecified(option) {
+		return false, fmt.Errorf("%s requires %s", option, NexusEnabledOption)
+	}
+	info.logf("not including %s: the namespace supports it, but %s is off, so this run generates "+
+		"no Nexus load", option, NexusEnabledOption)
+	return false, nil
+}

--- a/loadgen/nexus_test.go
+++ b/loadgen/nexus_test.go
@@ -1,0 +1,189 @@
+package loadgen
+
+import (
+	"strings"
+	"testing"
+
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+// Capability resolution is exercised here by handing over capabilities directly.
+// Fetching them needs a WorkflowService stub, which loadgen has no fake for, so
+// the dev-server test in scenarios covers that end to end.
+
+func nexusOptions(t *testing.T, provided map[string]string) *OptionSet {
+	t.Helper()
+	s := &Scenario{Options: DeclareNexusOptions}
+	set, err := s.ResolveOptions(provided)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return set
+}
+
+// omes is a testing tool, so the useful default is to exercise Nexus wherever the
+// server can. That makes nexus-enabled capability-gated rather than plainly true.
+func TestNexusEnabledFollowsServerCapability(t *testing.T) {
+	for _, supported := range []bool{true, false} {
+		set := nexusOptions(t, nil)
+		err := set.ResolveFeaturesFromCapabilities(Capabilities{
+			System: &workflowservice.GetSystemInfoResponse_Capabilities{Nexus: supported},
+		})
+		if err != nil {
+			t.Fatalf("resolve features: %v", err)
+		}
+		info := &ScenarioInfo{Options: set}
+		if got := info.OptionBool(NexusEnabledOption); got != supported {
+			t.Errorf("server Nexus support %v: want nexus-enabled %v, got %v", supported, supported, got)
+		}
+	}
+}
+
+// Asking for Nexus on a server without it cannot be honored, so it fails rather
+// than quietly running with less load than requested.
+func TestNexusEnabledExplicitlyOnUnsupportedServerFails(t *testing.T) {
+	set := nexusOptions(t, map[string]string{NexusEnabledOption: "true"})
+	err := set.ResolveFeaturesFromCapabilities(Capabilities{
+		System: &workflowservice.GetSystemInfoResponse_Capabilities{Nexus: false},
+	})
+	if err == nil {
+		t.Fatal("expected asking for Nexus against a server without it to fail")
+	}
+	if !strings.Contains(err.Error(), NexusEnabledOption) {
+		t.Errorf("error should name the option, got: %v", err)
+	}
+}
+
+func TestNexusEnabledShownAsCapabilityGated(t *testing.T) {
+	for _, o := range (&Scenario{Options: DeclareNexusOptions}).DeclaredOptions() {
+		if o.Name != NexusEnabledOption {
+			continue
+		}
+		if !o.IsFeature {
+			t.Error("nexus-enabled is gated on the server supporting Nexus, so it is a feature option")
+		}
+		if o.Default != featureDefaultDisplay {
+			t.Errorf("list-scenarios should show the dynamic default, got %q", o.Default)
+		}
+		return
+	}
+	t.Fatal("nexus-enabled should be declared")
+}
+
+func TestResolveNexusConfigRejectsEndpointWithoutNexus(t *testing.T) {
+	info := &ScenarioInfo{Options: nexusOptions(t, map[string]string{
+		NexusEnabledOption:  "false",
+		NexusEndpointOption: "some-endpoint",
+	})}
+	// Returns before touching the client, so a nil one is fine here.
+	_, err := info.ResolveNexusConfig(t.Context())
+	if err == nil {
+		t.Fatal("naming an endpoint for a run that generates no Nexus load should be rejected")
+	}
+	if !strings.Contains(err.Error(), NexusEndpointOption) {
+		t.Errorf("error should name the offending option, got: %v", err)
+	}
+}
+
+func TestResolveNexusConfigDisabledYieldsNoEndpoint(t *testing.T) {
+	info := &ScenarioInfo{Options: nexusOptions(t, map[string]string{NexusEnabledOption: "false"})}
+	cfg, err := info.ResolveNexusConfig(t.Context())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.Enabled || cfg.Endpoint != "" {
+		t.Errorf("Nexus off should yield an empty config, got %+v", cfg)
+	}
+}
+
+func TestNexusEndpointNamePrefersTheNamedEndpoint(t *testing.T) {
+	named := &ScenarioInfo{
+		RunID:   "run-1",
+		Options: nexusOptions(t, map[string]string{NexusEndpointOption: "mine"}),
+	}
+	if got := named.NexusEndpointName(); got != "mine" {
+		t.Errorf("want the named endpoint, got %q", got)
+	}
+
+	// Unnamed falls back to the run's conventional endpoint, which is what both
+	// the endpoint creation and the generated actions have to agree on.
+	unnamed := &ScenarioInfo{RunID: "run-1", Options: nexusOptions(t, nil)}
+	if got, want := unnamed.NexusEndpointName(), NexusEndpointForRun("run-1"); got != want {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
+func TestIncludeNexusSubFeature(t *testing.T) {
+	const sub = "include-standalone-nexus"
+	declare := func(o *OptionSet) {
+		DeclareNexusOptions(o)
+		o.Bool(sub, false, "")
+	}
+
+	cases := []struct {
+		name        string
+		provided    map[string]string
+		nexusOn     bool
+		wantInclude bool
+		wantErr     string
+	}{
+		{name: "off stays off", nexusOn: true},
+		{name: "on with nexus", provided: map[string]string{sub: "true"}, nexusOn: true, wantInclude: true},
+		{
+			name:     "explicitly on without nexus is a contradiction",
+			provided: map[string]string{sub: "true"},
+			wantErr:  "requires",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Scenario{Options: declare}
+			set, err := s.ResolveOptions(tc.provided)
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			info := &ScenarioInfo{Options: set}
+
+			include, err := IncludeNexusSubFeature(info, sub, tc.nexusOn)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("want an error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if include != tc.wantInclude {
+				t.Errorf("include: want %v, got %v", tc.wantInclude, include)
+			}
+		})
+	}
+}
+
+// A sub-feature switched on by a capability probe rather than by the user is
+// dropped when there is no Nexus load, instead of failing the run.
+func TestIncludeNexusSubFeatureDropsAutoEnabledWithoutNexus(t *testing.T) {
+	const sub = "include-standalone-nexus"
+	s := &Scenario{Options: func(o *OptionSet) {
+		DeclareNexusOptions(o)
+		o.Bool(sub, false, "")
+	}}
+	set, err := s.ResolveOptions(nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// Stand in for what a probe would have written for an unset feature option.
+	if err := set.FlagSet.Set(sub, "true"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	info := &ScenarioInfo{Options: set}
+
+	include, err := IncludeNexusSubFeature(info, sub, false)
+	if err != nil {
+		t.Fatalf("an auto-enabled sub-feature should not fail the run: %v", err)
+	}
+	if include {
+		t.Error("the sub-feature should be dropped when Nexus is off")
+	}
+}

--- a/loadgen/options.go
+++ b/loadgen/options.go
@@ -10,7 +10,20 @@ import (
 
 	"github.com/spf13/pflag"
 	namespacev1 "go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/workflowservice/v1"
 )
+
+// Capabilities is what a server reports about what it can do, as read by a
+// [OptionSet.Feature] predicate. Both fields may be nil for a server that
+// reports nothing, so read them through the generated getters.
+type Capabilities struct {
+	// Namespace holds the capabilities of the namespace under test, from
+	// DescribeNamespace. Use it for anything gated per namespace, such as a
+	// dynamic config flag.
+	Namespace *namespacev1.NamespaceInfo_Capabilities
+	// System holds the capabilities of the server as a whole, from GetSystemInfo.
+	System *workflowservice.GetSystemInfoResponse_Capabilities
+}
 
 // OptionSet declares the options a scenario accepts via `--option <name>=<value>`.
 // It embeds a [pflag.FlagSet], so options are declared with the same typed
@@ -26,7 +39,7 @@ type OptionSet struct {
 	explicit map[string]struct{}
 	// features holds the capability predicate for each option declared with
 	// Feature, keyed by name.
-	features map[string]func(*namespacev1.NamespaceInfo_Capabilities) bool
+	features map[string]func(Capabilities) bool
 	// featuresResolved records that the set has been reconciled against reported
 	// capabilities. Until it is, an unset feature option reads false whether or not
 	// it is supported, which is the wrong answer rather than a missing one — so
@@ -53,16 +66,18 @@ func (o *OptionSet) MarkRequired(names ...string) {
 	}
 }
 
-// Feature declares a boolean option gated on a namespace capability. It is enabled
-// by default when the namespace under test reports support, disabled when it does
-// not, and always follows an explicit `--option name=<bool>` instead. Explicitly
-// enabling a feature the namespace does not report fails the run.
+// Feature declares a boolean option gated on a reported capability. It is enabled
+// by default when the server reports support, disabled when it does not, and
+// always follows an explicit `--option name=<bool>` instead. Explicitly enabling a
+// feature that is not reported fails the run.
+//
+// The predicate reads [Capabilities], so it can gate on what the namespace
+// reports, what the server as a whole reports, or both.
 //
 // Resolution happens after the client dials, via [ResolveFeatureOptions]; until
-// then the option reads as its pflag default (false). The predicate is passed the
-// namespace's reported capabilities, which may be nil for a server that reports
-// none, so read them through the generated getters rather than dereferencing.
-func (o *OptionSet) Feature(name, usage string, supported func(*namespacev1.NamespaceInfo_Capabilities) bool) {
+// then the option reads as its pflag default (false), and reading it is reported
+// as a bug in the caller.
+func (o *OptionSet) Feature(name, usage string, supported func(Capabilities) bool) {
 	o.Bool(name, false, usage)
 	o.features[name] = supported
 }
@@ -91,11 +106,18 @@ func (o *OptionSet) sortedFeatureNames() []string {
 	return names
 }
 
-// resolveFeatures finalizes every Feature option against the namespace's
-// reported capabilities: an unset option takes the capability's value, and an
-// explicit true against an unsupported capability is collected as an error.
-// Every unsupported feature is reported at once.
-func (o *OptionSet) resolveFeatures(caps *namespacev1.NamespaceInfo_Capabilities) error {
+// ResolveFeaturesFromCapabilities finalizes feature options against capabilities
+// the caller already holds, so a caller that has already queried the server does
+// not pay for it twice. Prefer [ResolveFeatureOptions], which fetches them.
+func (o *OptionSet) ResolveFeaturesFromCapabilities(caps Capabilities) error {
+	return o.resolveFeatures(caps)
+}
+
+// resolveFeatures finalizes every Feature option against the reported
+// capabilities: an unset option takes the capability's value, and an explicit
+// true against an unsupported capability is collected as an error. Every
+// unsupported feature is reported at once.
+func (o *OptionSet) resolveFeatures(caps Capabilities) error {
 	var errs []error
 	for _, name := range o.sortedFeatureNames() {
 		supported := o.features[name](caps)
@@ -108,7 +130,7 @@ func (o *OptionSet) resolveFeatures(caps *namespacev1.NamespaceInfo_Capabilities
 		}
 		if flag.Value.String() == "true" && !supported {
 			errs = append(errs, fmt.Errorf(
-				"option %q was explicitly enabled, but the namespace does not report support for it",
+				"option %q was explicitly enabled, but the server does not report support for it",
 				name))
 		}
 	}
@@ -140,7 +162,7 @@ func newOptionSet(name string) *OptionSet {
 		FlagSet:  fs,
 		required: make(map[string]struct{}),
 		explicit: make(map[string]struct{}),
-		features: make(map[string]func(*namespacev1.NamespaceInfo_Capabilities) bool),
+		features: make(map[string]func(Capabilities) bool),
 	}
 }
 
@@ -152,8 +174,8 @@ func (o *OptionSet) names() []string {
 }
 
 // featureDefaultDisplay is the [DeclaredOption.Default] shown for a Feature
-// option: its real default depends on the namespace under test, not a constant.
-const featureDefaultDisplay = "auto (enabled when the namespace supports it)"
+// option: its real default depends on what the server reports, not a constant.
+const featureDefaultDisplay = "auto (enabled where supported)"
 
 // DeclaredOption describes one declared option for display.
 type DeclaredOption struct {
@@ -163,8 +185,7 @@ type DeclaredOption struct {
 	Usage    string
 	Required bool
 	// IsFeature is true for an option declared with Feature: its default is
-	// resolved from the namespace's capabilities rather than fixed at
-	// declaration time.
+	// resolved from reported capabilities rather than fixed at declaration time.
 	IsFeature bool
 }
 

--- a/loadgen/options_test.go
+++ b/loadgen/options_test.go
@@ -221,14 +221,16 @@ func TestGetDefaultConfigurationPrefersScenarioDeclaration(t *testing.T) {
 	}
 }
 
-func nexusOperationCapability(supported bool) *namespacev1.NamespaceInfo_Capabilities {
-	return &namespacev1.NamespaceInfo_Capabilities{StandaloneNexusOperation: supported}
+func nexusOperationCapability(supported bool) Capabilities {
+	return Capabilities{
+		Namespace: &namespacev1.NamespaceInfo_Capabilities{StandaloneNexusOperation: supported},
+	}
 }
 
 func TestFeatureUnsetEnabledWhenCapabilitySupported(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	set := s.MustResolveOptions(nil)
@@ -243,8 +245,8 @@ func TestFeatureUnsetEnabledWhenCapabilitySupported(t *testing.T) {
 
 func TestFeatureUnsetDisabledWhenCapabilityUnsupported(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	set := s.MustResolveOptions(nil)
@@ -253,14 +255,14 @@ func TestFeatureUnsetDisabledWhenCapabilityUnsupported(t *testing.T) {
 	}
 	info := &ScenarioInfo{Options: set}
 	if info.OptionBool("nexus") {
-		t.Error("want feature disabled when the namespace does not report support")
+		t.Error("want feature disabled when the server does not report support")
 	}
 }
 
 func TestFeatureExplicitFalseStaysFalseUnderSupportingCaps(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	set := s.MustResolveOptions(map[string]string{"nexus": "false"})
@@ -275,8 +277,8 @@ func TestFeatureExplicitFalseStaysFalseUnderSupportingCaps(t *testing.T) {
 
 func TestFeatureExplicitTrueUnderSupportingCapsSucceeds(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	set := s.MustResolveOptions(map[string]string{"nexus": "true"})
@@ -291,8 +293,8 @@ func TestFeatureExplicitTrueUnderSupportingCapsSucceeds(t *testing.T) {
 
 func TestFeatureExplicitTrueUnderNonSupportingCapsErrors(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	set := s.MustResolveOptions(map[string]string{"nexus": "true"})
@@ -307,15 +309,15 @@ func TestFeatureExplicitTrueUnderNonSupportingCapsErrors(t *testing.T) {
 
 func TestFeatureTwoUnsupportedExplicitErrorsJoined(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
-		o.Feature("activity", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneActivities()
+		o.Feature("activity", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneActivities()
 		})
 	}}
 	set := s.MustResolveOptions(map[string]string{"nexus": "true", "activity": "true"})
-	err := set.resolveFeatures(&namespacev1.NamespaceInfo_Capabilities{})
+	err := set.resolveFeatures(Capabilities{})
 	if err == nil {
 		t.Fatal("expected an error naming both unsupported features")
 	}
@@ -341,8 +343,8 @@ func TestUserSpecifiedReflectsExplicitSupply(t *testing.T) {
 
 func TestDeclaredOptionsReportsFeatureDefault(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "Include standalone Nexus operations.", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "Include standalone Nexus operations.", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	opts := s.DeclaredOptions()
@@ -352,15 +354,15 @@ func TestDeclaredOptionsReportsFeatureDefault(t *testing.T) {
 	if !opts[0].IsFeature {
 		t.Error("want IsFeature true for a Feature declaration")
 	}
-	if opts[0].Default != "auto (enabled when the namespace supports it)" {
+	if opts[0].Default != featureDefaultDisplay {
 		t.Errorf("want the dynamic default string, got %q", opts[0].Default)
 	}
 }
 
 func TestResolveOptionsRejectsMalformedFeatureValue(t *testing.T) {
 	s := &Scenario{Options: func(o *OptionSet) {
-		o.Feature("nexus", "", func(c *namespacev1.NamespaceInfo_Capabilities) bool {
-			return c.GetStandaloneNexusOperation()
+		o.Feature("nexus", "", func(c Capabilities) bool {
+			return c.Namespace.GetStandaloneNexusOperation()
 		})
 	}}
 	_, err := s.ResolveOptions(map[string]string{"nexus": "notabool"})

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -245,16 +245,6 @@ func (s *ScenarioInfo) options() *OptionSet {
 	return s.Options
 }
 
-// logf logs at info level, tolerating a ScenarioInfo built without a logger —
-// library callers assemble one by hand and need not set every field.
-func (s *ScenarioInfo) logf(format string, args ...any) {
-	if s.Logger != nil {
-		s.Logger.Infof(format, args...)
-	} else {
-		clioptions.BackupLogger.Printf(format, args...)
-	}
-}
-
 // unresolvedFeatureOption reports a feature option read before any namespace
 // probe ran, which leaves it false and quietly drops the feature from the load.
 // It is an error rather than a warning because a run generating less load than
@@ -270,6 +260,16 @@ func (s *ScenarioInfo) unresolvedFeatureOption(name string) {
 		s.Logger.Error(msg)
 	} else {
 		clioptions.BackupLogger.Println(msg)
+	}
+}
+
+// logf logs at info level, tolerating a ScenarioInfo built without a logger —
+// library callers assemble one by hand and need not set every field.
+func (s *ScenarioInfo) logf(format string, args ...any) {
+	if s.Logger != nil {
+		s.Logger.Infof(format, args...)
+	} else {
+		clioptions.BackupLogger.Printf(format, args...)
 	}
 }
 

--- a/scenarios/fuzzer.go
+++ b/scenarios/fuzzer.go
@@ -38,11 +38,7 @@ func init() {
 					if config := info.OptionString("config"); config != "" {
 						args = append(args, "--generator-config-override", config)
 					}
-					nexusEndpoint := info.OptionString("nexus-endpoint")
-					if nexusEndpoint == "" {
-						nexusEndpoint = loadgen.NexusEndpointForRun(info.RunID)
-					}
-					args = append(args, "--nexus-endpoint", nexusEndpoint)
+					args = append(args, "--nexus-endpoint", info.NexusEndpointName())
 					if outputFile := info.OptionString("output-file"); outputFile != "" {
 						args = append(args, "--output-path", outputFile)
 					}

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/temporalio/omes/loadgen/kitchensink"
 	"go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
-	namespacev1 "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -30,11 +29,12 @@ const (
 	// SleepTimeFlag controls the duration used for internal timer-based sleep actions (e.g. signal/update timers).
 	// Default is 1s.
 	SleepTimeFlag = "sleep-time"
-	// NexusEnabledFlag turns Nexus operations on.
-	NexusEnabledFlag = "nexus-enabled"
+	// NexusEnabledFlag governs whether the run generates Nexus load. On by default;
+	// see loadgen.DeclareNexusOptions.
+	NexusEnabledFlag = loadgen.NexusEnabledOption
 	// NexusEndpointFlag names the Nexus endpoint to use. Empty means one is created
 	// for this run. Only consulted when NexusEnabledFlag is set.
-	NexusEndpointFlag = "nexus-endpoint"
+	NexusEndpointFlag = loadgen.NexusEndpointOption
 	// VisibilityVerificationTimeoutFlag is the timeout for verifying the total visibility count at the end of the scenario.
 	// It needs to account for a backlog of tasks and, if used, ElasticSearch's eventual consistency.
 	VisibilityVerificationTimeoutFlag = "visibility-count-timeout"
@@ -51,7 +51,7 @@ const (
 	// Default is false.
 	IncludeDescribeFlag = "include-describe"
 	// IncludeStandaloneNexusFlag enables standalone Nexus operations in throughput_stress.
-	// On by default when the namespace under test reports support; pass
+	// On when the namespace reports support and the run generates Nexus load; pass
 	// include-standalone-nexus=false to force off.
 	IncludeStandaloneNexusFlag = "include-standalone-nexus"
 	// IncludeStandaloneActivityFlag enables standalone activities (activities started outside
@@ -117,17 +117,16 @@ func init() {
 			o.Duration(IterTimeoutFlag, 0, "Timeout for internal iterations. 0 means auto: the run duration plus a minute.")
 			o.Int(ContinueAsNewAfterIterFlag, 3, "Internal iterations before continue-as-new.")
 			o.Duration(SleepTimeFlag, time.Second, "How long each sleep activity sleeps.")
-			o.Bool(NexusEnabledFlag, false, "Include Nexus operations.")
-			o.String(NexusEndpointFlag, "", "Nexus endpoint to use when Nexus is enabled. Empty creates one for this run.")
+			loadgen.DeclareNexusOptions(o)
 			o.Duration(VisibilityVerificationTimeoutFlag, 3*time.Minute, "Timeout for the post-run visibility count check.")
 			o.String(SleepActivityJsonFlag, "", "JSON sleep-activity configuration; use @<file> to read from a file.")
 			o.Float64(MinThroughputPerHourFlag, 0, "Fail the run below this workflows-per-hour rate (0 disables).")
 			o.Bool(IncludeRetryScenariosFlag, false, "Include activities that exercise retries.")
 			o.Bool(IncludeDescribeFlag, false, "Include DescribeWorkflowExecution calls.")
 			o.Feature(IncludeStandaloneNexusFlag, "Include standalone Nexus operations.",
-				func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneNexusOperation() })
+				func(c loadgen.Capabilities) bool { return c.Namespace.GetStandaloneNexusOperation() })
 			o.Feature(IncludeStandaloneActivityFlag, "Include standalone activities.",
-				func(c *namespacev1.NamespaceInfo_Capabilities) bool { return c.GetStandaloneActivities() })
+				func(c loadgen.Capabilities) bool { return c.Namespace.GetStandaloneActivities() })
 			o.String(PayloadDistributionJsonFlag, "", "JSON payload-size distribution; use @<file> to read from a file.")
 		},
 		ExecutorFn: func() loadgen.Executor { return newThroughputStressExecutor() },
@@ -213,21 +212,10 @@ func (t *tpsExecutor) Configure(info loadgen.ScenarioInfo) error {
 
 	config.IncludeRetryScenarios = info.OptionBool(IncludeRetryScenariosFlag)
 	config.IncludeDescribe = info.OptionBool(IncludeDescribeFlag)
-	config.IncludeStandaloneNexus = info.OptionBool(IncludeStandaloneNexusFlag)
-	if config.IncludeStandaloneNexus && !config.NexusEnabled {
-		// Standalone Nexus can auto-enable via a capability probe without the user
-		// ever touching nexus-enabled; in that case turn Nexus on too, rather than
-		// fail on an option nobody set. An explicit nexus-enabled=false still wins.
-		if info.OptionUserSpecified(NexusEnabledFlag) {
-			return fmt.Errorf("%s requires %s, which was explicitly disabled",
-				IncludeStandaloneNexusFlag, NexusEnabledFlag)
-		}
-		// Configure is also called directly by tests, which may not set a Logger.
-		if info.Logger != nil {
-			info.Logger.Infof("enabling %s because %s is enabled",
-				NexusEnabledFlag, IncludeStandaloneNexusFlag)
-		}
-		config.NexusEnabled = true
+	config.IncludeStandaloneNexus, err = loadgen.IncludeNexusSubFeature(
+		&info, IncludeStandaloneNexusFlag, config.NexusEnabled)
+	if err != nil {
+		return err
 	}
 	if config.NexusEndpoint != "" && !config.NexusEnabled {
 		return fmt.Errorf("%s was set but %s is false", NexusEndpointFlag, NexusEnabledFlag)
@@ -259,15 +247,20 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 	}
 	t.runID = info.RunID
 
-	// Creating the endpoint needs a context, so it happens here rather than in
-	// Configure.
-	if t.config.NexusEnabled && t.config.NexusEndpoint == "" {
-		endpoint, err := info.EnsureNexusEndpoint(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to create nexus endpoint: %w", err)
-		}
-		t.config.NexusEndpoint = endpoint
-		info.Logger.Infof("Using nexus endpoint %q", endpoint)
+	// Settling Nexus needs a dialed client, so it happens here rather than in
+	// Configure: whether the server supports Nexus at all decides the default, and
+	// an endpoint may have to be created.
+	nexus, err := info.ResolveNexusConfig(ctx)
+	if err != nil {
+		return err
+	}
+	t.config.NexusEnabled = nexus.Enabled
+	t.config.NexusEndpoint = nexus.Endpoint
+	if !nexus.Enabled {
+		// Standalone operations are part of Nexus load, so they go with it.
+		t.config.IncludeStandaloneNexus = false
+	} else {
+		info.Logger.Infof("Using nexus endpoint %q", nexus.Endpoint)
 	}
 
 	// Track start time of current run

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/temporalio/omes/internal/workertest"
 	"github.com/temporalio/omes/loadgen"
 	ks "github.com/temporalio/omes/loadgen/kitchensink"
+	namespacev1 "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
 	"go.uber.org/zap"
@@ -88,9 +89,9 @@ func TestThroughputStressFeatureAutoEnable(t *testing.T) {
 
 	runID := fmt.Sprintf("tps-feature-%d", time.Now().Unix())
 
-	// No WithNexusEndpoint here: if standalone Nexus auto-enables, the scenario
-	// enables Nexus itself and creates its own endpoint, which is the path under
-	// test. Pre-creating one would collide on the same NexusEndpointForRun name.
+	// No WithNexusEndpoint here: the scenario creates its own endpoint for the run,
+	// which is part of the path under test. Pre-creating one would collide on the
+	// same NexusEndpointForRun name.
 	env := workertest.SetupTestEnvironment(t,
 		workertest.WithExecutorTimeout(1*time.Minute),
 		workertest.WithDynamicConfig(map[string]any{
@@ -120,6 +121,9 @@ func TestThroughputStressFeatureAutoEnable(t *testing.T) {
 			ContinueAsNewAfterIterFlag:        "1",
 			SleepTimeFlag:                     "1ms",
 			VisibilityVerificationTimeoutFlag: "10s",
+			// Requesting Nexus load is the user's call; the probe then decides
+			// whether standalone operations are part of it.
+			NexusEnabledFlag: "true",
 		}),
 	}
 
@@ -129,13 +133,10 @@ func TestThroughputStressFeatureAutoEnable(t *testing.T) {
 
 	require.True(t, executor.config.IncludeStandaloneActivity,
 		"standalone activities should auto-enable from the namespace capability")
-	// Standalone Nexus follows whatever this server version reports. When it is on,
-	// the scenario turns nexus-enabled on by itself.
+	// Nexus load was requested, so standalone Nexus follows whatever this server
+	// version reports.
+	require.True(t, executor.config.NexusEnabled)
 	require.Equal(t, caps.GetStandaloneNexusOperation(), executor.config.IncludeStandaloneNexus)
-	if caps.GetStandaloneNexusOperation() {
-		require.True(t, executor.config.NexusEnabled,
-			"auto-enabled standalone Nexus should also enable Nexus")
-	}
 	require.Equal(t, 1, executor.Snapshot().(tpsState).CompletedIterations)
 }
 
@@ -169,58 +170,69 @@ func TestThroughputStressConfigureNoPayload(t *testing.T) {
 	require.Equal(t, 256, executor.samplePayloadSize(rand.New(rand.NewSource(1))))
 }
 
-// TestThroughputStressConfigureFeatureAutoEnablesNexus covers the interaction
-// added for capability-gated feature options: when include-standalone-nexus
-// resolves to true (as it would after ResolveFeatureOptions probes a capable
-// namespace) and nexus-enabled was never touched by the user, Configure turns
-// Nexus on rather than failing on an option the user never set.
-//
-// ResolveFeatureOptions itself needs a dialed client, so this simulates its
-// outcome directly on the resolved option set with Set, exactly as
-// resolveFeatures would for an unset feature option.
-func TestThroughputStressConfigureFeatureAutoEnablesNexus(t *testing.T) {
+// capableOfStandaloneNexus resolves a throughput_stress option set as if the
+// namespace reported standalone Nexus support, so the auto-enabled path can be
+// tested without a server. Setting the option directly would instead mark it
+// user-specified, which is a different case.
+func capableOfStandaloneNexus(t *testing.T, provided map[string]string) *loadgen.OptionSet {
+	t.Helper()
+	set := loadgen.MustResolveScenarioOptions("throughput_stress", provided)
+	require.NoError(t, set.ResolveFeaturesFromCapabilities(loadgen.Capabilities{
+		Namespace: &namespacev1.NamespaceInfo_Capabilities{StandaloneNexusOperation: true},
+		System:    &workflowservice.GetSystemInfoResponse_Capabilities{Nexus: true},
+	}))
+	return set
+}
+
+// Nexus load is on by default, so the capability probe's answer is what decides
+// whether standalone operations are part of it.
+func TestThroughputStressConfigureStandaloneNexusAutoEnablesUnderNexus(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		nexus map[string]string
+	}{
+		{name: "nexus left at its default", nexus: map[string]string{}},
+		{name: "nexus explicitly on", nexus: map[string]string{NexusEnabledFlag: "true"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			executor := newThroughputStressExecutor()
+			info := loadgen.ScenarioInfo{
+				RunID:   "tps-feature-auto",
+				Logger:  zap.NewNop().Sugar(),
+				Options: capableOfStandaloneNexus(t, tc.nexus),
+			}
+
+			require.NoError(t, executor.Configure(info))
+			require.True(t, executor.config.NexusEnabled)
+			require.True(t, executor.config.IncludeStandaloneNexus,
+				"a supported standalone Nexus should be included once Nexus load is on")
+		})
+	}
+}
+
+// Turning Nexus off takes its sub-features with it, rather than failing on a
+// sub-feature the user never asked for.
+func TestThroughputStressConfigureStandaloneNexusDroppedWithoutNexus(t *testing.T) {
 	t.Parallel()
 
 	executor := newThroughputStressExecutor()
 	info := loadgen.ScenarioInfo{
-		RunID:  "tps-feature-auto",
-		Logger: zap.NewNop().Sugar(),
-		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
-			SleepActivityJsonFlag: "", // keep defaults minimal
-		}),
+		RunID:   "tps-feature-suppressed",
+		Logger:  zap.NewNop().Sugar(),
+		Options: capableOfStandaloneNexus(t, map[string]string{NexusEnabledFlag: "false"}),
 	}
-	require.NoError(t, info.Options.Set(IncludeStandaloneNexusFlag, "true"))
 
-	require.NoError(t, executor.Configure(info))
-	require.True(t, executor.config.NexusEnabled)
-	require.True(t, executor.config.IncludeStandaloneNexus)
+	require.NoError(t, executor.Configure(info),
+		"an auto-enabled sub-feature should not fail a run that asked for no Nexus")
+	require.False(t, executor.config.NexusEnabled)
+	require.False(t, executor.config.IncludeStandaloneNexus,
+		"standalone Nexus should be dropped when there is no Nexus load to add it to")
 }
 
-// TestThroughputStressConfigureFeatureRespectsExplicitNexusDisabled covers the
-// other half: an explicit nexus-enabled=false must not be silently overridden
-// even when the feature auto-enables standalone Nexus.
-func TestThroughputStressConfigureFeatureRespectsExplicitNexusDisabled(t *testing.T) {
-	t.Parallel()
-
-	executor := newThroughputStressExecutor()
-	info := loadgen.ScenarioInfo{
-		RunID:  "tps-feature-explicit-off",
-		Logger: zap.NewNop().Sugar(),
-		Options: loadgen.MustResolveScenarioOptions("throughput_stress", map[string]string{
-			NexusEnabledFlag: "false",
-		}),
-	}
-	require.NoError(t, info.Options.Set(IncludeStandaloneNexusFlag, "true"))
-
-	err := executor.Configure(info)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), IncludeStandaloneNexusFlag)
-	require.Contains(t, err.Error(), NexusEnabledFlag)
-}
-
-// TestThroughputStressConfigureExplicitStandaloneNexusRequiresNexusEnabled
-// preserves the pre-existing behavior: a user who explicitly asks for standalone
-// Nexus while explicitly disabling Nexus gets an error either way.
 func TestThroughputStressConfigureExplicitStandaloneNexusRequiresNexusEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

nexus-enabled and nexus-endpoint were declared per scenario and had diverged:
throughput_stress declared both, FuzzExecutor declared only the endpoint with a
different description, and fuzzer re-derived the endpoint name FuzzExecutor
derives in order to create it. Each scenario also implemented "empty endpoint
means create one" and its own relationship between a Nexus sub-feature and Nexus
itself.

DeclareNexusOptions declares them once. ResolveNexusConfig settles whether the
run generates Nexus load and against which endpoint, creating one if needed;
IncludeNexusSubFeature holds the sub-feature rule; NexusEndpointName gives the
creation site and the generator one derivation of the name.

Nexus is on by default: omes is a testing tool, so the useful default is to
exercise what the server supports, and nexus-enabled=false turns it off. Not a
bare true — it is gated on the server reporting Nexus, so it turns itself off
against a server without it, and asking for it explicitly there fails.

Gating it widened the feature mechanism. Predicates read namespace capabilities
from DescribeNamespace, while Nexus support comes from GetSystemInfo; they now
receive a Capabilities carrying both, leaving one implementation of the rule
instead of two.

Nexus being off takes standalone Nexus with it, which throughput_stress applies
in Run as well as Configure: whether the server supports Nexus is only known once
the client is dialed.

The per-language smoke tests pin nexus-enabled=false. They check that a built
worker can run the scenario at all, so the load shape should not follow what the
server happens to support; Nexus operations additionally need the worker to
handle them, which the java, dotnet, and typescript workers do not do within the
smoke test's budget. Nexus stays covered by the Go tests, which run it against a
dev server.
