### PR TITLE
dev: sync SDK dependencies with mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "dotnet go java node npm python ruby uv"
+          install_args: "dotnet gem:bundler go java node npm python ruby uv"
       - name: Restore package manager caches
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
   check-sdk-dependencies:
     runs-on: ubuntu-latest
     env:
-      MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
+      # Avoid mise's precompiled Python metadata endpoint, which has repeatedly timed out in CI,
+      # while still installing the repository's configured Python version through mise.
+      MISE_PYTHON_COMPILE: "1"
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,40 @@ jobs:
           annotate_only: true
           skip_annotations: true
 
+  check-sdk-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install SDK dependency tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "dotnet go java node npm python ruby uv"
+      - name: Restore package manager caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.bundle/cache
+            ~/.cache/go-build
+            ~/.cache/uv
+            ~/.npm
+            ~/go/pkg/mod
+          key: sdk-sync-${{ runner.os }}-${{ hashFiles('mise.toml', '**/go.sum', '**/package-lock.json', '**/uv.lock', '**/Gemfile.lock') }}
+          restore-keys: |
+            sdk-sync-${{ runner.os }}-
+      - name: Sync SDK dependencies
+        run: mise run sync-sdk
+      - name: Check SDK dependency drift
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git diff
+            git status --short
+            echo "SDK dependencies do not match the versions in mise.toml."
+            echo "Run 'mise run sync-sdk' and commit the resulting changes."
+            exit 1
+          fi
+
   check-worker:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
 
   check-sdk-dependencies:
     runs-on: ubuntu-latest
+    env:
+      MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 60s
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ mise run sync-sdk:typescript # Sync one SDK
 mise run sync-sdk            # Sync every SDK
 ```
 
-The sync tasks preserve declared compatibility ranges while updating exact dependency declarations and
-lockfiles to the versions in `mise.toml`. Review and commit the generated changes; CI reruns the aggregate
-task and fails if the committed dependency files have drifted.
+The sync tasks use each ecosystem's package manager to update declared SDK requirements and lockfiles to
+the versions in `mise.toml`. Review and commit the generated changes; CI reruns the aggregate task and
+fails if the committed dependency files have drifted.
 
 ## Fuzzer trophy case
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,17 @@ Or target specific languages: `go run ./cmd/dev build go java python`
 
 All development tool, SDK, and server versions are defined in `mise.toml`.
 
+After changing an SDK version in `[_.sdk]`, synchronize the corresponding worker dependency files:
+
+```sh
+mise run sync-sdk:typescript # Sync one SDK
+mise run sync-sdk            # Sync every SDK
+```
+
+The sync tasks preserve declared compatibility ranges while updating exact dependency declarations and
+lockfiles to the versions in `mise.toml`. Review and commit the generated changes; CI reruns the aggregate
+task and fails if the committed dependency files have drifted.
+
 ## Fuzzer trophy case
 
 * Python upsert SA with no initial attributes: [PR](https://github.com/temporalio/sdk-python/pull/440)

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,7 @@ protoc-gen-go = "v1.31.0"
 python = "3.10"
 "pipx:poethepoet" = "0.48.0"
 ruby = "3.3"
+"gem:bundler" = "4.0.10"
 rust = { version = "1.74.0", profile = "default" }
 uv = "0.7.19"
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ go = "1.26.5"
 go-junit-report = "2.1.0"
 java = "temurin-11"
 node = "24"
+npm = "11.17.0"
 pnpm = "10.32.1"
 protoc = "25.1"
 protoc-gen-go = "v1.31.0"
@@ -17,10 +18,130 @@ uv = "0.7.19"
 [_.sdk]
 dotnet = "1.17.0"
 go = "1.47.0"
-java = "1.35.0"
+java = "1.37.0"
 python = "1.31.0"
-ruby = "1.5.0"
-typescript = "1.18.1"
+ruby = "1.6.0"
+typescript = "1.22.0"
 
 [_.server]
 ref = "a4afe583eff6edd6a0d6aa9dc96d5dfec7996c77"
+
+[tasks."sync-sdk:go"]
+description = "Sync Go SDK dependencies to the version in mise.toml"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.go)"
+go get "go.temporal.io/sdk@v${TEMPORAL_SDK_VERSION}"
+go -C workers/go get "go.temporal.io/sdk@v${TEMPORAL_SDK_VERSION}"
+go -C workers/go mod tidy
+'''
+
+[tasks."sync-sdk:typescript"]
+description = "Sync TypeScript SDK dependencies to the version in mise.toml"
+dir = "workers/typescript"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.typescript)"
+STAGING_DIR="$(mktemp -d)"
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+cp package.json package-lock.json "$STAGING_DIR/"
+cp package.json "$STAGING_DIR/package.original.json"
+cd "$STAGING_DIR"
+npm install --package-lock-only --save-exact --ignore-scripts --no-audit --no-fund \
+  "@temporalio/activity@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/client@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/common@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/worker@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/workflow@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/testing@${TEMPORAL_SDK_VERSION}"
+cp package.original.json package.json
+npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+
+node - "$TEMPORAL_SDK_VERSION" <<'NODE'
+const fs = require('node:fs');
+const expected = process.argv[2];
+const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+const packages = ['activity', 'client', 'common', 'testing', 'worker', 'workflow'];
+for (const name of packages) {
+  const actual = lock.packages?.[`node_modules/@temporalio/${name}`]?.version;
+  if (actual !== expected) {
+    throw new Error(`@temporalio/${name}: expected ${expected}, found ${actual ?? 'missing'}`);
+  }
+}
+NODE
+
+cp package-lock.json "$MISE_CONFIG_ROOT/workers/typescript/package-lock.json"
+'''
+
+[tasks."sync-sdk:java"]
+description = "Sync Java SDK dependencies to the version in mise.toml"
+dir = "workers/java"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.java)"
+python3 - "$TEMPORAL_SDK_VERSION" <<'PYTHON'
+from pathlib import Path
+import re
+import sys
+
+path = Path("build.gradle")
+contents = path.read_text()
+version = sys.argv[1]
+for artifact in ("temporal-sdk", "temporal-testing"):
+    pattern = rf"(io\.temporal:{artifact}:)[^'\"]+"
+    contents, count = re.subn(pattern, rf"\g<1>{version}", contents)
+    if count != 1:
+        raise SystemExit(f"expected one {artifact} dependency, found {count}")
+path.write_text(contents)
+PYTHON
+'''
+
+[tasks."sync-sdk:python"]
+description = "Sync Python SDK dependencies to the version in mise.toml"
+dir = "workers/python"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.python)"
+uv lock --upgrade-package "temporalio==${TEMPORAL_SDK_VERSION}"
+'''
+
+[tasks."sync-sdk:dotnet"]
+description = "Sync .NET SDK dependencies to the version in mise.toml"
+dir = "workers/dotnet"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.dotnet)"
+dotnet add Temporalio.Omes.csproj package Temporalio \
+  --version "$TEMPORAL_SDK_VERSION" \
+  --no-restore
+'''
+
+[tasks."sync-sdk:ruby"]
+description = "Sync Ruby SDK dependencies to the version in mise.toml"
+dir = "workers/ruby"
+run = '''
+TEMPORAL_SDK_VERSION="$(mise config get _.sdk.ruby)"
+python3 - "$TEMPORAL_SDK_VERSION" <<'PYTHON'
+from pathlib import Path
+import re
+import sys
+
+path = Path("Gemfile")
+contents = path.read_text()
+dependency = f"gem 'temporalio', '= {sys.argv[1]}'"
+contents, count = re.subn(r"^gem ['\"]temporalio['\"].*$", dependency, contents, flags=re.MULTILINE)
+if count == 0:
+    contents = contents.rstrip() + "\n\n" + dependency + "\n"
+elif count != 1:
+    raise SystemExit(f"expected at most one temporalio dependency, found {count}")
+path.write_text(contents)
+PYTHON
+bundle lock --update temporalio --conservative
+'''
+
+[tasks.sync-sdk]
+description = "Sync all SDK dependencies to the versions in mise.toml"
+depends = [
+  "sync-sdk:dotnet",
+  "sync-sdk:go",
+  "sync-sdk:java",
+  "sync-sdk:python",
+  "sync-sdk:ruby",
+  "sync-sdk:typescript",
+]

--- a/mise.toml
+++ b/mise.toml
@@ -84,7 +84,7 @@ dir = "workers/ruby"
 run = '''
 TEMPORAL_SDK_VERSION="$(mise config get _.sdk.ruby)"
 python3 "$MISE_CONFIG_ROOT/scripts/sdk-sync/update_ruby.py" "$TEMPORAL_SDK_VERSION"
-bundle lock --update temporalio --conservative
+mise exec gem:bundler -- bundle lock --update temporalio --conservative
 '''
 
 [tasks.sync-sdk]

--- a/mise.toml
+++ b/mise.toml
@@ -40,36 +40,14 @@ description = "Sync TypeScript SDK dependencies to the version in mise.toml"
 dir = "workers/typescript"
 run = '''
 TEMPORAL_SDK_VERSION="$(mise config get _.sdk.typescript)"
-STAGING_DIR="$(mktemp -d)"
-trap 'rm -rf "$STAGING_DIR"' EXIT
-
-cp package.json package-lock.json "$STAGING_DIR/"
-cp package.json "$STAGING_DIR/package.original.json"
-cd "$STAGING_DIR"
-npm install --package-lock-only --save-exact --ignore-scripts --no-audit --no-fund \
+npm install --package-lock-only --save-prod --save-prefix='^' --ignore-scripts --no-audit --no-fund \
   "@temporalio/activity@${TEMPORAL_SDK_VERSION}" \
   "@temporalio/client@${TEMPORAL_SDK_VERSION}" \
   "@temporalio/common@${TEMPORAL_SDK_VERSION}" \
   "@temporalio/worker@${TEMPORAL_SDK_VERSION}" \
-  "@temporalio/workflow@${TEMPORAL_SDK_VERSION}" \
+  "@temporalio/workflow@${TEMPORAL_SDK_VERSION}"
+npm install --package-lock-only --save-dev --save-prefix='^' --ignore-scripts --no-audit --no-fund \
   "@temporalio/testing@${TEMPORAL_SDK_VERSION}"
-cp package.original.json package.json
-npm install --package-lock-only --ignore-scripts --no-audit --no-fund
-
-node - "$TEMPORAL_SDK_VERSION" <<'NODE'
-const fs = require('node:fs');
-const expected = process.argv[2];
-const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
-const packages = ['activity', 'client', 'common', 'testing', 'worker', 'workflow'];
-for (const name of packages) {
-  const actual = lock.packages?.[`node_modules/@temporalio/${name}`]?.version;
-  if (actual !== expected) {
-    throw new Error(`@temporalio/${name}: expected ${expected}, found ${actual ?? 'missing'}`);
-  }
-}
-NODE
-
-cp package-lock.json "$MISE_CONFIG_ROOT/workers/typescript/package-lock.json"
 '''
 
 [tasks."sync-sdk:java"]
@@ -77,21 +55,7 @@ description = "Sync Java SDK dependencies to the version in mise.toml"
 dir = "workers/java"
 run = '''
 TEMPORAL_SDK_VERSION="$(mise config get _.sdk.java)"
-python3 - "$TEMPORAL_SDK_VERSION" <<'PYTHON'
-from pathlib import Path
-import re
-import sys
-
-path = Path("build.gradle")
-contents = path.read_text()
-version = sys.argv[1]
-for artifact in ("temporal-sdk", "temporal-testing"):
-    pattern = rf"(io\.temporal:{artifact}:)[^'\"]+"
-    contents, count = re.subn(pattern, rf"\g<1>{version}", contents)
-    if count != 1:
-        raise SystemExit(f"expected one {artifact} dependency, found {count}")
-path.write_text(contents)
-PYTHON
+python3 "$MISE_CONFIG_ROOT/scripts/sdk-sync/update_java.py" "$TEMPORAL_SDK_VERSION"
 '''
 
 [tasks."sync-sdk:python"]
@@ -99,7 +63,8 @@ description = "Sync Python SDK dependencies to the version in mise.toml"
 dir = "workers/python"
 run = '''
 TEMPORAL_SDK_VERSION="$(mise config get _.sdk.python)"
-uv lock --upgrade-package "temporalio==${TEMPORAL_SDK_VERSION}"
+uv add --no-sync "temporalio>=${TEMPORAL_SDK_VERSION},<2"
+uv add --no-sync --package harness "temporalio>=${TEMPORAL_SDK_VERSION},<2"
 '''
 
 [tasks."sync-sdk:dotnet"]
@@ -117,21 +82,7 @@ description = "Sync Ruby SDK dependencies to the version in mise.toml"
 dir = "workers/ruby"
 run = '''
 TEMPORAL_SDK_VERSION="$(mise config get _.sdk.ruby)"
-python3 - "$TEMPORAL_SDK_VERSION" <<'PYTHON'
-from pathlib import Path
-import re
-import sys
-
-path = Path("Gemfile")
-contents = path.read_text()
-dependency = f"gem 'temporalio', '= {sys.argv[1]}'"
-contents, count = re.subn(r"^gem ['\"]temporalio['\"].*$", dependency, contents, flags=re.MULTILINE)
-if count == 0:
-    contents = contents.rstrip() + "\n\n" + dependency + "\n"
-elif count != 1:
-    raise SystemExit(f"expected at most one temporalio dependency, found {count}")
-path.write_text(contents)
-PYTHON
+python3 "$MISE_CONFIG_ROOT/scripts/sdk-sync/update_ruby.py" "$TEMPORAL_SDK_VERSION"
 bundle lock --update temporalio --conservative
 '''
 

--- a/scripts/sdk-sync/update_java.py
+++ b/scripts/sdk-sync/update_java.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import re
+
+
+DEFAULT_PROPERTIES = Path(__file__).resolve().parents[2] / "workers/java/gradle.properties"
+VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]*")
+
+
+def update_properties(path: Path, version: str) -> None:
+    if not VERSION_PATTERN.fullmatch(version):
+        raise SystemExit(f"invalid SDK version: {version!r}")
+
+    contents = path.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r"^temporalSdkVersion=.*$",
+        f"temporalSdkVersion={version}",
+        contents,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise SystemExit(f"expected one temporalSdkVersion property in {path}, found {count}")
+    if updated != contents:
+        path.write_text(updated, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update the Java SDK version property")
+    parser.add_argument("version")
+    parser.add_argument("--file", type=Path, default=DEFAULT_PROPERTIES)
+    args = parser.parse_args()
+    update_properties(args.file, args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sdk-sync/update_ruby.py
+++ b/scripts/sdk-sync/update_ruby.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import re
+
+
+DEFAULT_GEMFILE = Path(__file__).resolve().parents[2] / "workers/ruby/Gemfile"
+VERSION_PATTERN = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+-]*")
+
+
+def update_gemfile(path: Path, version: str) -> None:
+    if not VERSION_PATTERN.fullmatch(version):
+        raise SystemExit(f"invalid SDK version: {version!r}")
+
+    contents = path.read_text(encoding="utf-8")
+    dependency = f"gem 'temporalio', '= {version}'"
+    updated, count = re.subn(
+        r"^gem\s+(['\"])temporalio\1(?:\s*,.*)?$",
+        dependency,
+        contents,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise SystemExit(f"expected one top-level temporalio dependency in {path}, found {count}")
+    if updated != contents:
+        path.write_text(updated, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update the Ruby SDK development pin")
+    parser.add_argument("version")
+    parser.add_argument("--file", type=Path, default=DEFAULT_GEMFILE)
+    args = parser.parse_args()
+    update_gemfile(args.file, args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/java/build.gradle
+++ b/workers/java/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'com.google.protobuf' version '0.9.4'
 }
 
+def temporalSdkVersion = providers.gradleProperty('temporalSdkVersion').get()
+
 allprojects {
     group 'io.temporal'
     version '0.1.0'
@@ -38,7 +40,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
-    implementation 'io.temporal:temporal-sdk:1.37.0'
+    implementation "io.temporal:temporal-sdk:${temporalSdkVersion}"
     implementation 'org.reflections:reflections:0.10.2'
     implementation 'ch.qos.logback:logback-classic:1.2.13'
     implementation 'info.picocli:picocli:4.6.2'
@@ -51,7 +53,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
 
-    testImplementation 'io.temporal:temporal-testing:1.37.0'
+    testImplementation "io.temporal:temporal-testing:${temporalSdkVersion}"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }

--- a/workers/java/build.gradle
+++ b/workers/java/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
 
-    testImplementation 'io.temporal:temporal-testing:1.35.0'
+    testImplementation 'io.temporal:temporal-testing:1.37.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }

--- a/workers/java/gradle.properties
+++ b/workers/java/gradle.properties
@@ -1,0 +1,1 @@
+temporalSdkVersion=1.37.0

--- a/workers/python/harness/pyproject.toml
+++ b/workers/python/harness/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = "~=3.10.0"
 license = "MIT"
 dependencies = [
-    "temporalio>=1.23.0,<2",
+    "temporalio>=1.31.0,<2",
     "grpcio>=1.60.0,<2",
     "prometheus-client>=0.16.0,<0.17",
     "python-json-logger>=2.0.7,<3",

--- a/workers/python/pyproject.toml
+++ b/workers/python/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = "~=3.10.0"
 license = "MIT"
 dependencies = [
-    "temporalio>=1.23.0,<2",
+    "temporalio>=1.31.0,<2",
     "grpcio>=1.60.0,<2",
     "prometheus-client>=0.16.0,<0.17",
     "python-json-logger>=2.0.7,<3",

--- a/workers/python/uv.lock
+++ b/workers/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.10.*"
 
 [manifest]
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.25.0"
+version = "1.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -292,13 +292,15 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/9c/3782bab0bf11a40b550147c19a5d1a476c17405391751982408902d9f138/temporalio-1.25.0.tar.gz", hash = "sha256:a3bbec1dcc904f674402cfa4faae480fda490b1c53ea5440c1f1996c562016fb", size = 2152534, upload-time = "2026-04-08T18:53:55.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/43/676b56efaa64def06d4a9282cfc08d5a5b1c89de0ded47b692f8eaa30ca8/temporalio-1.31.0.tar.gz", hash = "sha256:2993f4b880170825414116dec7d7159a5d199efc279f29570be6b5c4a9f6edd5", size = 2785306, upload-time = "2026-07-29T17:55:10.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/e3/5676dd10d1164b6d6ca8752314054097b89c5da931e936af402a7b15236c/temporalio-1.25.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6dc1bc8e1773b1a833d86a7ede2dd90ef4e031ced5b748b59e7f09a5bf9b327d", size = 13943906, upload-time = "2026-04-08T18:53:30.022Z" },
-    { url = "https://files.pythonhosted.org/packages/89/50/7cbf7f845973be986ec165348f72f7a409750842a04d554965a39be5cb4f/temporalio-1.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c8fdcf79ea5ae8ae2cf6f48072e4a86c3e0f4778f6a8a066c6ff1d336587db4", size = 13298719, upload-time = "2026-04-08T18:53:35.95Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/31/d474bab8535552add6ed289911bf1ffae5d7071823ece1069842190fcaed/temporalio-1.25.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:141f37aaafd7d090ba5c8776e4e9bc60df1fbc64b9f50c8f00e905a436588ddc", size = 13555435, upload-time = "2026-04-08T18:53:41.36Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/c8/e7dc053d6107bf2a037a3c9fe7b86639a25dcb888bde0e1ca366901ee47f/temporalio-1.25.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff7ca5bb80264976477d4dc7a839b3d22af8577ae92306526a061481db49bf92", size = 14052050, upload-time = "2026-04-08T18:53:46.44Z" },
-    { url = "https://files.pythonhosted.org/packages/08/70/9340ed3a578321cbc153041d34834bb1ec3f1f3e3d9cded47cd1b7c3e403/temporalio-1.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9411534279a2e64847231b6059c214bff4d57cfd1532bd09f333d0b1603daa7f", size = 14299684, upload-time = "2026-04-08T18:53:52.482Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7c/b91d831df50651a26562285de7c434a14243504eed853513da6e6afa3f19/temporalio-1.31.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5f9aaf06000768eb80cf5774457d227379dae455a3099aa0a18c4dca631c0d27", size = 14505266, upload-time = "2026-07-29T17:54:52.932Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d9/4655fc5d7ea662aac2af972e114ffeae45800bcded5ca3d31b2bcd99179d/temporalio-1.31.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:abbfb486ba00053ccfa57c9c38b38f80f5dbfd08c67beb7a621515a57a9b9e9b", size = 14037187, upload-time = "2026-07-29T17:54:55.771Z" },
+    { url = "https://files.pythonhosted.org/packages/52/8e/52bd6a90cba3d4b257d7aa7426598e622cf05ab39a174b477535eba59c14/temporalio-1.31.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e840b462125274cb0d4748e7cedc386c303b2a51bf76bab30b96f1ebbc657ae", size = 14445065, upload-time = "2026-07-29T17:54:58.254Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/91/b644c2122943939e02c0e0ff1902b9c6ff7d5e0d6eec334abbfd4ee6bb17/temporalio-1.31.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04d26f0f634f5325f6a19a45cd67cc5a2da4bd35268d27997f6723134d38c8be", size = 14831115, upload-time = "2026-07-29T17:55:00.923Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/42/abc82a89323234026753ac801a1dbc36b4322dcdec5f1e38bee6405f3493/temporalio-1.31.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f23f36d0e5d2e67f2129fc1cb876cf1e4e614f791a717d692f7c15fb732abe41", size = 14542828, upload-time = "2026-07-29T17:55:03.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/9260f4544eb5d44867ef58e4a0e63dd3d643e26b2a94e21e027ceaeb0059/temporalio-1.31.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:52f8cc7f0b5a19d49f0c2d748420267aaacc2be0bb614743de8d10faf77a57c9", size = 15019517, upload-time = "2026-07-29T17:55:05.758Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/96/b71e66a1921906f072038286e30946098531fd3363029f3d08c1723aa39a/temporalio-1.31.0-cp310-abi3-win_amd64.whl", hash = "sha256:aa6e9602829584b22037da6ccf99d2e089f02cec86ee7178206b1afb115cf092", size = 15527552, upload-time = "2026-07-29T17:55:08.287Z" },
 ]
 
 [[package]]

--- a/workers/python/uv.lock
+++ b/workers/python/uv.lock
@@ -91,7 +91,7 @@ requires-dist = [
     { name = "grpcio", specifier = ">=1.60.0,<2" },
     { name = "prometheus-client", specifier = ">=0.16.0,<0.17" },
     { name = "python-json-logger", specifier = ">=2.0.7,<3" },
-    { name = "temporalio", specifier = ">=1.23.0,<2" },
+    { name = "temporalio", specifier = ">=1.31.0,<2" },
 ]
 
 [package.metadata.requires-dev]
@@ -199,7 +199,7 @@ requires-dist = [
     { name = "harness", editable = "harness" },
     { name = "prometheus-client", specifier = ">=0.16.0,<0.17" },
     { name = "python-json-logger", specifier = ">=2.0.7,<3" },
-    { name = "temporalio", specifier = ">=1.23.0,<2" },
+    { name = "temporalio", specifier = ">=1.31.0,<2" },
 ]
 
 [package.metadata.requires-dev]

--- a/workers/ruby/Gemfile
+++ b/workers/ruby/Gemfile
@@ -10,3 +10,5 @@ group :development do
   gem 'rubocop', '~> 1.0'
   gem 'steep', '~> 1.10'
 end
+
+gem 'temporalio', '= 1.6.0'

--- a/workers/ruby/Gemfile.lock
+++ b/workers/ruby/Gemfile.lock
@@ -168,25 +168,25 @@ GEM
       terminal-table (>= 2, < 5)
       uri (>= 0.12.0)
     strscan (3.1.8)
-    temporalio (1.5.0)
+    temporalio (1.6.0)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-aarch64-linux)
+    temporalio (1.6.0-aarch64-linux)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-aarch64-linux-musl)
+    temporalio (1.6.0-aarch64-linux-musl)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-arm64-darwin)
+    temporalio (1.6.0-arm64-darwin)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-x86_64-darwin)
+    temporalio (1.6.0-x86_64-darwin)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-x86_64-linux)
+    temporalio (1.6.0-x86_64-linux)
       google-protobuf (>= 3.25.0)
       logger
-    temporalio (1.5.0-x86_64-linux-musl)
+    temporalio (1.6.0-x86_64-linux-musl)
       google-protobuf (>= 3.25.0)
       logger
     terminal-table (4.0.0)
@@ -220,6 +220,7 @@ DEPENDENCIES
   rbs (~> 3.10)
   rubocop (~> 1.0)
   steep (~> 1.10)
+  temporalio (= 1.6.0)
 
 CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
@@ -289,13 +290,13 @@ CHECKSUMS
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   steep (1.10.0) sha256=1b295b55f9aaff1b8d3ee42453ee55bc2a1078fda0268f288edb2dc014f4d7d1
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
-  temporalio (1.5.0) sha256=e736ac74ccecf1ab9c9a581b3c1505a718f355e8c9fecd5cc22ece0386b57750
-  temporalio (1.5.0-aarch64-linux) sha256=460d3b872226a7ccc5b2f9564a7226ef81f7366f1414efb70f7840aaed425a3a
-  temporalio (1.5.0-aarch64-linux-musl) sha256=a0b4f8c8ae1e25f72e26c0469b0a29e839e1a8dcd0ebfd9383f7d2bf15082581
-  temporalio (1.5.0-arm64-darwin) sha256=ccd90b063d4703ee00c8698f8c68879f04646d2425618bfa39598b6f237445a9
-  temporalio (1.5.0-x86_64-darwin) sha256=257fbf661204ed922f6b84120219f9416b9ab56e30923f111e58623ed0be99eb
-  temporalio (1.5.0-x86_64-linux) sha256=6c9ee36beef7f1aa9e949dfee4e7ba62eb8370daf6ad60246e90dce281e56e3e
-  temporalio (1.5.0-x86_64-linux-musl) sha256=a6f64a9e77d03bd466db73e5fad266cc50d9b00ed1b87e9fad6bca768f0b2632
+  temporalio (1.6.0) sha256=16f3230865fb821d1a36f94f0c0c60f08f3de176527db6f466db8d7b7c19f06f
+  temporalio (1.6.0-aarch64-linux) sha256=33a2d73efe00a1e9d8e288331cfb4b4f6440952444152025b80a28118d840772
+  temporalio (1.6.0-aarch64-linux-musl) sha256=a831b2f7ebb23214b991b5cf6c5bd22ba044216b4e06d4a8db8aba24bafa8ba4
+  temporalio (1.6.0-arm64-darwin) sha256=768c8ede4b384fffd142be5046161c261d6cedf75d9eb30a72080f6e338900ca
+  temporalio (1.6.0-x86_64-darwin) sha256=e76ccd3ee46b3e1cb4da66d84ae741f34504e531dd12c069a20208facee8878b
+  temporalio (1.6.0-x86_64-linux) sha256=e09582bda5ec49c9fe05ed3621cc2b289c371679b48b3e7aeff6635853253d2a
+  temporalio (1.6.0-x86_64-linux-musl) sha256=b40ae04006a05826878c5fdf244314d0cc97b72b2e698161dc0175d5590785f2
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/workers/typescript/package-lock.json
+++ b/workers/typescript/package-lock.json
@@ -567,13 +567,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
-      "integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -588,14 +588,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
-      "integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -610,16 +610,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
-      "integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
-        "@jsonjoy.com/fs-print": "4.56.10",
-        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
-      "integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
@@ -651,14 +651,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
-      "integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10"
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -672,12 +672,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
-      "integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.10"
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "glob-to-regex.js": "^1.0.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -691,12 +692,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
-      "integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -711,13 +712,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
-      "integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -946,19 +947,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1215,207 +1215,202 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.17.1.tgz",
-      "integrity": "sha512-DfcWhqAHtRtkEcBDx1zKJKXljljK4mmaeoemYvNk6mZizTnt+HPYEnMXGulcSEYILiO3E648JJneScMM7VrUSw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.22.0.tgz",
+      "integrity": "sha512-hrPeELIMloFWVrwmDfG1lh3uFNkaYp1ZHpcpWmJniTeSyxqCqLdil4lBOv11FByb6HeKxE6rsvOOUohulyVhRg==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/client": "1.17.1",
-        "@temporalio/common": "1.17.1",
-        "abort-controller": "^3.0.0"
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.17.1.tgz",
-      "integrity": "sha512-xDA1Vt+b8VYyIWaZbUdCL0uEeGVu186ARXaIJGK33fx45GR18ZQ5DmY2Ipdp6Pb/TRU8/SPaRhFy0AcMkxmYBw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.22.0.tgz",
+      "integrity": "sha512-b02ty0uDly6/ZRKlbavs5GjXVTry/GB4tkq0v1NH4H7x+nTo/OK0u5Ms8Nni8D+aar3xff9lzIpXNwu/Dp3P3w==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.4",
-        "@temporalio/common": "1.17.1",
-        "@temporalio/proto": "1.17.1",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
+        "nexus-rpc": "^0.0.2",
         "uuid": "^11.1.0"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.1.tgz",
-      "integrity": "sha512-lzDdDeXKO0EmG65zdimzx+v0mF123uoT6MHP7UugobnqEuqeUU+d8i4sdvGqBSYivr5ziF0xI8ceX9DjVkyj7w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.22.0.tgz",
+      "integrity": "sha512-1NpQpo/y6XU1ULbo/bXgBEhl6qQnOeB79NrsSJdjI38/hfXPom2IYGJcIxOFfsQICQ0zePEKzB9Yyo31KNpIxA==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/proto": "1.17.1",
+        "@temporalio/proto": "1.22.0",
         "long": "^5.2.3",
         "ms": "3.0.0-canary.1",
         "nexus-rpc": "^0.0.2",
         "proto3-json-serializer": "^2.0.0"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.17.1.tgz",
-      "integrity": "sha512-ig4nhiSkgE3enI7faxWWPm37NbmF88TWcJZyrL9JACg3punVWZ+VcOV9BG0RLtn5J9wb2KCdHLBxjhHdH6yEaA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.22.0.tgz",
+      "integrity": "sha512-mJ5agqtfW+GBPYl+ivYLrBpKJ3oFOw8ogcoizNrxYCzwJeprGFiEgHDb/jzyvECR4HAy5s9zQFJYNyTruXXFMw==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.4",
-        "@temporalio/common": "1.17.1"
+        "@temporalio/common": "1.22.0"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/nexus": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.17.1.tgz",
-      "integrity": "sha512-e7nXkWAcWkGGW9mZVKgTBtltDhV71oZo6fDq+PifljqNGmQ3zq8oM06JOPFkx8fPw3TuH+JsGT3gocmHWzd1Ng==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.22.0.tgz",
+      "integrity": "sha512-4S1ZZdSNjrO9IUyhWxweIidvNn1X/ihEl+P2fOn/Ky38YRx9G+8wtV6g6lqG8zUrtEv//uqFw+HsRMziE2y4tg==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/client": "1.17.1",
-        "@temporalio/common": "1.17.1",
-        "@temporalio/proto": "1.17.1",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
         "long": "^5.2.3",
         "nexus-rpc": "^0.0.2"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.1.tgz",
-      "integrity": "sha512-bNrTijDjbQaC6Ae/JThTAeOAqQOM5e40H0XE1HTuOaS0WyeCKRpiQ4t+5F3D2KlBOiZq7sIVm+9bFrHlIOHjoA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.22.0.tgz",
+      "integrity": "sha512-X7NVa0Z6HK3l9irZR48FKwZ9w9YXetCdF2z2KCIRr0W7Kul64Wt9o5hwvSXShAtrZuCEEHH8WO/ffHTXxJieLg==",
       "license": "MIT",
       "dependencies": {
         "long": "^5.2.3",
-        "protobufjs": "7.5.5"
+        "protobufjs": "^7.6.4"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/proto/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@temporalio/testing": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/testing/-/testing-1.17.1.tgz",
-      "integrity": "sha512-9d5+k3GlwE7mZz8Qu5WMUyIgHo6cUL1s7AJFW9o/i7DRb5hiSALSwz5Lq9u4VBXZoycXZuFGUGX+wG/1zmj+Ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@temporalio/activity": "1.17.1",
-        "@temporalio/client": "1.17.1",
-        "@temporalio/common": "1.17.1",
-        "@temporalio/core-bridge": "1.17.1",
-        "@temporalio/proto": "1.17.1",
-        "@temporalio/worker": "1.17.1",
-        "@temporalio/workflow": "1.17.1",
-        "abort-controller": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 20.0.0"
-      }
-    },
-    "node_modules/@temporalio/worker": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.17.1.tgz",
-      "integrity": "sha512-KyD+Cx2vtL+AsEeG5PLjfFwoZmy/Ih+rSF8QBCDwO7yb2mO+qrZUYBBIDrfQiw8XaUwILJEJguilTDNzwAHvzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.12.4",
-        "@swc/core": "^1.3.102",
-        "@temporalio/activity": "1.17.1",
-        "@temporalio/client": "1.17.1",
-        "@temporalio/common": "1.17.1",
-        "@temporalio/core-bridge": "1.17.1",
-        "@temporalio/nexus": "1.17.1",
-        "@temporalio/proto": "1.17.1",
-        "@temporalio/workflow": "1.17.1",
-        "abort-controller": "^3.0.0",
-        "heap-js": "^2.6.0",
-        "memfs": "^4.6.0",
-        "nexus-rpc": "^0.0.2",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "^7.5.5",
-        "rxjs": "^7.8.1",
-        "source-map": "^0.7.4",
-        "source-map-loader": "^4.0.2",
-        "supports-color": "^8.1.1",
-        "swc-loader": "^0.2.3",
-        "unionfs": "^4.5.1",
-        "webpack": "^5.104.1"
-      },
-      "engines": {
-        "node": ">= 20.0.0"
-      }
-    },
-    "node_modules/@temporalio/worker/node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@temporalio/testing": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/testing/-/testing-1.22.0.tgz",
+      "integrity": "sha512-LWIVkJZHLKsuuXLeTZ9VuN6Sjt79BJTl9KKTQ84dOysPj+tMGTET8TEZasBhCuocS0qFGrh00c5e4RzXjfnLLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/core-bridge": "1.22.0",
+        "@temporalio/proto": "1.22.0",
+        "@temporalio/worker": "1.22.0",
+        "@temporalio/workflow": "1.22.0"
+      },
+      "engines": {
+        "node": ">= 20.3.0"
+      }
+    },
+    "node_modules/@temporalio/worker": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.22.0.tgz",
+      "integrity": "sha512-axRHhUsovFlqDtXZxUnhRLV7WmC6qOMUCij13lw4glT5yRH62k8wIZqcT3naEfvLSzoDxjt2xM7me3VvTRSaow==",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.4",
+        "@swc/core": "^1.3.102",
+        "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/core-bridge": "1.22.0",
+        "@temporalio/nexus": "1.22.0",
+        "@temporalio/proto": "1.22.0",
+        "@temporalio/workflow": "1.22.0",
+        "heap-js": "^2.6.0",
+        "memfs": "^4.6.0",
+        "nexus-rpc": "^0.0.2",
+        "protobufjs": "^7.6.4",
+        "rxjs": "^7.8.1",
+        "source-map": "^0.7.4",
+        "source-map-loader": "^5.0.0",
+        "supports-color": "^8.1.1",
+        "swc-loader": "^0.2.3",
+        "unionfs": "^4.5.1",
+        "webpack": "^5.108.4"
+      },
+      "engines": {
+        "node": ">= 20.3.0"
+      }
+    },
+    "node_modules/@temporalio/worker/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@temporalio/workflow": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.17.1.tgz",
-      "integrity": "sha512-FxMHNbeZsx+xRk2q/xuHVbt0tNIE9qELvUWD7L3kBwl5/xcm4xAROnUEamLDVnkfcu/CAJdd9xMIO1lJUdc75g==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.22.0.tgz",
+      "integrity": "sha512-31Ax529+TvfH2RCexOhiCyM3lARJJoVzrnRUS1gX+jl+mka+pRRnEUx4B572mZz0oOlCCxbiztHZF72wwwWZDA==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/common": "1.17.1",
-        "@temporalio/proto": "1.17.1",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
         "nexus-rpc": "^0.0.2"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1452,26 +1447,6 @@
       "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1940,18 +1915,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2010,9 +1973,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2100,9 +2063,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2158,9 +2121,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2177,11 +2140,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2207,9 +2170,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2484,9 +2447,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -2502,13 +2465,13 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -2528,9 +2491,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/escalade": {
@@ -2938,9 +2901,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3115,12 +3078,6 @@
       "peerDependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3430,12 +3387,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3498,19 +3449,6 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -3635,19 +3573,19 @@
       "license": "MIT"
     },
     "node_modules/memfs": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
-      "integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-to-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
-        "@jsonjoy.com/fs-print": "4.56.10",
-        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -3658,9 +3596,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/merge-stream": {
@@ -3670,22 +3605,10 @@
       "license": "MIT"
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -3714,6 +3637,76 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/mkdirp": {
@@ -3761,10 +3754,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodemon": {
       "version": "2.0.22",
@@ -4143,15 +4139,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -4281,9 +4268,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4325,15 +4312,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -4401,16 +4379,16 @@
       }
     },
     "node_modules/source-map-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
-      "integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4525,9 +4503,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4538,9 +4516,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
+      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -4553,50 +4531,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -4612,9 +4546,9 @@
       "license": "MIT"
     },
     "node_modules/thingies": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
-      "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.18"
@@ -4896,9 +4830,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4962,12 +4896,11 @@
       "license": "MIT"
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -4975,36 +4908,31 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
+        "acorn": "^8.16.0",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.19.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -5023,9 +4951,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"

--- a/workers/typescript/package-lock.json
+++ b/workers/typescript/package-lock.json
@@ -10,17 +10,17 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@temporalio/activity": "^1.17.1",
-        "@temporalio/client": "^1.17.1",
-        "@temporalio/common": "^1.17.1",
-        "@temporalio/worker": "^1.17.1",
-        "@temporalio/workflow": "^1.17.1",
+        "@temporalio/activity": "^1.22.0",
+        "@temporalio/client": "^1.22.0",
+        "@temporalio/common": "^1.22.0",
+        "@temporalio/worker": "^1.22.0",
+        "@temporalio/workflow": "^1.22.0",
         "commander": "^11.1.0",
         "long": "^5.2.3",
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@temporalio/testing": "^1.17.1",
+        "@temporalio/testing": "^1.22.0",
         "@tsconfig/node24": "^24.0.4",
         "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.10.0",

--- a/workers/typescript/package.json
+++ b/workers/typescript/package.json
@@ -28,17 +28,17 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@temporalio/activity": "^1.17.1",
-    "@temporalio/client": "^1.17.1",
-    "@temporalio/common": "^1.17.1",
-    "@temporalio/worker": "^1.17.1",
-    "@temporalio/workflow": "^1.17.1",
+    "@temporalio/activity": "^1.22.0",
+    "@temporalio/client": "^1.22.0",
+    "@temporalio/common": "^1.22.0",
+    "@temporalio/worker": "^1.22.0",
+    "@temporalio/workflow": "^1.22.0",
     "commander": "^11.1.0",
     "long": "^5.2.3",
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "@temporalio/testing": "^1.17.1",
+    "@temporalio/testing": "^1.22.0",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.10.0",


### PR DESCRIPTION
## What changed?

This adds per-SDK and aggregate `mise` tasks that synchronize the repository's SDK dependency declarations and lockfiles with the versions pinned in `mise.toml`. The tasks delegate updates to each ecosystem's package manager where possible, with small fail-fast helpers for the Ruby and Java declarations that their package managers cannot update directly.

The TypeScript and Python compatibility-range lower bounds now advance with their tested SDK versions.
Java uses one shared Gradle property for its SDK and testing dependencies, while Ruby retains its published compatibility range and an exact development pin. 

CI runs the aggregate synchronization task and fails when it leaves a repository diff, and the README documents the workflow.

## Why?

`mise.toml` already defines the SDK versions used by CI and worker-image builds, but changing those pins did not update files such as `package.json`, `pyproject.toml`, `go.mod`, or their lockfiles. Keeping this workflow in `mise` makes the version pins actionable across the repository without expanding the Go development CLI.

After this change, an SDK bump consists of updating the relevant `mise` pin, running `mise run sync-sdk`, and reviewing the package-manager changes. There is no runtime rollout or manual migration.

## How did you test it?

- [ ] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Validation included `mise tasks validate`, two consecutive aggregate sync runs with identical diff hashes, a complete declared/resolved-version audit, fail-fast and idempotence checks for the Ruby and Java helpers, Gradle configuration, and the affected existing worker test suites plus focused Go tests.

## Potential risks

Package-manager resolution can update transitive lockfile entries alongside the requested SDK. The CI drift check also depends on the configured package registries being available. The helper scripts intentionally fail if the Ruby or Java declaration shape changes, requiring the synchronization logic to be updated alongside such a refactor.
