### PR TITLE
loadgen: don't count iterations abandoned by a stop as failures

### DIFF
--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -2,6 +2,7 @@ package loadgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -144,15 +145,26 @@ func (g *genericRun) Run(ctx context.Context) error {
 					err = nil
 				}
 
+				// An iteration cut short because the run is stopping is left out of
+				// both tallies.
+				//
+				// Both conditions are needed: the run's context is also done once a
+				// run simply finishes, and an iteration can fail with its own
+				// cancellation while the run is healthy.
+				stopping := iterErr != nil && ctx.Err() != nil && errors.Is(iterErr, context.Canceled)
+
 				select {
 				case <-ctx.Done():
 				case doneCh <- err:
-					if iterErr == nil {
+					switch {
+					case stopping:
+						g.logger.Debugf("Iteration %v abandoned: run is stopping", run.Iteration)
+					case iterErr == nil:
 						g.completed.Add(1)
 						if g.config.OnCompletion != nil {
 							g.config.OnCompletion(ctx, run)
 						}
-					} else {
+					default:
 						g.failed.Add(1)
 						if g.config.OnIterationFailure != nil {
 							g.config.OnIterationFailure(ctx, run, iterErr)

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -278,6 +278,71 @@ func TestRunContinueOnIterationFailure(t *testing.T) {
 	})
 }
 
+// TestRunStoppedIterationsAreNotCountedAsFailures pins that iterations abandoned
+// by a caller stopping the run are left out of the tallies, so a clean stop is
+// not reported as a burst of failures.
+func TestRunStoppedIterationsAreNotCountedAsFailures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var failed, completed []int
+
+		const concurrent = 5
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var inFlight int
+		executor := &GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				mu.Lock()
+				inFlight++
+				full := inFlight == concurrent
+				mu.Unlock()
+
+				// Stop the run once every slot is occupied, so every in-flight
+				// iteration ends on the stop rather than on its own outcome.
+				if full {
+					cancel()
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+
+		logger := zap.Must(zap.NewDevelopment())
+		defer logger.Sync()
+		err := executor.Run(ctx, ScenarioInfo{
+			MetricsHandler: client.MetricsNopHandler,
+			Logger:         logger.Sugar(),
+			Configuration: RunConfiguration{
+				Iterations:                 100,
+				MaxConcurrent:              concurrent,
+				ContinueOnIterationFailure: true,
+				OnCompletion: func(ctx context.Context, run *Run) {
+					mu.Lock()
+					defer mu.Unlock()
+					completed = append(completed, run.Iteration)
+				},
+				OnIterationFailure: func(ctx context.Context, run *Run, err error) {
+					mu.Lock()
+					defer mu.Unlock()
+					failed = append(failed, run.Iteration)
+				},
+			},
+		})
+
+		// Stopping a run is still an error for the caller to interpret; what must
+		// not happen is the stop being reported as failed iterations.
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "iterations failed",
+			"a stopped run must not report the end-of-run failure verdict")
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Empty(t, failed, "iterations abandoned by the stop must not be counted as failures")
+		require.Empty(t, completed, "nor as successes — they did not finish")
+	})
+}
+
 func TestExecutorRetriesLimit(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		totalTracker := newIterationTracker()


### PR DESCRIPTION
## What changed

An iteration that ends because the caller stopped the run is no longer tallied as
a failure, and no longer surfaced through `OnIterationFailure`. It is left out of
both tallies — abandoned, not rejected, so no more a success than a failure.

## Why

Counting them ties the failure tally to `MaxConcurrent` at the moment of the stop
rather than to the health of the run: every clean stop reports a burst of roughly
one concurrency window of failures. Because that burst is a near-fixed cost per
run, it reads as a failure *rate* that grows the shorter the run is — so a caller
scoring runs on failure rate sees a long run pass and a short one fail on
identical behaviour.

On a release-validation run driving `throughput_stress` for 57 minutes at
`MaxConcurrent=50`, 22 of 26 tolerated failures were iterations numbered above
the completed count, all ending in `context canceled` as teardown stopped the
load. Only 4 were real (a `context deadline exceeded` retried into
`Workflow execution is already running`). The reported rate was 0.49%; the real
one was 0.10%. At ten minutes the same fixed burst would have been several
percent.

## Details worth reviewing

Both halves of the condition are load-bearing. `Run` wraps its own cancellable
context, so `ctx.Err()` is non-nil once a run merely *finishes*, not only when a
caller stops it — keying off the context alone drops late-completing iterations
from the tallies. That is a race rather than a rule: it passed locally at
`-count=50` and still broke `TestRunContinueOnIterationFailure` in CI, which saw
`2 of 5` where it expected `3 of 6`. Requiring the iteration error to be
`context.Canceled` scopes it to genuine stops.

An iteration failing with its own deadline stays counted. That is a real failure,
and it is how a stopped start surfaces before its retry hits "already running".

The tallying on this path was already nondeterministic: with the context done,
the `select` between `ctx.Done()` and the done channel picked arbitrarily, so a
stopped run counted roughly half its in-flight iterations. That is why the
observed run tallied 22 rather than a full concurrency window.

`build-ks-gen-and-ensure-protos-up-to-date` fails on this branch for an unrelated
reason: CI regenerates `workers/go/harness/api/api.pb.go` with `protoc-gen-go
v1.36.12` while the committed file records `v1.36.11`, so the diff check trips on
the generator version comment alone. Nothing here touches protos.
