### PR TITLE
scenarios: report scheduler_stress failures instead of logging them

### DIFF
--- a/scenarios/scheduler_stress.go
+++ b/scenarios/scheduler_stress.go
@@ -164,6 +164,18 @@ func (s *SchedulerExecutor) Execute(ctx context.Context, run *loadgen.Run) error
 		ctx = metadata.AppendToOutgoingContext(ctx, "temporal-experiment", "chasm-scheduler")
 	}
 
+	// How many failed iterations a run tolerates is the caller's policy, via
+	// RunConfiguration.ContinueOnIterationFailure.
+	var (
+		mu   sync.Mutex
+		errs []error
+	)
+	record := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		errs = append(errs, err)
+	}
+
 	var wg sync.WaitGroup
 	for i := range s.config.ScheduleCreationPerIteration {
 		wg.Go(func() {
@@ -171,23 +183,25 @@ func (s *SchedulerExecutor) Execute(ctx context.Context, run *loadgen.Run) error
 			defer ticker.Stop()
 			start := time.Now()
 
-			sch_id := fmt.Sprintf("sched-%s-%d-%d-%s", run.RunID, run.Iteration, i, uuid.New())
-			sc, err := s.createSchedule(ctx, client, sch_id, run.TaskQueue(), logger)
+			scheduleID := fmt.Sprintf("sched-%s-%d-%d-%s", run.RunID, run.Iteration, i, uuid.New())
+			sc, err := s.createSchedule(ctx, client, scheduleID, run.TaskQueue(), logger)
 			if err != nil {
-				logger.Error("Failed to create schedule", "scheduleID", sc.ScheduleID, "error", err)
+				record(fmt.Errorf("creating schedule %s: %w", scheduleID, err))
 				return
 			}
 			<-ticker.C
+			// Read and update failures fall through to the delete below; an
+			// abandoned schedule would outlive the iteration until its EndAt.
 			for range s.config.ScheduleReadsPerCreation {
 				if err := s.describeSchedule(ctx, client, sc.ScheduleID, logger); err != nil {
-					logger.Error("Failed to describe schedule", "scheduleID", sc.ScheduleID, "error", err)
+					record(fmt.Errorf("describing schedule %s: %w", sc.ScheduleID, err))
 				}
 				<-ticker.C // Wait between read operations
 			}
 
 			for range s.config.ScheduleUpdatesPerCreation {
 				if err := s.updateSchedule(ctx, client, sc.ScheduleID, logger); err != nil {
-					logger.Error("Failed to update schedule", "scheduleID", sc.ScheduleID, "error", err)
+					record(fmt.Errorf("updating schedule %s: %w", sc.ScheduleID, err))
 				}
 				<-ticker.C // Wait between update operations
 			}
@@ -195,15 +209,22 @@ func (s *SchedulerExecutor) Execute(ctx context.Context, run *loadgen.Run) error
 			select {
 			case <-time.After(dur):
 				if err := s.deleteSchedule(ctx, client, sc.ScheduleID, logger); err != nil {
-					logger.Error("Failed to delete schedule", "scheduleID", sc.ScheduleID, "error", err)
+					record(fmt.Errorf("deleting schedule %s: %w", sc.ScheduleID, err))
 				}
 			case <-ctx.Done():
-				logger.Info("Context canceled")
+				// Left undeleted; EndAt bounds how long it survives.
 			}
 		})
 	}
 	wg.Wait()
-	return nil
+
+	// GenericExecutor checks errors.Is(err, context.Canceled) to tell a stopped
+	// iteration from a failed one. The operation errors above are gRPC status
+	// errors that do not unwrap to that sentinel, whatever their message says.
+	if err := ctx.Err(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 type ScheduleState struct {

--- a/scenarios/scheduler_stress_test.go
+++ b/scenarios/scheduler_stress_test.go
@@ -1,0 +1,118 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/omes/clioptions"
+	"github.com/temporalio/omes/internal/workertest"
+	"github.com/temporalio/omes/loadgen"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestSchedulerStress_Configure(t *testing.T) {
+	t.Parallel()
+
+	configure := func(t *testing.T, opts map[string]string) (*schedulerExecutorConfig, error) {
+		t.Helper()
+		var s SchedulerExecutor
+		err := s.Configure(loadgen.ScenarioInfo{
+			Options: loadgen.MustResolveScenarioOptions("scheduler_stress", opts),
+		})
+		return s.config, err
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := configure(t, nil)
+		require.NoError(t, err)
+		require.Equal(t, DefaultScheduleCreationPerIteration, cfg.ScheduleCreationPerIteration)
+		require.Equal(t, DefaultScheduleReadsPerCreation, cfg.ScheduleReadsPerCreation)
+		require.Equal(t, DefaultScheduleUpdatesPerCreation, cfg.ScheduleUpdatesPerCreation)
+		require.Equal(t, DefaultPayloadSize, cfg.PayloadSize)
+		require.Equal(t, NoopScheduledWorkflowType, cfg.ScheduledWorkflowType)
+		require.True(t, cfg.EnableChasmScheduler)
+	})
+
+	t.Run("rejects invalid values", func(t *testing.T) {
+		cases := map[string]map[string]string{
+			"non-positive creations":      {ScheduleCreationPerIterationFlag: "0"},
+			"negative reads":              {ScheduleReadsPerCreationFlag: "-1"},
+			"negative updates":            {ScheduleUpdatesPerCreationFlag: "-1"},
+			"non-positive payload":        {PayloadSizeFlag: "0"},
+			"non-positive iter duration":  {SchedulerDurationPerIterationFlag: "0s"},
+			"negative cleanup wait":       {WaitTimeBeforeCleanupFlag: "-1s"},
+			"negative operation interval": {OperationIntervalFlag: "-1s"},
+		}
+		for name, opts := range cases {
+			t.Run(name, func(t *testing.T) {
+				_, err := configure(t, opts)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestSchedulerStress(t *testing.T) {
+	t.Parallel()
+
+	env := workertest.SetupTestEnvironment(t, workertest.WithExecutorTimeout(2*time.Minute))
+
+	scenarioInfo := func(runID string, overrides map[string]string) loadgen.ScenarioInfo {
+		opts := map[string]string{
+			ScheduleCreationPerIterationFlag:  "2",
+			ScheduleReadsPerCreationFlag:      "1",
+			ScheduleUpdatesPerCreationFlag:    "1",
+			OperationIntervalFlag:             "10ms",
+			SchedulerDurationPerIterationFlag: "1s",
+			WaitTimeBeforeCleanupFlag:         "1s",
+			// Routing is the pipeline's concern; these cases are about run outcome.
+			EnableChasmSchedulerFlag: "false",
+		}
+		maps.Copy(opts, overrides)
+		return loadgen.ScenarioInfo{
+			RunID:         runID,
+			Configuration: loadgen.RunConfiguration{Iterations: 1},
+			Options:       loadgen.MustResolveScenarioOptions("scheduler_stress", opts),
+		}
+	}
+
+	run := func(t *testing.T, info loadgen.ScenarioInfo) error {
+		t.Helper()
+		scenario := loadgen.GetScenario("scheduler_stress")
+		require.NotNil(t, scenario)
+		_, err := env.RunExecutorTest(t, scenario.ExecutorFn(), info, clioptions.LangGo)
+		return err
+	}
+
+	t.Run("healthy run reports success", func(t *testing.T) {
+		runID := fmt.Sprintf("sched-ok-%d", time.Now().UnixNano())
+		require.NoError(t, run(t, scenarioInfo(runID, nil)))
+	})
+
+	t.Run("rejected schedule creation fails the run", func(t *testing.T) {
+		// An unparseable cron spec makes the server reject every Create.
+		runID := fmt.Sprintf("sched-bad-%d", time.Now().UnixNano())
+		err := run(t, scenarioInfo(runID, map[string]string{CronExpressionFlag: "not a cron expression"}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "creating schedule")
+	})
+
+	t.Run("a stopped iteration reads as canceled, not failed", func(t *testing.T) {
+		// GenericExecutor keys abandoned-vs-failed off errors.Is(err,
+		// context.Canceled), which the operations' own gRPC errors do not satisfy.
+		info := scenarioInfo(fmt.Sprintf("sched-stop-%d", time.Now().UnixNano()), nil)
+		info.Logger = zaptest.NewLogger(t).Sugar()
+		info.Client = env.TemporalClient()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := new(SchedulerExecutor).Execute(ctx, info.NewRun(1))
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}


### PR DESCRIPTION
## What changed

`SchedulerExecutor.Execute` collects the failures from its per-schedule goroutines and returns them joined, instead of logging each one and returning `nil`. An iteration fails if any of its schedules did; how many failed iterations a run tolerates stays the caller's policy, via `ContinueOnIterationFailure`.

## Why

The scenario could not fail. Every create/read/update/delete error was logged and `Execute` returned `nil` unconditionally, so `GenericExecutor`'s iteration tallies never incremented and a run in which the server rejected every schedule creation was indistinguishable from a healthy one.

saas-cicd is preparing to adopt this scenario as the CHASM-scheduler validation load in place of bench-go's `EnableCreateSchedule`, where a run outcome that carries no information is disqualifying.

## Details worth reviewing

The `ctx.Err()` join at the end is the subtle hunk. `GenericExecutor` keys abandoned-vs-failed off `errors.Is(err, context.Canceled)`, and the schedule operations fail with gRPC status errors that print as `context canceled` but do not unwrap to that sentinel — so without the join, every clean stop tallies a concurrency window of false failures, the effect #447 removed. Deleting the join makes the cancellation test fail, with the sentinel absent from a chain whose text reads `context canceled`.

Read and update failures deliberately do not abandon their schedule: it still has to reach the delete below, or it outlives the iteration until its `EndAt`.

Part of RE-354.
