### PR TITLE
Track max per-iteration elapsed time in throughput_stress

### DIFF
--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -134,7 +134,8 @@ func (g *genericRun) Run(ctx context.Context) error {
 			iterStart := time.Now()
 
 			defer func() {
-				g.executeTimer.Record(time.Since(iterStart))
+				elapsed := time.Since(iterStart)
+				g.executeTimer.Record(elapsed)
 
 				// Swallow the error for the spawn loop only, so a tolerated failure
 				// doesn't stop new iterations from starting. It is not ignored: it is
@@ -160,6 +161,7 @@ func (g *genericRun) Run(ctx context.Context) error {
 					case stopping:
 						g.logger.Debugf("Iteration %v abandoned: run is stopping", run.Iteration)
 					case iterErr == nil:
+						run.Duration = elapsed
 						g.completed.Add(1)
 						if g.config.OnCompletion != nil {
 							g.config.OnCompletion(ctx, run)

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -378,6 +378,10 @@ type Run struct {
 	Iteration int
 	Logger    *zap.SugaredLogger
 
+	// Duration is the wall-clock elapsed time of this iteration. It is set
+	// by the executor before OnCompletion fires, so callbacks can read it.
+	Duration time.Duration
+
 	// tracks how many attempts have been made for this iteration
 	attemptCount int
 }

--- a/scenarios/throughput_stress.go
+++ b/scenarios/throughput_stress.go
@@ -83,6 +83,11 @@ type tpsState struct {
 	// AccumulatedDuration is the total execution time across all runs (original + resumes).
 	// This excludes any downtime between runs. Used for accurate throughput calculation.
 	AccumulatedDuration time.Duration `json:"accumulatedDuration"`
+	// MaxElapsedNanos is the wall-clock duration of the slowest completed iteration,
+	// in nanoseconds. Useful for detecting degraded recovery: even when throughput
+	// barely drops during a disruption, individual iteration latency can spike
+	// significantly. Zero means no iteration has completed yet.
+	MaxElapsedNanos int64 `json:"maxElapsedNanos"`
 }
 
 type tpsConfig struct {
@@ -301,8 +306,8 @@ func (t *tpsExecutor) Run(ctx context.Context, info loadgen.ScenarioInfo) error 
 
 	// Listen to iteration completion events to update the state.
 	info.Configuration.OnCompletion = func(ctx context.Context, run *loadgen.Run) {
-		t.updateStateOnIterationCompletion()
-		info.Logger.Debugf("Completed iteration %d", run.Iteration)
+		t.updateStateOnIterationCompletion(run.Duration)
+		info.Logger.Debugf("Completed iteration %d in %v", run.Iteration, run.Duration)
 	}
 
 	// Tally terminal iteration failures into the state so the failed count is
@@ -458,11 +463,14 @@ func (t *tpsExecutor) samplePayloadSize(rng *rand.Rand) int {
 	return int(t.config.Payload.SamplePayloadSize(rng, 256))
 }
 
-func (t *tpsExecutor) updateStateOnIterationCompletion() {
+func (t *tpsExecutor) updateStateOnIterationCompletion(d time.Duration) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	t.state.CompletedIterations += 1
 	t.state.LastCompletedIterationAt = time.Now()
+	if n := d.Nanoseconds(); n > t.state.MaxElapsedNanos {
+		t.state.MaxElapsedNanos = n
+	}
 }
 
 func (t *tpsExecutor) updateStateOnIterationFailure() {

--- a/scenarios/throughput_stress_test.go
+++ b/scenarios/throughput_stress_test.go
@@ -49,6 +49,7 @@ func TestThroughputStress(t *testing.T) {
 
 		state := executor.Snapshot().(tpsState)
 		require.Equal(t, state.CompletedIterations, 2)
+		require.Greater(t, state.MaxElapsedNanos, int64(0))
 	})
 
 	t.Run("Run executor again, resuming from middle", func(t *testing.T) {


### PR DESCRIPTION
## What was changed
Adds `Duration time.Duration` to loadgen.Run, set by generic_executor before OnCompletion fires, making per-iteration elapsed time available to any scenario that registers an OnCompletion callback. Also adds MaxElapsedNanos int64 to the throughput_stress snapshot to track the running maximum across completed iterations. Tracking the max is a useful signal that doesn't grow unbounded with iteration count.

## Why?


Currently `completedIterations` and `failedIterations` are available in the final result but there is no per-iteration timing data. We would like to use this data in AZ partition testing, where throughput may not necessarily degrade but individual iteration latency can spike significantly.` maxElapsedNanos` gives callers data to enforce a latency threshold as a pass/fail signal. 

How was this tested:
* Unit test (included)
* Local run 
```
2026-08-25T12:30:48.119-0500	INFO	loadgen/generic_executor.go:211	Run cooldown: stopped starting new iterations and waiting for 5 iterations to complete
2026-08-25T12:30:57.731-0500	DEBUG	scenarios/throughput_stress.go:310	Completed iteration 11 in 41.362928833s
2026-08-25T12:30:59.629-0500	DEBUG	scenarios/throughput_stress.go:310	Completed iteration 13 in 42.086289708s
2026-08-25T12:31:00.516-0500	DEBUG	scenarios/throughput_stress.go:310	Completed iteration 12 in 43.726900916s
2026-08-25T12:31:00.848-0500	DEBUG	scenarios/throughput_stress.go:310	Completed iteration 14 in 43.058620125s
2026-08-25T12:31:01.156-0500	DEBUG	scenarios/throughput_stress.go:310	Completed iteration 15 in 43.20101175s
2026-08-25T12:31:01.156-0500	INFO	loadgen/generic_executor.go:233	Run completed in 2m13.038176917s
2026-08-25T12:31:01.156-0500	INFO	scenarios/throughput_stress.go:402	[Scenario completion summary] Run ID: s-tli-0819rel, Total iterations completed: 15, Total child workflows: 150 (10 per iteration), Total continue-as-new workflows: 45 (3 per iteration), Total workflows completed: 210
2026-08-25T12:31:01.591-0500	INFO	workerctl/run.go:194	Sending interrupt to worker, PID: 63686
2026-08-25T12:31:01.592-0500	INFO	internal/internal_worker.go:1602	Worker has been stopped.
...
```