### PR TITLE
Allow CLI load runs to continue after terminal iteration failures

### DIFF
--- a/cmd/omes/run_scenario.go
+++ b/cmd/omes/run_scenario.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -13,6 +14,12 @@ import (
 	"github.com/temporalio/omes/loadgen"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
+)
+
+const (
+	iterationFailurePolicyContinue = "continue"
+	iterationFailurePolicyFailFast = "fail-fast"
+	defaultIterationFailurePolicy  = iterationFailurePolicyFailFast
 )
 
 func runScenarioCmd() *cobra.Command {
@@ -51,6 +58,7 @@ type scenarioRunConfig struct {
 	maxConcurrent                 int
 	maxIterationsPerSecond        float64
 	maxIterationAttempts          int
+	iterationFailurePolicy        string
 	scenarioOptions               []string
 	timeout                       time.Duration
 	doNotRegisterSearchAttributes bool
@@ -75,6 +83,8 @@ func (r *scenarioRunConfig) addCLIFlags(fs *pflag.FlagSet) {
 	fs.Float64Var(&r.maxIterationsPerSecond, "max-iterations-per-second", 0, "Override iterations per second rate limit for the scenario."+
 		" This is the maximum rate at which we will start new iterations of the scenario.")
 	fs.IntVar(&r.maxIterationAttempts, "max-iteration-attempts", 1, "Maximum attempts per iteration")
+	fs.StringVar(&r.iterationFailurePolicy, "iteration-failure-policy", defaultIterationFailurePolicy,
+		"How to handle terminal iteration failures: fail-fast (default) or continue")
 	fs.DurationVar(&r.timeout, "timeout", 0, "If set, the scenario will stop after this amount of"+
 		" time has elapsed. Any still-running iterations will be cancelled, and omes will exit nonzero.")
 	fs.IntVar(&r.maxConcurrent, "max-concurrent", 0, "Override max-concurrent for the scenario")
@@ -109,6 +119,13 @@ func (r *scenarioRunner) validateInput() (*loadgen.Scenario, *loadgen.OptionSet,
 		return nil, nil, loadgen.NewUsageError("--iterations and --duration cannot be combined; " +
 			"use --iterations to run a fixed number of times, or --duration to keep starting " +
 			"iterations for a period")
+	} else if policy := r.resolvedIterationFailurePolicy(); policy != iterationFailurePolicyContinue && policy != iterationFailurePolicyFailFast {
+		return nil, nil, loadgen.NewUsageError(
+			"--iteration-failure-policy must be %q or %q, got %q",
+			iterationFailurePolicyContinue,
+			iterationFailurePolicyFailFast,
+			r.iterationFailurePolicy,
+		)
 	}
 
 	// Parse options
@@ -138,6 +155,43 @@ func (r *scenarioRunner) validateInput() (*loadgen.Scenario, *loadgen.OptionSet,
 		return nil, nil, &loadgen.InvalidOptionsError{ScenarioName: r.scenario.Scenario, Err: resolveErr}
 	}
 	return scenario, resolvedOptions, nil
+}
+
+func (r scenarioRunConfig) resolvedIterationFailurePolicy() string {
+	if r.iterationFailurePolicy == "" {
+		return defaultIterationFailurePolicy
+	}
+	return r.iterationFailurePolicy
+}
+
+func (r scenarioRunConfig) loadgenConfiguration() loadgen.RunConfiguration {
+	return loadgen.RunConfiguration{
+		Iterations:                    r.iterations,
+		Duration:                      r.duration,
+		MaxConcurrent:                 r.maxConcurrent,
+		MaxIterationsPerSecond:        r.maxIterationsPerSecond,
+		MaxIterationAttempts:          r.maxIterationAttempts,
+		Timeout:                       r.timeout,
+		DoNotRegisterSearchAttributes: r.doNotRegisterSearchAttributes,
+		IgnoreAlreadyStarted:          r.ignoreAlreadyStarted,
+		ContinueOnIterationFailure:    r.resolvedIterationFailurePolicy() == iterationFailurePolicyContinue,
+	}
+}
+
+// iterationFailuresOnly recognizes an IterationFailuresError through ordinary
+// single-cause wrapping. It deliberately rejects multi-errors so a degraded
+// completion cannot hide another run-level failure joined to it.
+func iterationFailuresOnly(err error) (*loadgen.IterationFailuresError, bool) {
+	for err != nil {
+		if failures, ok := err.(*loadgen.IterationFailuresError); ok {
+			return failures, true
+		}
+		if _, ok := err.(interface{ Unwrap() []error }); ok {
+			return nil, false
+		}
+		err = errors.Unwrap(err)
+	}
+	return nil, false
 }
 
 func (r *scenarioRunner) run(ctx context.Context) error {
@@ -192,19 +246,10 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 		MetricsHandler: metrics.NewHandler(),
 		Client:         client,
 		ClientOptions:  r.clientOptions,
-		Configuration: loadgen.RunConfiguration{
-			Iterations:                    r.iterations,
-			Duration:                      r.duration,
-			MaxConcurrent:                 r.maxConcurrent,
-			MaxIterationsPerSecond:        r.maxIterationsPerSecond,
-			MaxIterationAttempts:          r.maxIterationAttempts,
-			Timeout:                       r.timeout,
-			DoNotRegisterSearchAttributes: r.doNotRegisterSearchAttributes,
-			IgnoreAlreadyStarted:          r.ignoreAlreadyStarted,
-		},
-		Options:   resolvedOptions,
-		Namespace: r.clientOptions.Namespace,
-		RootPath:  repoDir,
+		Configuration:  r.loadgenConfiguration(),
+		Options:        resolvedOptions,
+		Namespace:      r.clientOptions.Namespace,
+		RootPath:       repoDir,
 		ExportOptions: loadgen.ExportOptions{
 			ExportHistoriesDir:    r.exportHistoriesDir,
 			ExportHistoriesFilter: r.exportHistoriesFilter,
@@ -213,7 +258,14 @@ func (r *scenarioRunner) run(ctx context.Context) error {
 	executor := scenario.ExecutorFn()
 	err = executor.Run(ctx, scenarioInfo)
 	if err != nil {
-		return fmt.Errorf("failed scenario: %w", err)
+		if r.resolvedIterationFailurePolicy() == iterationFailurePolicyContinue {
+			if _, ok := iterationFailuresOnly(err); ok {
+				err = nil
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("failed scenario: %w", err)
+		}
 	}
 	err = loadgen.ExportWorkflowHistories(ctx, scenarioInfo)
 	if err != nil {

--- a/cmd/omes/run_scenario_test.go
+++ b/cmd/omes/run_scenario_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	"github.com/temporalio/omes/clioptions"
 	"github.com/temporalio/omes/loadgen"
 )
@@ -46,6 +48,11 @@ func TestValidateInputClassifiesBadInputAsUsageErrors(t *testing.T) {
 			wantMsg: "cannot be combined",
 		},
 		{
+			name:    "invalid iteration failure policy",
+			mutate:  func(r *scenarioRunner) { r.iterationFailurePolicy = "sometimes" },
+			wantMsg: "--iteration-failure-policy must be",
+		},
+		{
 			name:    "option without equals",
 			mutate:  func(r *scenarioRunner) { r.scenarioOptions = []string{"novalue"} },
 			wantMsg: `--option "novalue" is not in key=value format`,
@@ -82,6 +89,52 @@ func TestValidateInputClassifiesBadInputAsUsageErrors(t *testing.T) {
 				t.Errorf("error should mention %q, got: %v", tc.wantMsg, err)
 			}
 		})
+	}
+}
+
+func TestIterationFailurePolicyConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   bool
+	}{
+		{name: "zero value defaults to fail fast", want: false},
+		{name: "continue", policy: iterationFailurePolicyContinue, want: true},
+		{name: "fail fast", policy: iterationFailurePolicyFailFast, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := scenarioRunConfig{iterationFailurePolicy: test.policy}.loadgenConfiguration()
+			if config.ContinueOnIterationFailure != test.want {
+				t.Fatalf("ContinueOnIterationFailure = %v, want %v", config.ContinueOnIterationFailure, test.want)
+			}
+		})
+	}
+}
+
+func TestIterationFailurePolicyFlagDefaultsToFailFast(t *testing.T) {
+	var config scenarioRunConfig
+	config.addCLIFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	if config.iterationFailurePolicy != iterationFailurePolicyFailFast {
+		t.Fatalf("iterationFailurePolicy = %q, want %q",
+			config.iterationFailurePolicy, iterationFailurePolicyFailFast)
+	}
+}
+
+func TestIterationFailuresOnly(t *testing.T) {
+	degraded := &loadgen.IterationFailuresError{Attempted: 2, Succeeded: 1, Failed: 1}
+
+	found, ok := iterationFailuresOnly(fmt.Errorf("scenario wrapper: %w", degraded))
+	if !ok || found != degraded {
+		t.Fatalf("expected wrapped degraded completion to be recognized, got %v, %v", found, ok)
+	}
+
+	if _, ok := iterationFailuresOnly(errors.Join(degraded, errors.New("cleanup failed"))); ok {
+		t.Fatal("must not treat a joined run-level error as only iteration failures")
+	}
+	if _, ok := iterationFailuresOnly(errors.New("run failed")); ok {
+		t.Fatal("must not treat an ordinary run error as degraded completion")
 	}
 }
 

--- a/docs/authoring-scenarios.md
+++ b/docs/authoring-scenarios.md
@@ -143,7 +143,8 @@ scenario's `DefaultConfiguration` field over the older `HasDefaultConfiguration`
 
 Scenario configuration arrives through **two separate channels**, and knowing which is which matters:
 
-1. **Built-in run flags** — iterations, duration, concurrency, rate, attempts, timeout. These are
+1. **Built-in run flags** — iterations, duration, concurrency, rate, attempts, iteration-failure policy,
+   timeout. These are
    framework-level and apply to every scenario, so you neither declare nor read them; see
    [running.md](./running.md#configuring-the-load) for the list.
 2. **Your own options** — `--option key=value` pairs that you **declare** on the scenario.

--- a/docs/running.md
+++ b/docs/running.md
@@ -70,11 +70,17 @@ These apply to every scenario and override its defaults:
 | `--max-concurrent` | Max iterations running at once. |
 | `--max-iterations-per-second` | Rate limit on starting iterations (0 = unlimited). |
 | `--max-iteration-attempts` | Attempts per iteration (default 1). |
+| `--iteration-failure-policy` | `fail-fast` (default) stops on the first terminal failure; `continue` records failures and keeps generating load. |
 | `--timeout` | Hard stop; cancels in-flight iterations and exits non-zero. |
 
 If you set neither `--iterations` nor `--duration`, the scenario's own default applies — and most
 scenarios declare none, in which case omes's default does. `list-scenarios` states which is the case for
 each scenario.
+
+Iteration retries and the terminal-failure policy are independent. `--max-iteration-attempts` controls
+how many times one logical iteration may execute. With the default `fail-fast` policy, exhausting those
+attempts stops the run and exits non-zero. The `continue` policy logs the terminal failure, keeps starting
+load, and emits a warning summary before exiting zero if the run otherwise completes.
 
 ### 2. Per-scenario options (`--option key=value`)
 

--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -218,8 +218,9 @@ func (g *genericRun) Run(ctx context.Context) error {
 			return fmt.Errorf("timed out while waiting for runs to complete: %w", ctx.Err())
 		}
 	}
+	elapsed := time.Since(startTime)
 	if runErr != nil {
-		return fmt.Errorf("run finished with error after %v: %w", time.Since(startTime), runErr)
+		return fmt.Errorf("run finished with error after %v: %w", elapsed, runErr)
 	}
 	// ContinueOnIterationFailure changed only when the run stops (it ran to
 	// completion instead of aborting on the first failure); the verdict is
@@ -227,11 +228,20 @@ func (g *genericRun) Run(ctx context.Context) error {
 	// outcomes were tallied into the snapshot, so the caller can read the
 	// success/failure counts and apply its own policy on top.
 	if failed := g.failed.Load(); failed > 0 {
-		completed := g.completed.Load()
-		g.logger.Infof("Run completed in %v: %d iterations succeeded, %d failed",
-			time.Since(startTime), completed, failed)
-		return fmt.Errorf("run completed with %d of %d iterations failed", failed, completed+failed)
+		succeeded := g.completed.Load()
+		g.logger.Warnw("Run completed with iteration failures",
+			"elapsed", elapsed,
+			"attempted", succeeded+failed,
+			"succeeded", succeeded,
+			"failed", failed,
+		)
+		return &IterationFailuresError{
+			Attempted: succeeded + failed,
+			Succeeded: succeeded,
+			Failed:    failed,
+			Elapsed:   elapsed,
+		}
 	}
-	g.logger.Infof("Run completed in %v", time.Since(startTime))
+	g.logger.Infof("Run completed in %v", elapsed)
 	return nil
 }

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type iterationTracker struct {
@@ -309,10 +312,13 @@ func TestRunContinueOnIterationFailure(t *testing.T) {
 			},
 		)
 
-		// Every iteration runs (tolerated failures don't abort), but the verdict is
-		// unchanged: the run still fails because iterations failed.
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "3 of 6 iterations failed")
+		// Every iteration runs (tolerated failures don't abort), while library
+		// callers still receive a structured degraded-run verdict.
+		var failures *IterationFailuresError
+		require.ErrorAs(t, err, &failures)
+		require.Equal(t, int64(6), failures.Attempted)
+		require.Equal(t, int64(3), failures.Succeeded)
+		require.Equal(t, int64(3), failures.Failed)
 		mu.Lock()
 		defer mu.Unlock()
 		require.ElementsMatch(t, []int{1, 3, 5}, completed)
@@ -349,6 +355,64 @@ func TestRunReportsNonCancellationFailureAfterCancellation(t *testing.T) {
 		default:
 		}
 		require.True(t, reported, "non-cancellation error should be reported as a failure")
+	})
+}
+
+func TestRunContinueOnIterationFailureDuration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var attempts atomic.Int64
+		err := execute(&GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				time.Sleep(10 * time.Millisecond)
+				attempts.Add(1)
+				if run.Iteration%2 == 0 {
+					return errors.New("deliberate fail from test")
+				}
+				return nil
+			}},
+			RunConfiguration{
+				Duration:                   50 * time.Millisecond,
+				MaxConcurrent:              1,
+				ContinueOnIterationFailure: true,
+			},
+		)
+
+		var failures *IterationFailuresError
+		require.ErrorAs(t, err, &failures)
+		require.Equal(t, attempts.Load(), failures.Attempted)
+		require.Positive(t, failures.Succeeded)
+		require.Positive(t, failures.Failed)
+	})
+}
+
+func TestRunContinueOnIterationFailureLogsWarning(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		err := (&GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				if run.Iteration == 2 {
+					return errors.New("deliberate fail from test")
+				}
+				return nil
+			},
+		}).Run(context.Background(), ScenarioInfo{
+			MetricsHandler: client.MetricsNopHandler,
+			Logger:         zap.New(core).Sugar(),
+			Configuration: RunConfiguration{
+				Iterations:                 2,
+				MaxConcurrent:              1,
+				ContinueOnIterationFailure: true,
+			},
+		})
+
+		var failures *IterationFailuresError
+		require.ErrorAs(t, err, &failures)
+		entries := logs.FilterMessage("Run completed with iteration failures").All()
+		require.Len(t, entries, 1)
+		fields := entries[0].ContextMap()
+		require.Equal(t, int64(2), fields["attempted"])
+		require.Equal(t, int64(1), fields["succeeded"])
+		require.Equal(t, int64(1), fields["failed"])
 	})
 }
 

--- a/loadgen/scenario.go
+++ b/loadgen/scenario.go
@@ -291,6 +291,22 @@ const DefaultMaxIterationAttempts = 1
 const BaseIterationRetryBackoff = 1 * time.Second
 const MaxIterationRetryBackoff = 60 * time.Second
 
+// IterationFailuresError reports a run that reached its configured end while
+// tolerating one or more terminal iteration failures.
+//
+// Library callers receive a non-nil error so they can apply their own failure
+// policy.
+type IterationFailuresError struct {
+	Attempted int64
+	Succeeded int64
+	Failed    int64
+	Elapsed   time.Duration
+}
+
+func (e *IterationFailuresError) Error() string {
+	return fmt.Sprintf("run completed with %d of %d iterations failed", e.Failed, e.Attempted)
+}
+
 type RunConfiguration struct {
 	// Number of iterations to run of this scenario (mutually exclusive with Duration).
 	Iterations int


### PR DESCRIPTION
## What was changed

`omes run-scenario` and `run-scenario-with-worker` now accept `--iteration-failure-policy=fail-fast|continue`. Existing commands remain `fail-fast` by default; operators running sustained load can explicitly select `continue`. Retry count and terminal-failure policy remain independent.

The loadgen library still defaults to fail-fast. When continuation is enabled, it returns a typed `IterationFailuresError` containing attempted, succeeded, failed, and elapsed values. The CLI treats only that degraded completion as successful in `continue` mode, so cancellation, timeout, validation, connection, joined, and other run-level errors remain fatal. Every terminal failure remains an error log, and a completed degraded run emits a structured warning with its outcome counts.

The operational observability changes are intentionally separated into stacked follow-up PR #486.

## Why?

A terminal iteration failure currently ends an `omes run-scenario` invocation. In a Kubernetes load-driver deployment, that turns a transient workflow failure into a container restart and stops the configured load run early. This PR adds an explicit continuation mode for that use case while preserving existing fail-fast behavior for unflagged CLI, CI, and automation callers.

## Checklist

1. Closes #453

2. How was this tested:
   - Focused loadgen tests cover fixed-iteration and duration-based degraded results.
   - CLI tests cover the zero-value and registered fail-fast defaults, explicit continue, explicit fail-fast, invalid policy, wrapped degraded result, joined error, and unrelated error cases.
   - A logger-observer test verifies the final degraded-run warning and its attempted, succeeded, and failed fields.
   - Full `cmd/omes` tests and focused race-detector coverage pass locally.
   - All 46 GitHub Actions checks pass on the revised head.

3. Any docs updates needed?
   - Updated `docs/running.md` and `docs/authoring-scenarios.md` for the opt-in policy, warning behavior, and relationship to retries.
