### PR TITLE
ci: retry and cache Docker dependency downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,13 @@ jobs:
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', '**/go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-${{ runner.arch }}-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Expose GitHub Actions runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Build ${{ matrix.sdk }} worker image
+        env:
+          OMES_BUILDKIT_CACHE_SCOPE: omes-ci-${{ github.job }}-${{ matrix.sdk }}-linux-amd64
         run: |
           go run ./cmd/dev build-worker-image \
             --language ${{ matrix.sdk }} \
@@ -283,7 +289,13 @@ jobs:
           key: go-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', '**/go.sum') }}
           restore-keys: |
             go-${{ runner.os }}-${{ runner.arch }}-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Expose GitHub Actions runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Build ${{ matrix.sdk }} worker image from local SDK path
+        env:
+          OMES_BUILDKIT_CACHE_SCOPE: omes-ci-${{ github.job }}-${{ matrix.sdk }}-linux-amd64
         run: |
           args=(
             --language "${{ matrix.sdk }}"
@@ -554,7 +566,11 @@ jobs:
             go-${{ runner.os }}-${{ runner.arch }}-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Expose GitHub Actions runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Build CLI image
+        env:
+          OMES_BUILDKIT_CACHE_SCOPE: omes-ci-${{ github.job }}-linux-amd64
         run: |
           go run ./cmd/dev build-cli-image
       - name: Test CLI image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Expose GitHub Actions runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -99,6 +101,7 @@ jobs:
 
       - name: Build and push to Docker Hub
         env:
+          OMES_BUILDKIT_CACHE_SCOPE: omes-publish-${{ inputs.lang || 'cli' }}-linux-amd64-linux-arm64
           LANG: ${{ inputs.lang }}
           SDK_VERSION: ${{ inputs.sdk-version || 'checked-out-sdk/' }}
           IMAGE_TAG_ARGS: ${{ inputs.sdk-repo-ref && format('--image-tag {0}-{1}', inputs.lang, inputs.docker-tag-ext) || ''}}

--- a/cmd/dev/build_helper.go
+++ b/cmd/dev/build_helper.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const buildKitCacheScopeEnv = "OMES_BUILDKIT_CACHE_SCOPE"
+
 type baseImageBuilder struct {
 	logger         *zap.SugaredLogger
 	tagAsLatest    bool
@@ -84,6 +86,12 @@ func (b *baseImageBuilder) buildDockerArgs(dockerFile string, allowPush bool, bu
 		"--pull",
 		"--file", dockerFile,
 		"--platform", strings.Join(b.platforms, ","),
+	}
+	if cacheScope := os.Getenv(buildKitCacheScopeEnv); cacheScope != "" {
+		dockerArgs = append(dockerArgs,
+			"--cache-from", fmt.Sprintf("type=gha,scope=%s,timeout=5m,version=2", cacheScope),
+			"--cache-to", fmt.Sprintf("type=gha,scope=%s,mode=max,ignore-error=true,timeout=5m,version=2", cacheScope),
+		)
 	}
 
 	// Handle multi-platform build requirements

--- a/cmd/dev/build_helper_test.go
+++ b/cmd/dev/build_helper_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDockerArgsGitHubActionsCache(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv(buildKitCacheScopeEnv, "")
+		builder := baseImageBuilder{platforms: []string{"amd64"}}
+
+		args, err := builder.buildDockerArgs("Dockerfile", false, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"buildx", "build", "--pull", "--file", "Dockerfile", "--platform", "amd64", "--load",
+		}, args)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		t.Setenv(buildKitCacheScopeEnv, "omes-ci-typescript-linux-amd64")
+		builder := baseImageBuilder{platforms: []string{"amd64"}}
+
+		args, err := builder.buildDockerArgs("Dockerfile", false, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"buildx", "build", "--pull", "--file", "Dockerfile", "--platform", "amd64",
+			"--cache-from", "type=gha,scope=omes-ci-typescript-linux-amd64,timeout=5m,version=2",
+			"--cache-to", "type=gha,scope=omes-ci-typescript-linux-amd64,mode=max,ignore-error=true,timeout=5m,version=2",
+			"--load",
+		}, args)
+	})
+
+	t.Run("enabled for multi-platform push", func(t *testing.T) {
+		t.Setenv(buildKitCacheScopeEnv, "omes-publish-typescript-linux-amd64-linux-arm64")
+		builder := baseImageBuilder{platforms: []string{"linux/amd64", "linux/arm64"}}
+
+		args, err := builder.buildDockerArgs("Dockerfile", true, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"buildx", "build", "--pull", "--file", "Dockerfile", "--platform", "linux/amd64,linux/arm64",
+			"--cache-from", "type=gha,scope=omes-publish-typescript-linux-amd64-linux-arm64,timeout=5m,version=2",
+			"--cache-to", "type=gha,scope=omes-publish-typescript-linux-amd64-linux-arm64,mode=max,ignore-error=true,timeout=5m,version=2",
+			"--push",
+		}, args)
+	})
+}

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -30,7 +30,15 @@ ENV PATH="$PATH:/root/.cargo/bin"
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/dotnet.Dockerfile
+++ b/dockerfiles/dotnet.Dockerfile
@@ -27,7 +27,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -9,7 +9,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -23,7 +23,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -30,7 +30,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -27,7 +27,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd

--- a/dockerfiles/typescript.Dockerfile
+++ b/dockerfiles/typescript.Dockerfile
@@ -25,7 +25,15 @@ WORKDIR /app
 # to resolve the module graph.
 COPY go.mod go.sum ./
 COPY workers/go/harness/api ./workers/go/harness/api
-RUN go mod download
+RUN for attempt in 1 2 3; do \
+      go mod download && exit 0; \
+      if [ "$attempt" -lt 3 ]; then \
+        delay=$((attempt * 5)); \
+        echo "go mod download failed (attempt $attempt/3); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+      fi; \
+    done; \
+    exit 1
 
 # Copy CLI source and build the CLI.
 COPY cmd ./cmd


### PR DESCRIPTION
Docker image builds download the repository Go module graph inside BuildKit, so the Go cache restored on the GitHub Actions host does not protect that step. A transient HTTP/2 failure from proxy.golang.org therefore failed an otherwise unrelated TypeScript source-worker job, and the same cold-download exposure exists in every worker and CLI Dockerfile.

This change makes that dependency layer resilient in two complementary ways. Each Dockerfile retries go mod download up to three times with short bounded backoff. GitHub Actions also uses scoped version-2 BuildKit caches for regular workers, source-built workers, the CLI image, and multi-platform publishing. Cache export is best-effort, scopes are isolated by job, language, and platform set, and runtime cache credentials remain environment-only rather than appearing in the logged Docker command.

Local builds are unchanged because cache arguments are added only when OMES_BUILDKIT_CACHE_SCOPE is set by CI. There is no runtime or deployment migration. The draft status allows the first CI cycle to validate cold-cache behavior and subsequent runs to demonstrate restored intermediate layers.

Validation:
- go test ./cmd/dev ./internal/workerctl
- actionlint workflow and expression validation
- docker buildx build --check for all seven modified Dockerfiles
- image-builder dry run confirming scoped cache arguments

Failure motivating this change: https://github.com/temporalio/omes/actions/runs/34357997033/job/102487464734