### PR TITLE
Report terminal iteration outcomes in logs and Prometheus

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -80,7 +80,10 @@ each scenario.
 Iteration retries and the terminal-failure policy are independent. `--max-iteration-attempts` controls
 how many times one logical iteration may execute. With the default `fail-fast` policy, exhausting those
 attempts stops the run and exits non-zero. The `continue` policy logs the terminal failure, keeps starting
-load, and emits a warning summary before exiting zero if the run otherwise completes.
+load, and emits a warning summary before exiting zero if the run otherwise completes. The summary includes
+attempted, succeeded, and failed totals plus success/failure rates and successful iterations per second. When the
+load-driver Prometheus endpoint is enabled with `--prom-listen-address`, the same terminal outcomes are
+exported as `omes_iterations_total`, labeled by scenario, outcome, and status code.
 
 ### 2. Per-scenario options (`--option key=value`)
 

--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -52,6 +52,36 @@ func (g *GenericExecutor) newRun(info ScenarioInfo) (*genericRun, error) {
 	}, nil
 }
 
+func (g *genericRun) logRunSummary(elapsed time.Duration) {
+	succeeded := g.completed.Load()
+	failed := g.failed.Load()
+	attempted := succeeded + failed
+
+	var successRate, failureRate, successfulThroughput float64
+	if attempted > 0 {
+		successRate = float64(succeeded) / float64(attempted)
+		failureRate = float64(failed) / float64(attempted)
+	}
+	if elapsed > 0 {
+		successfulThroughput = float64(succeeded) / elapsed.Seconds()
+	}
+
+	fields := []any{
+		"elapsed", elapsed,
+		"attempted", attempted,
+		"succeeded", succeeded,
+		"failed", failed,
+		"success_rate", successRate,
+		"failure_rate", failureRate,
+		"successful_iterations_per_second", successfulThroughput,
+	}
+	if failed > 0 {
+		g.logger.Warnw("Run completed with iteration failures", fields...)
+	} else {
+		g.logger.Infow("Run completed", fields...)
+	}
+}
+
 // Run a scenario.
 // Spins up coroutines according to the scenario configuration.
 // Each coroutine runs the scenario Execute method in a loop until the scenario duration or max
@@ -229,12 +259,7 @@ func (g *genericRun) Run(ctx context.Context) error {
 	// success/failure counts and apply its own policy on top.
 	if failed := g.failed.Load(); failed > 0 {
 		succeeded := g.completed.Load()
-		g.logger.Warnw("Run completed with iteration failures",
-			"elapsed", elapsed,
-			"attempted", succeeded+failed,
-			"succeeded", succeeded,
-			"failed", failed,
-		)
+		g.logRunSummary(elapsed)
 		return &IterationFailuresError{
 			Attempted: succeeded + failed,
 			Succeeded: succeeded,
@@ -242,6 +267,6 @@ func (g *genericRun) Run(ctx context.Context) error {
 			Elapsed:   elapsed,
 		}
 	}
-	g.logger.Infof("Run completed in %v", elapsed)
+	g.logRunSummary(elapsed)
 	return nil
 }

--- a/loadgen/generic_executor.go
+++ b/loadgen/generic_executor.go
@@ -9,6 +9,14 @@ import (
 
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	iterationOutcomeSucceeded = "succeeded"
+	iterationOutcomeFailed    = "failed"
+	iterationsMetricName      = "omes_iterations_total"
 )
 
 type GenericExecutor struct {
@@ -21,10 +29,12 @@ type genericRun struct {
 	info     ScenarioInfo
 	config   RunConfiguration
 	logger   *zap.SugaredLogger
+	// Metrics tagged with the scenario name for this run.
+	metricsHandler client.MetricsHandler
 	// Timer capturing E2E execution of each scenario run iteration.
 	executeTimer client.MetricsTimer
-	// Iteration outcome tallies, used for the end-of-run summary. failed counts
-	// only terminal failures tolerated via ContinueOnIterationFailure.
+	// Iteration outcome tallies used for reporting. failed excludes iterations
+	// abandoned because the run is stopping.
 	completed atomic.Int64
 	failed    atomic.Int64
 }
@@ -42,14 +52,29 @@ func (g *GenericExecutor) newRun(info ScenarioInfo) (*genericRun, error) {
 	if err := info.Configuration.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid scenario: %w", err)
 	}
+	metricsHandler := info.MetricsHandler.WithTags(map[string]string{"scenario": info.ScenarioName})
 	return &genericRun{
-		executor: g,
-		info:     info,
-		config:   info.Configuration,
-		logger:   info.Logger,
-		executeTimer: info.MetricsHandler.WithTags(
-			map[string]string{"scenario": info.ScenarioName}).Timer("omes_execute_histogram"),
+		executor:       g,
+		info:           info,
+		config:         info.Configuration,
+		logger:         info.Logger,
+		metricsHandler: metricsHandler,
+		executeTimer:   metricsHandler.Timer("omes_execute_histogram"),
 	}, nil
+}
+
+func iterationStatusCode(err error) codes.Code {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Code()
+	}
+	return status.Code(err)
+}
+
+func (g *genericRun) recordIterationOutcome(outcome string, code codes.Code) {
+	g.metricsHandler.WithTags(map[string]string{
+		"outcome":     outcome,
+		"status_code": code.String(),
+	}).Counter(iterationsMetricName).Inc(1)
 }
 
 func (g *genericRun) logRunSummary(elapsed time.Duration) {
@@ -190,11 +215,20 @@ func (g *genericRun) Run(ctx context.Context) error {
 				case iterErr == nil:
 					run.Duration = elapsed
 					g.completed.Add(1)
+					g.recordIterationOutcome(iterationOutcomeSucceeded, codes.OK)
 					if g.config.OnCompletion != nil {
 						g.config.OnCompletion(ctx, run)
 					}
 				default:
+					code := iterationStatusCode(iterErr)
 					g.failed.Add(1)
+					g.recordIterationOutcome(iterationOutcomeFailed, code)
+					g.logger.Errorw("Iteration failed",
+						"scenario", g.info.ScenarioName,
+						"iteration", run.Iteration,
+						"status_code", code.String(),
+						"error", iterErr,
+					)
 					if g.config.OnIterationFailure != nil {
 						g.config.OnIterationFailure(ctx, run, iterErr)
 					}
@@ -223,7 +257,6 @@ func (g *genericRun) Run(ctx context.Context) error {
 					g.logger.Error(err)
 				} else {
 					err = fmt.Errorf("iteration %v failed: %w", run.Iteration, err)
-					g.logger.Error(err)
 					break retryLoop
 				}
 

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -3,17 +3,22 @@ package loadgen
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	omesmetrics "github.com/temporalio/omes/metrics"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type iterationTracker struct {
@@ -412,6 +417,111 @@ func TestRunContinueOnIterationFailureLogsWarning(t *testing.T) {
 		require.Equal(t, int64(2), fields["attempted"])
 		require.Equal(t, int64(1), fields["succeeded"])
 		require.Equal(t, int64(1), fields["failed"])
+	})
+}
+
+func TestIterationStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{name: "wrapped canceled context", err: fmt.Errorf("start failed: %w", context.Canceled), want: codes.Canceled},
+		{name: "wrapped deadline context", err: fmt.Errorf("start failed: %w", context.DeadlineExceeded), want: codes.DeadlineExceeded},
+		{name: "wrapped grpc status", err: fmt.Errorf("start failed: %w", status.Error(codes.ResourceExhausted, "busy")), want: codes.ResourceExhausted},
+		{name: "plain error", err: errors.New("plain"), want: codes.Unknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, iterationStatusCode(test.err))
+		})
+	}
+}
+
+func TestRunRecordsTerminalIterationOutcomes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		metrics := &omesmetrics.Metrics{
+			Registry: registry,
+			Cache:    make(map[string]any),
+		}
+		logger := zap.NewNop()
+		attempts := make(map[int]int)
+		err := (&GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				attempts[run.Iteration]++
+				if run.Iteration == 1 && attempts[run.Iteration] == 2 {
+					return nil
+				}
+				return fmt.Errorf("workflow start failed: %w", status.Error(codes.Unavailable, "down"))
+			},
+		}).Run(context.Background(), ScenarioInfo{
+			ScenarioName:   "metric-test",
+			MetricsHandler: metrics.NewHandler(),
+			Logger:         logger.Sugar(),
+			Configuration: RunConfiguration{
+				Iterations:                 2,
+				MaxConcurrent:              1,
+				MaxIterationAttempts:       2,
+				ContinueOnIterationFailure: true,
+			},
+		})
+
+		var failures *IterationFailuresError
+		require.ErrorAs(t, err, &failures)
+		families, gatherErr := registry.Gather()
+		require.NoError(t, gatherErr)
+
+		outcomes := make(map[string]float64)
+		for _, family := range families {
+			if family.GetName() != iterationsMetricName {
+				continue
+			}
+			for _, metric := range family.Metric {
+				labels := make(map[string]string)
+				for _, label := range metric.Label {
+					labels[label.GetName()] = label.GetValue()
+				}
+				require.Equal(t, "metric-test", labels["scenario"])
+				outcomes[labels["outcome"]+"/"+labels["status_code"]] = metric.Counter.GetValue()
+			}
+		}
+
+		require.Equal(t, float64(1), outcomes["succeeded/OK"])
+		require.Equal(t, float64(1), outcomes["failed/Unavailable"])
+	})
+}
+
+func TestRunDoesNotRecordCanceledIterationOutcome(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		metrics := &omesmetrics.Metrics{
+			Registry: registry,
+			Cache:    make(map[string]any),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		err := (&GenericExecutor{
+			Execute: func(ctx context.Context, run *Run) error {
+				cancel()
+				return ctx.Err()
+			},
+		}).Run(ctx, ScenarioInfo{
+			ScenarioName:   "metric-test",
+			MetricsHandler: metrics.NewHandler(),
+			Logger:         zap.NewNop().Sugar(),
+			Configuration: RunConfiguration{
+				Iterations:                 1,
+				ContinueOnIterationFailure: true,
+			},
+		})
+		require.Error(t, err)
+
+		families, gatherErr := registry.Gather()
+		require.NoError(t, gatherErr)
+		for _, family := range families {
+			require.NotEqual(t, iterationsMetricName, family.GetName())
+		}
 	})
 }
 

--- a/loadgen/generic_executor_test.go
+++ b/loadgen/generic_executor_test.go
@@ -44,8 +44,7 @@ func execute(executor *GenericExecutor, runConfig RunConfiguration) error {
 }
 
 func executeContext(ctx context.Context, executor *GenericExecutor, runConfig RunConfiguration) error {
-	logger := zap.Must(zap.NewDevelopment())
-	defer logger.Sync()
+	logger := zap.NewNop()
 	info := ScenarioInfo{
 		MetricsHandler: client.MetricsNopHandler,
 		Logger:         logger.Sugar(),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -76,10 +77,15 @@ func (h *metricsHandler) WithTags(tags map[string]string) client.MetricsHandler 
 	}
 	maps.Copy(mergedTags, tags)
 
-	var labels, values []string
-	for l, v := range mergedTags {
-		labels = append(labels, l)
-		values = append(values, v)
+	labels := make([]string, 0, len(mergedTags))
+	for label := range mergedTags {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+
+	values := make([]string, 0, len(labels))
+	for _, label := range labels {
+		values = append(values, mergedTags[label])
 	}
 
 	return &metricsHandler{

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMetricsHandlerSortsTags(t *testing.T) {
+	handler := (&Metrics{}).NewHandler().WithTags(map[string]string{
+		"status_code": "Unavailable",
+		"scenario":    "test-scenario",
+		"outcome":     "failed",
+	}).(*metricsHandler)
+
+	wantLabels := []string{"outcome", "scenario", "status_code"}
+	wantValues := []string{"failed", "test-scenario", "Unavailable"}
+	if !reflect.DeepEqual(wantLabels, handler.labels) {
+		t.Fatalf("labels = %v, want %v", handler.labels, wantLabels)
+	}
+	if !reflect.DeepEqual(wantValues, handler.values) {
+		t.Fatalf("values = %v, want %v", handler.values, wantValues)
+	}
+}


### PR DESCRIPTION
## What was changed

The load driver extends PR #461's basic degraded-run warning with structured terminal iteration failures and an aggregate attempted, succeeded, failed, success-rate, failure-rate, and successful-throughput summary. It also exports `omes_iterations_total` with bounded `scenario`, `outcome`, and normalized `status_code` labels.

The local Prometheus handler orders tag names and values deterministically because cached metric vectors bind label values positionally. Metrics record one terminal outcome per logical iteration after retries finish; iterations abandoned by cancellation are omitted. Full wrapped errors remain in logs rather than metric labels.

This is the top layer of native stack #487 and depends on PR #461. Review PR #461 first for the iteration-tolerance behavior, then this PR for observability.

## Why?

When operators opt into continuing after terminal iteration failures, they need explicit visibility into degraded runs. Structured logs retain actionable errors, while the bounded Prometheus dimensions support aggregation without introducing unbounded cardinality.

## Checklist

1. Closes: N/A. This is the observability follow-up to PR #461.

2. How was this tested:
   - Metrics-handler tests verify deterministic tag ordering.
   - Loadgen tests cover status classification, retry-aware logical-outcome counting, successful and failed outcomes, and cancellation exclusion.
   - Focused race-detector coverage passes.
   - Focused `cmd/omes`, loadgen, metrics, and race-detector tests pass locally on the rebased stack.
   - All 46 GitHub Actions checks pass on the revised head.

3. Any docs updates needed?
   - Updated `docs/running.md` with the aggregate summary and Prometheus metric contract.
